### PR TITLE
Add CSVFileWrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Visual Studio Code
 .vscode
 
+# PyCharm and IntelliJ IDEA
+.idea
+
 # Storage
 *.tar
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ isort
 black
 grpcio-tools
 mypy-protobuf
+pandas

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,4 +11,3 @@ isort
 black
 grpcio-tools
 mypy-protobuf
-pandas

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
   - types-PyYAML
   - pytorch::pytorch
   - pytorch::torchvision
+  - pandas
   - pytorch::cpuonly # comment out if commenting in lines below for CUDA
 #  - nvidia::cudatoolkit=11.7
 #  - nvidia::cuda-nvprof=11.7

--- a/modyn/config/schema/modyn_config_schema.yaml
+++ b/modyn/config/schema/modyn_config_schema.yaml
@@ -96,6 +96,22 @@ properties:
                   type: string
                   description: |
                     The byteorder when reading an integer from multibyte data in a binary file. Should either be "big" or "little".
+                number_cols:
+                  type: number
+                  description: |
+                    The number of columns in the csv file.
+                delimiter:
+                  type: string
+                  description: |
+                    The CSV file delimiter, it can be, for example, ",", ";" or any other string.
+                encoding:
+                  type: string
+                  description: |
+                    The file encoding. It can be "UTF-8", "UTF-16" etc.
+                header:
+                  type: number
+                  description: |
+                    The row index of the header if exists. Otherwise, it is not specified.
             ignore_last_timestamp:
               type: boolean
               description: |

--- a/modyn/config/schema/modyn_config_schema.yaml
+++ b/modyn/config/schema/modyn_config_schema.yaml
@@ -96,10 +96,6 @@ properties:
                   type: string
                   description: |
                     The byteorder when reading an integer from multibyte data in a binary file. Should either be "big" or "little".
-                number_cols:
-                  type: number
-                  description: |
-                    The number of columns in the csv file.
                 delimiter:
                   type: string
                   description: |
@@ -112,6 +108,10 @@ properties:
                   type: number
                   description: |
                     The row index of the header if exists. Otherwise, it is not specified.
+                labels:
+                  type: object
+                  description: |
+                    The name if with header or index otherwise of the column with labels.
             ignore_last_timestamp:
               type: boolean
               description: |

--- a/modyn/storage/internal/file_wrapper/binary_file_wrapper.py
+++ b/modyn/storage/internal/file_wrapper/binary_file_wrapper.py
@@ -96,8 +96,8 @@ class BinaryFileWrapper(AbstractFileWrapper):
         self._validate_request_indices(total_samples, [index])
 
         record_start = index * self.record_size
-        lable_bytes = data[record_start : record_start + self.label_size]
-        return int.from_bytes(lable_bytes, byteorder=self.byteorder)
+        label_bytes = data[record_start : record_start + self.label_size]
+        return int.from_bytes(label_bytes, byteorder=self.byteorder)
 
     def get_all_labels(self) -> list[int]:
         """Returns a list of all labels of all samples in the file.

--- a/modyn/storage/internal/file_wrapper/csv_file_wrapper.py
+++ b/modyn/storage/internal/file_wrapper/csv_file_wrapper.py
@@ -9,7 +9,7 @@ from modyn.storage.internal.filesystem_wrapper.abstract_filesystem_wrapper impor
 class CSVFileWrapper(AbstractFileWrapper):
     """CSV file wrapper.
 
