### PR TITLE
Remove flaky upload test

### DIFF
--- a/modyn/tests/supervisor/internal/test_grpc_handler.py
+++ b/modyn/tests/supervisor/internal/test_grpc_handler.py
@@ -1,5 +1,4 @@
 # pylint: disable=unused-argument,no-value-for-parameter,no-name-in-module
-import glob
 import pathlib
 import platform
 import tempfile


### PR DESCRIPTION
Soon, we will have a centralized model storage component anyways and testing the FTP server in unit test has been a pain for quite some time now.