### PR TITLE
Add script for setting timestamps according to the day

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,12 +3,10 @@
 In this directory, you find different scripts and examples that assist in running benchmarks on Modyn.
 Currently, we provide an MNIST example and a Criteo 1TB Advertising dataset example 
 
-
 ## Benchmarks
 
 ### MNIST 
 In the `mnist` directory, you find files to running experiments on a dynamic version of the MNIST data set.
-
 
 ### Criteo 1TB Dataset
 We provide scripts and guidelines for using the Criteo 1TB benchmark data set.

--- a/benchmark/criteo_1TB/preprocessing/README.md
+++ b/benchmark/criteo_1TB/preprocessing/README.md
@@ -160,6 +160,13 @@ Preprocessing Data:
 	```
 	The frequency-threshold parameter controls what consists of "high" frequency vs "low" frequency features as explained in the Preprocessing Information section. NVIDIA suggests 15 for a smaller model, or 2 or 1 for larger models. 
 	The second argument is to specify if you want to use the CPU or GPU processing.
+10. Adjust the file timestamps to reflect the individual days using the script we provide.
+	For this, identify the folder in which the final processed binary dataset resides (should be `/mnt/disks/criteo/binary_dataset`).
+	Then, run
+	```
+	python criteo_timestamps.py <DIRECTORY_PATH>
+	```
+	to adjust the modified timestamps such that Modyn recognizes the files as from multiple days.
 
 ## Uploading Data to GCS:
 1. Create a bucket on the Google Console

--- a/benchmark/criteo_1TB/preprocessing/criteo_timestamps.py
+++ b/benchmark/criteo_1TB/preprocessing/criteo_timestamps.py
@@ -1,0 +1,54 @@
+import argparse
+import logging
+import os
+import pathlib
+
+logging.basicConfig(
+    level=logging.NOTSET,
+    format="[%(asctime)s]  [%(filename)15s:%(lineno)4d] %(levelname)-8s %(message)s",
+    datefmt="%Y-%m-%d:%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+DAY_LENGTH_SECONDS = 24 * 60 * 60
+
+
+def setup_argparser() -> argparse.ArgumentParser:
+    parser_ = argparse.ArgumentParser(description="Criteo Timestamp script")
+    parser_.add_argument("dir", type=pathlib.Path, action="store", help="Path to Criteo data directory")
+
+    return parser_
+
+
+def main():
+    parser = setup_argparser()
+    args = parser.parse_args()
+
+    validate_dir(args.dir)
+    fix_timestamps(args.dir)
+
+
+def validate_dir(path: pathlib.Path):
+    for i in range(0, 24):
+        subpath = path / f"day{i}"
+        if not subpath.exists():
+            raise ValueError(f"Did not find directory for day {i} (checked {subpath.resolve()})")
+
+
+def fix_timestamps(path: pathlib.Path):
+    for i in range(0, 24):
+        subpath = path / f"day{i}"
+        fix_day(subpath, i)
+
+
+def fix_day(path: pathlib.Path, day: int):
+    assert day >= 0 and day < 24
+    timestamp = (day * DAY_LENGTH_SECONDS) + 1  # avoid off by ones in storage by adding + 1
+
+    filelist = path.glob("**/*.bin")
+    for file in filelist:
+        os.utime(file, (timestamp, timestamp))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We need to set the unix timestamps of the Criteo data in order for Modyn to recognize the temporality of the data. This adds a script in the process to do so.