-    CSV files store samples data in a row-oriented format. CSV file can have a header. The header line index should
+    CSV files store samples data in a row-oriented format. CSV file can have a header. The header line index can
     be specified in the file_wrapper_config while creating an instance. The file wrapper is able to read samples by
     index, and value by feature name / col index and row index.
     """
@@ -165,3 +165,18 @@ class CSVFileWrapper(AbstractFileWrapper):
         data_frame = pd.read_csv(self.file_path, sep=self.delim, header=self.header, encoding=self.encoding)
         samples = [bytes(data_frame.get_value(index, feature)) for feature, index in features_indices]
         return samples
+
+    def delete_samples(self, indices: list) -> None:
+        """Delete the samples at the given index list.
+        The indices are zero based.
+
+        We do not support deleting samples from CSV files.
+        We can only delete the entire file which is done when every sample is deleted.
+        This is done to avoid the overhead of updating the file after every deletion.
+
+        See remove_empty_files in the storage grpc servicer for more details.
+
+        Args:
+            indices (list): List of indices of the samples to delete
+        """
+        return

--- a/modyn/storage/internal/file_wrapper/csv_file_wrapper.py
+++ b/modyn/storage/internal/file_wrapper/csv_file_wrapper.py
@@ -1,0 +1,167 @@
+"""CSV file wrapper."""
+
+import pandas as pd
+from modyn.storage.internal.file_wrapper.abstract_file_wrapper import AbstractFileWrapper
+from modyn.storage.internal.file_wrapper.file_wrapper_type import FileWrapperType
+from modyn.storage.internal.filesystem_wrapper.abstract_filesystem_wrapper import AbstractFileSystemWrapper
+
+
+class CSVFileWrapper(AbstractFileWrapper):
+    """CSV file wrapper.
+
+    CSV files store samples data in a row-oriented format. CSV file can have a header. The header line index should
+    be specified in the file_wrapper_config while creating an instance. The file wrapper is able to read samples by
+    index, and value by feature name / col index and row index.
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        file_wrapper_config: dict,
+        filesystem_wrapper: AbstractFileSystemWrapper,
+    ):
+        """Init CSV file wrapper.
+
+        Args:
+            file_path (str): Path to file
+            file_wrapper_config (dict): File wrapper config
+            filesystem_wrapper (AbstractFileSystemWrapper): File system wrapper to abstract storage of the file
+
+        Raises:
+            ValueError: If the file has the wrong file extension
+            ValueError: If the file does not contain an exact number of samples of given size
+        """
+        super().__init__(file_path, file_wrapper_config, filesystem_wrapper)
+        self.file_wrapper_type = FileWrapperType.CSVFileWrapper
+        self.ncols = file_wrapper_config["number_cols"]
+        if self.ncols is None or self.ncols < 1:
+            raise ValueError("Each csv should have at least one column.")
+
+        self.delim = file_wrapper_config["delimiter"]
+        if self.delim is None or self.delim == "":
+            self.delim = ","
+
+        self.extension = file_wrapper_config["file_extension"]
+        if self.extension is None or self.extension == "":
+            self.extension = ".csv"
+
+        self.encoding = file_wrapper_config["encoding"]
+        if self.encoding is None or self.encoding == "":
+            self.extension = "utf-8"
+
+        self.header = file_wrapper_config["header"]
+        if self.header is None:
+            self.header = None
+
+        self._validate_file_extension()
+
+    def _validate_file_extension(self) -> None:
+        """Validates the file extension as bin
+
+        Raises:
+            ValueError: File has wrong file extension
+        """
+        if not self.file_path.endswith(self.extension):
+            raise ValueError("File has wrong file extension.")
+
+    def get_number_of_samples(self) -> int:
+        """Get number of samples in file.
+
+        Returns:
+            int: Number of samples in file
+        """
+        i = 0
+        with open(self.file_path, "r", encoding=self.encoding) as file_pointer:
+            for _ in file_pointer:
+                i += 1
+        return i - (1 if self.header is not None else 0)
+
+    def get_label(self, index: int) -> bytes:
+        """Get the label of the sample at the given index.
+
+        Args:
+            index (int): Index
+
+        Raises:
+            IndexError: If the index is out of bounds
+
+        Returns:
+            object: Label for the sample
+        """
+        data_frame = pd.read_csv(self.file_path, sep=self.delim, header=self.header, encoding=self.encoding)
+        return bytes(data_frame.columns[index], self.encoding)
+
+    def get_all_labels(self) -> list[bytes]:
+        """Returns a list of all labels of all samples in the file.
+
+        Returns:
+            list: List of labels
+        """
+        data_frame = pd.read_csv(self.file_path, sep=self.delim, header=self.header, encoding=self.encoding)
+        return [bytes(col, self.encoding) for col in data_frame.columns.tolist()]
+
+    def get_sample(self, index: int) -> list[bytes]:
+        """Get the sample at the given index.
+        The indices are zero based.
+
+        Args:
+            index (int): Index
+
+        Raises:
+            IndexError: If the index is out of bounds
+
+        Returns:
+            bytes: Sample
+        """
+        return self.get_samples_from_indices([index])[0]
+
+    def get_samples(self, start: int, end: int) -> list[list[bytes]]:
+        """Get the samples at the given range from start (inclusive) to end (exclusive).
+        The indices are zero based.
+
+        Args:
+            start (int): Start index
+            end (int): End index
+
+        Raises:
+            IndexError: If the index is out of bounds
+
+        Returns:
+            bytes: Sample
+        """
+        return self.get_samples_from_indices([*range(start, end)])
+
+    def get_samples_from_indices(self, indices: list) -> list[list[bytes]]:
+        """Get the samples at the given index list.
+        The indices are zero based.
+
+        Args:
+            indices (list): List of indices of the required samples
+
+        Raises:
+            IndexError: If the index is out of bounds
+
+        Returns:
+            bytes: Sample
+        """
+        data_frame = pd.read_csv(self.file_path, sep=self.delim, header=self.header, encoding=self.encoding)
+        samples = data_frame.iloc[indices].values.tolist()
+        res = [[bytes(val, self.encoding) for val in row] for row in samples]
+        return res
+
+    def get_values_from_features_indices(self, features_indices: list) -> list[bytes]:
+        """Get the samples at the given list of feature name (str) and index (int).
+        The indices are zero based.
+
+        Args:
+            features_indices (list): List of feature names (str) and indices (int) of the required samples
+
+        Raises:
+            IndexError: If the index is out of bounds
+
+        Returns:
+            bytes: Sample
+        """
+        data_frame = pd.read_csv(self.file_path, sep=self.delim, header=self.header, encoding=self.encoding)
+        samples = [bytes(data_frame.get_value(index, feature)) for feature, index in features_indices]
+        return samples

