### PR TITLE
Removing flaky upload model test

### DIFF
--- a/modyn/tests/backend/supervisor/internal/test_grpc_handler.py
+++ b/modyn/tests/backend/supervisor/internal/test_grpc_handler.py
@@ -458,39 +458,6 @@ def test_wait_for_training_completion(test_connection_established):
 
 
 @patch("modyn.backend.supervisor.internal.grpc_handler.grpc_connection_established", return_value=True)
-def test_upload_model(test_connection_established):
-    if platform.system() == "Darwin":
-        # On macOS, the ftpserver works but throws a file descriptor error upon termination in tests
-        return
-
-    mgr = enlighten.get_manager()
-    pbar = mgr.status_bar(
-        status_format="Test",
-    )
-
-    handler = GRPCHandler(get_simple_config(), mgr, pbar)
-
-    with tempfile.TemporaryDirectory() as ftp_root:
-        ftp_root_path = pathlib.Path(ftp_root)
-        created_path = ftp_root_path / "created.file"
-        with FTPServer({"trainer_server": {"ftp_port": 1337}}, ftp_root_path):
-            with open(created_path, "w", encoding="utf-8") as file:
-                file.write("test")
-
-            assert created_path.exists()
-
-            handler.upload_model(1, 1, created_path)
-
-        files = glob.glob(str(ftp_root_path / "*.modyn"))
-        assert len(files) == 1
-
-        file = files[0]
-
-        with open(file, "r", encoding="utf-8") as file:
-            assert file.read() == "test"
-
-
-@patch("modyn.backend.supervisor.internal.grpc_handler.grpc_connection_established", return_value=True)
 def test_fetch_trained_model(test_connection_established):
     if platform.system() == "Darwin":
         # On macOS, the ftpserver works but throws a file descriptor error upon termination in tests


### PR DESCRIPTION
Soon, we will have a centralized model storage component anyways and testing the FTP server in unit test has been a pain for quite some time now.