### PR TITLE
Fix TriggerSampleStorage for more than 10 partitions

### DIFF
--- a/modyn/selector/internal/trigger_sample/trigger_sample_storage.py
+++ b/modyn/selector/internal/trigger_sample/trigger_sample_storage.py
@@ -55,15 +55,16 @@ class TriggerSampleStorage:
         :param partition_id: the id of the partition
         :param retrieval_worker_id: the id of the retrieval worker
         :param total_retrieval_workers: the total number of retrieval workers
-        :param total_samples: the total number of samples
+        :param num_samples_trigger: the total number of samples
         :return: the trigger samples
         """
         if not Path(self.trigger_sample_directory).exists():
             raise FileNotFoundError(f"The trigger sample directory {self.trigger_sample_directory} does not exist.")
         assert (retrieval_worker_id >= 0 and total_retrieval_workers >= 0) or (
-            retrieval_worker_id < 0 and total_retrieval_workers < 0
-        ), "Either both or none of the retrieval worker id and the total retrieval workers must be negative."
-        if retrieval_worker_id < 0 and total_retrieval_workers < 0:
+            retrieval_worker_id < 0 and total_retrieval_workers < 2
+        ), "Either both or none of the retrieval worker id must be negative and \
+            the total retrieval workers must be smaller than 2."
+        if retrieval_worker_id < 0 and total_retrieval_workers < 2:
             return self._get_all_samples(pipeline_id, trigger_id, partition_id)
         return self._get_worker_samples(
             pipeline_id, trigger_id, partition_id, retrieval_worker_id, total_retrieval_workers, num_samples_trigger

--- a/modyn/tests/selector/internal/trigger_sample/test_trigger_sample_storage.py
+++ b/modyn/tests/selector/internal/trigger_sample/test_trigger_sample_storage.py
@@ -191,13 +191,14 @@ def test_extended_get_trigger_samples():
     ]
 
     TriggerSampleStorage(TMP_DIR).save_trigger_sample(
-        1, 2, 3, np.array([(7, 7.0), (8, 8.0), (9, 9.0), (10, 10.0)], dtype=np.dtype("i8,f8")), 6
+        1, 2, 3, np.array([(7, 7.0), (8, 8.0), (9, 9.0), (10, 10.0), (11, 11.0)], dtype=np.dtype("i8,f8")), 6
     )
     expected_order = expected_order + [
         (7, 7.0),
         (8, 8.0),
         (9, 9.0),
         (10, 10.0),
+        (11, 11.0),
     ]
 
     result = TriggerSampleStorage(TMP_DIR).get_trigger_samples(1, 2, 3, 0, 2, 12)
@@ -231,6 +232,22 @@ def test_extended_get_trigger_samples():
     result = TriggerSampleStorage(TMP_DIR).get_trigger_samples(1, 2, 3, 4, 5, 12)
     assert len(result) == 0
     assert not result
+
+    result = TriggerSampleStorage(TMP_DIR).get_trigger_samples(1, 2, 3, -1, -1, 13)
+    assert len(result) == 13
+    assert result == expected_order
+
+    TriggerSampleStorage(TMP_DIR).save_trigger_sample(
+        1, 2, 30, np.array([(1, 1.0), (2, 2.0), (3, 3.0), (4, 4.0)], dtype=np.dtype("i8,f8")), 6
+    )
+
+    result = TriggerSampleStorage(TMP_DIR).get_trigger_samples(1, 2, 3, 0, 2, 13)
+    assert len(result) == 7
+    assert result == expected_order[0:7]
+
+    result = TriggerSampleStorage(TMP_DIR).get_trigger_samples(1, 2, 30, -1, -1, 4)
+    assert len(result) == 4
+    assert result == expected_order[0:4]
 
 
 def test_get_trigger_samples_no_file():


### PR DESCRIPTION
Fix #212 (assert fails when there are more ten Chunks). 

I tried to see the tests but having never worked on storage before I find it a bit difficult to write about it from scratch. I could do it but it would take me much more time than necessary.

However I tried in docker and with this modification the problem is solved.