--- a/modyn/storage/internal/file_wrapper/file_wrapper_type.py
+++ b/modyn/storage/internal/file_wrapper/file_wrapper_type.py
@@ -12,6 +12,7 @@ class FileWrapperType(Enum):
 
     SingleSampleFileWrapper = "single_sample_file_wrapper"  # pylint: disable=invalid-name
     BinaryFileWrapper = "binary_file_wrapper"  # pylint: disable=invalid-name
+    CSVFileWrapper = "csv_file_wrapper"  # pylint: disable=invalid-name
 
 
 class InvalidFileWrapperTypeException(Exception):

--- a/modyn/tests/storage/internal/file_wrapper/test_csv_file_wrapper.py
+++ b/modyn/tests/storage/internal/file_wrapper/test_csv_file_wrapper.py
@@ -1,0 +1,128 @@
+import os
+import pathlib
+import shutil
+from io import StringIO
+
+import pytest
+from modyn.storage.internal.file_wrapper.csv_file_wrapper import CSVFileWrapper
+from modyn.storage.internal.file_wrapper.file_wrapper_type import FileWrapperType
+
+TMP_DIR = str(pathlib.Path(os.path.abspath(__file__)).parent / "test_tmp" / "modyn")
+FILE_PATH = str(pathlib.Path(os.path.abspath(__file__)).parent / "test_tmp" / "modyn" / "test.csv")
+FILE_DATA = "hero,description\nbatman,uses technology\nsuperman,flies through the air\nspiderman,uses a web "
+INVALID_FILE_EXTENSION_PATH = str(pathlib.Path(os.path.abspath(__file__)).parent / "test_tmp" / "modyn" / "test.txt")
+FILE_WRAPPER_CONFIG = {
+    "number_cols": 2,
+    "delimiter": ",",
+    "file_extension": ".csv",
+    "header": 0,
+    "label_col_index": 0,
+    "encoding": "utf-8",
+}
+
+
+def setup():
+    os.makedirs(TMP_DIR, exist_ok=True)
+    file = StringIO(FILE_DATA)
+
+    with open(FILE_PATH, "w", encoding=FILE_WRAPPER_CONFIG.get("encoding")) as file_pointer:
+        file.seek(0)
+        shutil.copyfileobj(file, file_pointer)
+
+
+def teardown():
+    os.remove(FILE_PATH)
+    shutil.rmtree(TMP_DIR)
+
+
+class MockFileSystemWrapper:
+    def __init__(self, file_path):
+        self.file_path = file_path
+
+    def get(self, file_path):
+        with open(file_path, "rb") as file:
+            return file.read()
+
+    def get_size(self, path):
+        return os.path.getsize(path)
+
+
+def test_init():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    assert file_wrapper.file_path == FILE_PATH
+    assert file_wrapper.file_wrapper_type == FileWrapperType.CSVFileWrapper
+
+
+def test_init_with_invalid_file_extension():
+    with pytest.raises(ValueError):
+        CSVFileWrapper(
+            INVALID_FILE_EXTENSION_PATH,
+            FILE_WRAPPER_CONFIG,
+            MockFileSystemWrapper(INVALID_FILE_EXTENSION_PATH),
+        )
+
+
+def test_get_number_of_samples():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    assert file_wrapper.get_number_of_samples() == 3
+
+
+def test_get_sample():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    sample = file_wrapper.get_sample(0)
+    assert sample == [b"batman", b"uses technology"]
+
+
+def test_get_sample_with_invalid_index():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    with pytest.raises(IndexError):
+        file_wrapper.get_sample(10)
+
+
+def test_get_label():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    label = file_wrapper.get_label(1)
+    assert label == b"description"
+
+
+def test_get_all_labels():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    assert file_wrapper.get_all_labels() == [b"hero", b"description"]
+
+
+def test_get_label_with_invalid_index():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    with pytest.raises(IndexError):
+        file_wrapper.get_label(10)
+
+
+def test_get_samples():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    samples = file_wrapper.get_samples(0, 1)
+    assert len(samples) == 1
+    assert samples == [[b"batman", b"uses technology"]]
+
+
+def test_get_samples_with_invalid_index():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    with pytest.raises(IndexError):
+        file_wrapper.get_samples(0, 5)
+
+    with pytest.raises(IndexError):
+        file_wrapper.get_samples(3, 6)
+
+
+def test_get_samples_from_indices():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    samples = file_wrapper.get_samples_from_indices([0, 1])
+    assert len(samples) == 2
+    assert samples == [
+        [b"batman", b"uses technology"],
+        [b"superman", b"flies through the air"],
+    ]
+
+
+def test_get_samples_from_indices_with_invalid_indices():
+    file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
+    with pytest.raises(IndexError):
+        file_wrapper.get_samples_from_indices([-2, 10])

--- a/modyn/tests/storage/internal/file_wrapper/test_csv_file_wrapper.py
+++ b/modyn/tests/storage/internal/file_wrapper/test_csv_file_wrapper.py
@@ -9,8 +9,12 @@ from modyn.storage.internal.file_wrapper.file_wrapper_type import FileWrapperTyp
 
 TMP_DIR = str(pathlib.Path(os.path.abspath(__file__)).parent / "test_tmp" / "modyn")
 FILE_PATH = str(pathlib.Path(os.path.abspath(__file__)).parent / "test_tmp" / "modyn" / "test.csv")
-FILE_DATA = "hero,description\nbatman,uses technology\nsuperman,flies through the air\nspiderman,uses a web "
+FILE_DATA = (
+    "hero,description,can_fly\nbatman,uses technology,0\nsuperman,flies through the air,1\nspiderman,"
+    "uses a web,0\nwonder women,truth lasso,0 "
+)
 INVALID_FILE_EXTENSION_PATH = str(pathlib.Path(os.path.abspath(__file__)).parent / "test_tmp" / "modyn" / "test.txt")
+# Try 2 configs
 FILE_WRAPPER_CONFIG = {
     "number_cols": 2,
     "delimiter": ",",
@@ -18,6 +22,7 @@ FILE_WRAPPER_CONFIG = {
     "header": 0,
     "label_col_index": 0,
     "encoding": "utf-8",
+    "labels": "can_fly",
 }
 
 
@@ -64,13 +69,13 @@ def test_init_with_invalid_file_extension():
 
 def test_get_number_of_samples():
     file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
-    assert file_wrapper.get_number_of_samples() == 3
+    assert file_wrapper.get_number_of_samples() == 4
 
 
 def test_get_sample():
     file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
-    sample = file_wrapper.get_sample(0)
-    assert sample == [b"batman", b"uses technology"]
+    sample = file_wrapper.get_sample(1)
+    assert sample == b"hero,description\nsuperman,flies through the air\n"
 
 
 def test_get_sample_with_invalid_index():
@@ -82,12 +87,12 @@ def test_get_sample_with_invalid_index():
 def test_get_label():
     file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
     label = file_wrapper.get_label(1)
-    assert label == b"description"
+    assert label == 1
 
 
 def test_get_all_labels():
     file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
-    assert file_wrapper.get_all_labels() == [b"hero", b"description"]
+    assert file_wrapper.get_all_labels() == [0, 1, 0, 0]
 
 
 def test_get_label_with_invalid_index():
@@ -98,9 +103,9 @@ def test_get_label_with_invalid_index():
 
 def test_get_samples():
     file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
-    samples = file_wrapper.get_samples(0, 1)
-    assert len(samples) == 1
-    assert samples == [[b"batman", b"uses technology"]]
+    samples = file_wrapper.get_samples(1, 3)
+    print(samples)
+    assert samples == b"hero,description\nsuperman,flies through the air\nspiderman,uses a web\n"
 
 
 def test_get_samples_with_invalid_index():
@@ -115,11 +120,8 @@ def test_get_samples_with_invalid_index():
 def test_get_samples_from_indices():
     file_wrapper = CSVFileWrapper(FILE_PATH, FILE_WRAPPER_CONFIG, MockFileSystemWrapper(FILE_PATH))
     samples = file_wrapper.get_samples_from_indices([0, 1])
-    assert len(samples) == 2
-    assert samples == [
-        [b"batman", b"uses technology"],
-        [b"superman", b"flies through the air"],
-    ]
+    # assert len(samples) == 2
+    assert samples == b"hero,description\nbatman,uses technology\nsuperman,flies through the air\n"
 
 
 def test_get_samples_from_indices_with_invalid_indices():


### PR DESCRIPTION
This PR adds CSV file wrapper and corresponding tests, and addresses issue #235. 
CSVs are read as pandas DataFrames in methods as `get_sample` etc. Therefore, pandas was added. 
All data is returned as bytes or list of bytes as discussed.