### PR TITLE
Added support for multi-epoch training

### DIFF
--- a/modyn/config/schema/pipeline-schema.yaml
+++ b/modyn/config/schema/pipeline-schema.yaml
@@ -44,6 +44,10 @@ properties:
         type: number
         description: |
           The number of GPUs that should be used for training.
+      epochs_per_trigger:
+        type: number
+        description: |
+          The number of epochs per trigger.
       device:
         type: string
         description: |

--- a/modyn/protos/trainer_server.proto
+++ b/modyn/protos/trainer_server.proto
@@ -52,6 +52,7 @@ message StartTrainingRequest {
   JsonString lr_scheduler = 18;
   PythonString label_transformer = 19;
   JsonString grad_scaler_configuration = 20;
+  int32 epochs_per_trigger = 21;
 }
 
 message StartTrainingResponse {

--- a/modyn/tests/trainer_server/internal/trainer/test_pytorch_trainer.py
+++ b/modyn/tests/trainer_server/internal/trainer/test_pytorch_trainer.py
@@ -216,6 +216,7 @@ def get_training_info(
                 lr_scheduler=JsonString(value=json.dumps(lr_scheduler_config)),
                 label_transformer=PythonString(value=get_mock_label_transformer() if transform_label else ""),
                 grad_scaler_configuration=JsonString(value=json.dumps({})),
+                epochs_per_trigger=1,
             )
             training_info = TrainingInfo(
                 request,
@@ -265,7 +266,7 @@ def get_mock_trainer(
         lr_scheduler,
         transform_label,
     )
-    trainer = PytorchTrainer(training_info, "cpu", query_queue, response_queue, logging.getLogger(__name__))
+    trainer = PytorchTrainer(training_info, "cpu", query_queue, response_queue, logging.getLogger(__name__), 1)
     return trainer
 
 
@@ -772,14 +773,7 @@ def test_create_trainer_with_exception(
             raise TimeoutError("Did not reach desired queue state within timelimit.")
 
     with tempfile.NamedTemporaryFile() as temp:
-        train(
-            training_info,
-            "cpu",
-            temp.name,
-            exception_queue,
-            query_status_queue,
-            status_queue,
-        )
+        train(training_info, "cpu", temp.name, exception_queue, query_status_queue, status_queue, 1)
         elapsed = 0
         while not (query_status_queue.empty() and status_queue.empty()):
             sleep(1)

--- a/modyn/trainer_server/internal/grpc/generated/trainer_server_pb2.py
+++ b/modyn/trainer_server/internal/grpc/generated/trainer_server_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14trainer_server.proto\x12\x07trainer\"\x1b\n\nJsonString\x12\r\n\x05value\x18\x01 \x01(\t\"\x1d\n\x0cPythonString\x12\r\n\x05value\x18\x01 \x01(\t\"3\n\x04\x44\x61ta\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x17\n\x0fnum_dataloaders\x18\x02 \x01(\x05\"\x19\n\x17TrainerAvailableRequest\"-\n\x18TrainerAvailableResponse\x12\x11\n\tavailable\x18\x01 \x01(\x08\"F\n\x0e\x43heckpointInfo\x12\x1b\n\x13\x63heckpoint_interval\x18\x01 \x01(\x05\x12\x17\n\x0f\x63heckpoint_path\x18\x02 \x01(\t\"\xc6\x05\n\x14StartTrainingRequest\x12\x13\n\x0bpipeline_id\x18\x01 \x01(\x05\x12\x12\n\ntrigger_id\x18\x02 \x01(\x05\x12\x0e\n\x06\x64\x65vice\x18\x03 \x01(\t\x12\x0b\n\x03\x61mp\x18\x04 \x01(\x08\x12\x10\n\x08model_id\x18\x05 \x01(\t\x12\x30\n\x13model_configuration\x18\x06 \x01(\x0b\x32\x13.trainer.JsonString\x12\x1c\n\x14use_pretrained_model\x18\x07 \x01(\x08\x12\x1c\n\x14load_optimizer_state\x18\x08 \x01(\x08\x12\x1d\n\x15pretrained_model_path\x18\t \x01(\t\x12\x12\n\nbatch_size\x18\n \x01(\x05\x12;\n\x1etorch_optimizers_configuration\x18\x0b \x01(\x0b\x32\x13.trainer.JsonString\x12\x17\n\x0ftorch_criterion\x18\x0c \x01(\t\x12\x31\n\x14\x63riterion_parameters\x18\r \x01(\x0b\x32\x13.trainer.JsonString\x12 \n\tdata_info\x18\x0e \x01(\x0b\x32\r.trainer.Data\x12\x30\n\x0f\x63heckpoint_info\x18\x0f \x01(\x0b\x32\x17.trainer.CheckpointInfo\x12+\n\x0c\x62ytes_parser\x18\x10 \x01(\x0b\x32\x15.trainer.PythonString\x12\x16\n\x0etransform_list\x18\x11 \x03(\t\x12)\n\x0clr_scheduler\x18\x12 \x01(\x0b\x32\x13.trainer.JsonString\x12\x30\n\x11label_transformer\x18\x13 \x01(\x0b\x32\x15.trainer.PythonString\x12\x36\n\x19grad_scaler_configuration\x18\x14 \x01(\x0b\x32\x13.trainer.JsonString\"F\n\x15StartTrainingResponse\x12\x18\n\x10training_started\x18\x01 \x01(\x08\x12\x13\n\x0btraining_id\x18\x02 \x01(\x05\",\n\x15TrainingStatusRequest\x12\x13\n\x0btraining_id\x18\x01 \x01(\x05\"\xe3\x01\n\x16TrainingStatusResponse\x12\r\n\x05valid\x18\x01 \x01(\x08\x12\x12\n\nis_running\x18\x02 \x01(\x08\x12\x17\n\x0fstate_available\x18\x03 \x01(\x08\x12\x0f\n\x07\x62locked\x18\x04 \x01(\x08\x12\x16\n\texception\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0c\x62\x61tches_seen\x18\x06 \x01(\x05H\x01\x88\x01\x01\x12\x19\n\x0csamples_seen\x18\x07 \x01(\x05H\x02\x88\x01\x01\x42\x0c\n\n_exceptionB\x0f\n\r_batches_seenB\x0f\n\r_samples_seen\"+\n\x14GetFinalModelRequest\x12\x13\n\x0btraining_id\x18\x01 \x01(\x05\"@\n\x15GetFinalModelResponse\x12\x13\n\x0bvalid_state\x18\x01 \x01(\x08\x12\x12\n\nmodel_path\x18\x02 \x01(\t\",\n\x15GetLatestModelRequest\x12\x13\n\x0btraining_id\x18\x01 \x01(\x05\"A\n\x16GetLatestModelResponse\x12\x13\n\x0bvalid_state\x18\x01 \x01(\x08\x12\x12\n\nmodel_path\x18\x02 \x01(\t2\xc3\x03\n\rTrainerServer\x12Z\n\x11trainer_available\x12 .trainer.TrainerAvailableRequest\x1a!.trainer.TrainerAvailableResponse\"\x00\x12Q\n\x0estart_training\x12\x1d.trainer.StartTrainingRequest\x1a\x1e.trainer.StartTrainingResponse\"\x00\x12X\n\x13get_training_status\x12\x1e.trainer.TrainingStatusRequest\x1a\x1f.trainer.TrainingStatusResponse\"\x00\x12R\n\x0fget_final_model\x12\x1d.trainer.GetFinalModelRequest\x1a\x1e.trainer.GetFinalModelResponse\"\x00\x12U\n\x10get_latest_model\x12\x1e.trainer.GetLatestModelRequest\x1a\x1f.trainer.GetLatestModelResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14trainer_server.proto\x12\x07trainer\"\x1b\n\nJsonString\x12\r\n\x05value\x18\x01 \x01(\t\"\x1d\n\x0cPythonString\x12\r\n\x05value\x18\x01 \x01(\t\"3\n\x04\x44\x61ta\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x17\n\x0fnum_dataloaders\x18\x02 \x01(\x05\"\x19\n\x17TrainerAvailableRequest\"-\n\x18TrainerAvailableResponse\x12\x11\n\tavailable\x18\x01 \x01(\x08\"F\n\x0e\x43heckpointInfo\x12\x1b\n\x13\x63heckpoint_interval\x18\x01 \x01(\x05\x12\x17\n\x0f\x63heckpoint_path\x18\x02 \x01(\t\"\xe2\x05\n\x14StartTrainingRequest\x12\x13\n\x0bpipeline_id\x18\x01 \x01(\x05\x12\x12\n\ntrigger_id\x18\x02 \x01(\x05\x12\x0e\n\x06\x64\x65vice\x18\x03 \x01(\t\x12\x0b\n\x03\x61mp\x18\x04 \x01(\x08\x12\x10\n\x08model_id\x18\x05 \x01(\t\x12\x30\n\x13model_configuration\x18\x06 \x01(\x0b\x32\x13.trainer.JsonString\x12\x1c\n\x14use_pretrained_model\x18\x07 \x01(\x08\x12\x1c\n\x14load_optimizer_state\x18\x08 \x01(\x08\x12\x1d\n\x15pretrained_model_path\x18\t \x01(\t\x12\x12\n\nbatch_size\x18\n \x01(\x05\x12;\n\x1etorch_optimizers_configuration\x18\x0b \x01(\x0b\x32\x13.trainer.JsonString\x12\x17\n\x0ftorch_criterion\x18\x0c \x01(\t\x12\x31\n\x14\x63riterion_parameters\x18\r \x01(\x0b\x32\x13.trainer.JsonString\x12 \n\tdata_info\x18\x0e \x01(\x0b\x32\r.trainer.Data\x12\x30\n\x0f\x63heckpoint_info\x18\x0f \x01(\x0b\x32\x17.trainer.CheckpointInfo\x12+\n\x0c\x62ytes_parser\x18\x10 \x01(\x0b\x32\x15.trainer.PythonString\x12\x16\n\x0etransform_list\x18\x11 \x03(\t\x12)\n\x0clr_scheduler\x18\x12 \x01(\x0b\x32\x13.trainer.JsonString\x12\x30\n\x11label_transformer\x18\x13 \x01(\x0b\x32\x15.trainer.PythonString\x12\x36\n\x19grad_scaler_configuration\x18\x14 \x01(\x0b\x32\x13.trainer.JsonString\x12\x1a\n\x12\x65pochs_per_trigger\x18\x15 \x01(\x05\"F\n\x15StartTrainingResponse\x12\x18\n\x10training_started\x18\x01 \x01(\x08\x12\x13\n\x0btraining_id\x18\x02 \x01(\x05\",\n\x15TrainingStatusRequest\x12\x13\n\x0btraining_id\x18\x01 \x01(\x05\"\xe3\x01\n\x16TrainingStatusResponse\x12\r\n\x05valid\x18\x01 \x01(\x08\x12\x12\n\nis_running\x18\x02 \x01(\x08\x12\x17\n\x0fstate_available\x18\x03 \x01(\x08\x12\x0f\n\x07\x62locked\x18\x04 \x01(\x08\x12\x16\n\texception\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0c\x62\x61tches_seen\x18\x06 \x01(\x05H\x01\x88\x01\x01\x12\x19\n\x0csamples_seen\x18\x07 \x01(\x05H\x02\x88\x01\x01\x42\x0c\n\n_exceptionB\x0f\n\r_batches_seenB\x0f\n\r_samples_seen\"+\n\x14GetFinalModelRequest\x12\x13\n\x0btraining_id\x18\x01 \x01(\x05\"@\n\x15GetFinalModelResponse\x12\x13\n\x0bvalid_state\x18\x01 \x01(\x08\x12\x12\n\nmodel_path\x18\x02 \x01(\t\",\n\x15GetLatestModelRequest\x12\x13\n\x0btraining_id\x18\x01 \x01(\x05\"A\n\x16GetLatestModelResponse\x12\x13\n\x0bvalid_state\x18\x01 \x01(\x08\x12\x12\n\nmodel_path\x18\x02 \x01(\t2\xc3\x03\n\rTrainerServer\x12Z\n\x11trainer_available\x12 .trainer.TrainerAvailableRequest\x1a!.trainer.TrainerAvailableResponse\"\x00\x12Q\n\x0estart_training\x12\x1d.trainer.StartTrainingRequest\x1a\x1e.trainer.StartTrainingResponse\"\x00\x12X\n\x13get_training_status\x12\x1e.trainer.TrainingStatusRequest\x1a\x1f.trainer.TrainingStatusResponse\"\x00\x12R\n\x0fget_final_model\x12\x1d.trainer.GetFinalModelRequest\x1a\x1e.trainer.GetFinalModelResponse\"\x00\x12U\n\x10get_latest_model\x12\x1e.trainer.GetLatestModelRequest\x1a\x1f.trainer.GetLatestModelResponse\"\x00\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'trainer_server_pb2', globals())
@@ -34,21 +34,21 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _CHECKPOINTINFO._serialized_start=220
   _CHECKPOINTINFO._serialized_end=290
   _STARTTRAININGREQUEST._serialized_start=293
-  _STARTTRAININGREQUEST._serialized_end=1003
-  _STARTTRAININGRESPONSE._serialized_start=1005
-  _STARTTRAININGRESPONSE._serialized_end=1075
-  _TRAININGSTATUSREQUEST._serialized_start=1077
-  _TRAININGSTATUSREQUEST._serialized_end=1121
-  _TRAININGSTATUSRESPONSE._serialized_start=1124
-  _TRAININGSTATUSRESPONSE._serialized_end=1351
-  _GETFINALMODELREQUEST._serialized_start=1353
-  _GETFINALMODELREQUEST._serialized_end=1396
-  _GETFINALMODELRESPONSE._serialized_start=1398
-  _GETFINALMODELRESPONSE._serialized_end=1462
-  _GETLATESTMODELREQUEST._serialized_start=1464
-  _GETLATESTMODELREQUEST._serialized_end=1508
-  _GETLATESTMODELRESPONSE._serialized_start=1510
-  _GETLATESTMODELRESPONSE._serialized_end=1575
-  _TRAINERSERVER._serialized_start=1578
-  _TRAINERSERVER._serialized_end=2029
+  _STARTTRAININGREQUEST._serialized_end=1031
+  _STARTTRAININGRESPONSE._serialized_start=1033
+  _STARTTRAININGRESPONSE._serialized_end=1103
+  _TRAININGSTATUSREQUEST._serialized_start=1105
+  _TRAININGSTATUSREQUEST._serialized_end=1149
+  _TRAININGSTATUSRESPONSE._serialized_start=1152
+  _TRAININGSTATUSRESPONSE._serialized_end=1379
+  _GETFINALMODELREQUEST._serialized_start=1381
+  _GETFINALMODELREQUEST._serialized_end=1424
+  _GETFINALMODELRESPONSE._serialized_start=1426
+  _GETFINALMODELRESPONSE._serialized_end=1490
+  _GETLATESTMODELREQUEST._serialized_start=1492
+  _GETLATESTMODELREQUEST._serialized_end=1536
+  _GETLATESTMODELRESPONSE._serialized_start=1538
+  _GETLATESTMODELRESPONSE._serialized_end=1603
+  _TRAINERSERVER._serialized_start=1606
+  _TRAINERSERVER._serialized_end=2057
 # @@protoc_insertion_point(module_scope)

--- a/modyn/trainer_server/internal/grpc/generated/trainer_server_pb2.pyi
+++ b/modyn/trainer_server/internal/grpc/generated/trainer_server_pb2.pyi
@@ -132,6 +132,7 @@ class StartTrainingRequest(google.protobuf.message.Message):
     LR_SCHEDULER_FIELD_NUMBER: builtins.int
     LABEL_TRANSFORMER_FIELD_NUMBER: builtins.int
     GRAD_SCALER_CONFIGURATION_FIELD_NUMBER: builtins.int
+    EPOCHS_PER_TRIGGER_FIELD_NUMBER: builtins.int
     pipeline_id: builtins.int
     trigger_id: builtins.int
     device: builtins.str
@@ -162,6 +163,7 @@ class StartTrainingRequest(google.protobuf.message.Message):
     def label_transformer(self) -> global___PythonString: ...
     @property
     def grad_scaler_configuration(self) -> global___JsonString: ...
+    epochs_per_trigger: builtins.int
     def __init__(
         self,
         *,
@@ -185,9 +187,10 @@ class StartTrainingRequest(google.protobuf.message.Message):
         lr_scheduler: global___JsonString | None = ...,
         label_transformer: global___PythonString | None = ...,
         grad_scaler_configuration: global___JsonString | None = ...,
+        epochs_per_trigger: builtins.int = ...,
     ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["bytes_parser", b"bytes_parser", "checkpoint_info", b"checkpoint_info", "criterion_parameters", b"criterion_parameters", "data_info", b"data_info", "grad_scaler_configuration", b"grad_scaler_configuration", "label_transformer", b"label_transformer", "lr_scheduler", b"lr_scheduler", "model_configuration", b"model_configuration", "torch_optimizers_configuration", b"torch_optimizers_configuration"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["amp", b"amp", "batch_size", b"batch_size", "bytes_parser", b"bytes_parser", "checkpoint_info", b"checkpoint_info", "criterion_parameters", b"criterion_parameters", "data_info", b"data_info", "device", b"device", "grad_scaler_configuration", b"grad_scaler_configuration", "label_transformer", b"label_transformer", "load_optimizer_state", b"load_optimizer_state", "lr_scheduler", b"lr_scheduler", "model_configuration", b"model_configuration", "model_id", b"model_id", "pipeline_id", b"pipeline_id", "pretrained_model_path", b"pretrained_model_path", "torch_criterion", b"torch_criterion", "torch_optimizers_configuration", b"torch_optimizers_configuration", "transform_list", b"transform_list", "trigger_id", b"trigger_id", "use_pretrained_model", b"use_pretrained_model"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["amp", b"amp", "batch_size", b"batch_size", "bytes_parser", b"bytes_parser", "checkpoint_info", b"checkpoint_info", "criterion_parameters", b"criterion_parameters", "data_info", b"data_info", "device", b"device", "epochs_per_trigger", b"epochs_per_trigger", "grad_scaler_configuration", b"grad_scaler_configuration", "label_transformer", b"label_transformer", "load_optimizer_state", b"load_optimizer_state", "lr_scheduler", b"lr_scheduler", "model_configuration", b"model_configuration", "model_id", b"model_id", "pipeline_id", b"pipeline_id", "pretrained_model_path", b"pretrained_model_path", "torch_criterion", b"torch_criterion", "torch_optimizers_configuration", b"torch_optimizers_configuration", "transform_list", b"transform_list", "trigger_id", b"trigger_id", "use_pretrained_model", b"use_pretrained_model"]) -> None: ...
 
 global___StartTrainingRequest = StartTrainingRequest
 

--- a/modyn/trainer_server/internal/grpc/trainer_server_grpc_servicer.py
+++ b/modyn/trainer_server/internal/grpc/trainer_server_grpc_servicer.py
@@ -109,6 +109,7 @@ class TrainerServerGRPCServicer:
                 exception_queue,
                 status_query_queue,
                 status_response_queue,
+                request.epochs_per_trigger,
             ),
         )
         process.start()

--- a/modyn/trainer_server/internal/trainer/pytorch_trainer.py
+++ b/modyn/trainer_server/internal/trainer/pytorch_trainer.py
@@ -37,6 +37,7 @@ class PytorchTrainer:
         status_query_queue: mp.Queue,
         status_response_queue: mp.Queue,
         logger: logging.Logger,
+        epochs_per_trigger: int,
     ) -> None:
         self.logger = logger
         self.pipeline_id = training_info.pipeline_id
@@ -93,6 +94,7 @@ class PytorchTrainer:
         self._checkpoint_path = training_info.checkpoint_path
         self._checkpoint_interval = training_info.checkpoint_interval
         self._final_checkpoint_path = training_info.final_checkpoint_path
+        self.epochs_per_trigger = epochs_per_trigger
 
         if not self._checkpoint_path.is_dir():
             self._checkpoint_path.mkdir()
@@ -243,93 +245,94 @@ class PytorchTrainer:
         self._info("Handled OnBegin Callbacks.")
 
         batch_number = 0
-        for batch_number, batch in enumerate(self._train_dataloader):
-            for _, callback in self._callbacks.items():
-                callback.on_batch_begin(self._model.model, self._optimizers, batch, batch_number)
+        for _ in range(self.epochs_per_trigger):
+            for batch_number, batch in enumerate(self._train_dataloader):
+                for _, callback in self._callbacks.items():
+                    callback.on_batch_begin(self._model.model, self._optimizers, batch, batch_number)
 
-            # As empty() is unreliable
-            # we try to fetch an element within 10ms. If there is no
-            # element within that timeframe returned, we continue.
-            try:
-                req = self._status_query_queue.get(timeout=0.01)
-                if req == TrainerMessages.STATUS_QUERY_MESSAGE:
-                    self.send_status_to_server(batch_number)
-                elif req == TrainerMessages.MODEL_STATE_QUERY_MESSAGE:
-                    self.send_model_state_to_server()
+                # As empty() is unreliable
+                # we try to fetch an element within 10ms. If there is no
+                # element within that timeframe returned, we continue.
+                try:
+                    req = self._status_query_queue.get(timeout=0.01)
+                    if req == TrainerMessages.STATUS_QUERY_MESSAGE:
+                        self.send_status_to_server(batch_number)
+                    elif req == TrainerMessages.MODEL_STATE_QUERY_MESSAGE:
+                        self.send_model_state_to_server()
+                    else:
+                        raise ValueError("Unknown message in the status query queue")
+                except queue.Empty:
+                    pass
+
+                sample_ids = batch[0]
+                if isinstance(sample_ids, torch.Tensor):
+                    sample_ids = sample_ids.tolist()
+                elif isinstance(sample_ids, tuple):
+                    sample_ids = list(sample_ids)
+
+                assert isinstance(sample_ids, list), "Cannot parse result from DataLoader"
+
+                if self._label_tranformer_function is None:
+                    target = batch[2].to(self._device)
                 else:
-                    raise ValueError("Unknown message in the status query queue")
-            except queue.Empty:
-                pass
+                    target = self._label_tranformer_function(batch[2]).to(self._device)
 
-            sample_ids = batch[0]
-            if isinstance(sample_ids, torch.Tensor):
-                sample_ids = sample_ids.tolist()
-            elif isinstance(sample_ids, tuple):
-                sample_ids = list(sample_ids)
+                data: Union[torch.Tensor, dict]
+                if isinstance(batch[1], torch.Tensor):
+                    data = batch[1].to(self._device)
+                elif isinstance(batch[1], dict):
+                    data: dict[str, torch.Tensor] = {}  # type: ignore[no-redef]
+                    for name, tensor in batch[1].items():
+                        data[name] = tensor.to(self._device)
 
-            assert isinstance(sample_ids, list), "Cannot parse result from DataLoader"
+                for _, optimizer in self._optimizers.items():
+                    optimizer.zero_grad()
 
-            if self._label_tranformer_function is None:
-                target = batch[2].to(self._device)
-            else:
-                target = self._label_tranformer_function(batch[2]).to(self._device)
+                # TODO(#163): where to perform lr_scheduler.step? make it configurable
+                if self._lr_scheduler is not None:
+                    self._lr_scheduler.step()
 
-            data: Union[torch.Tensor, dict]
-            if isinstance(batch[1], torch.Tensor):
-                data = batch[1].to(self._device)
-            elif isinstance(batch[1], dict):
-                data: dict[str, torch.Tensor] = {}  # type: ignore[no-redef]
-                for name, tensor in batch[1].items():
-                    data[name] = tensor.to(self._device)
+                pre_downsampling_size = target.shape[0]
 
-            for _, optimizer in self._optimizers.items():
-                optimizer.zero_grad()
+                with torch.autocast(self._device_type, enabled=self._amp):
+                    if self._downsampling_enabled:
+                        # TODO(#218) Persist information on the sample IDs/weights when downsampling is performed
+                        assert self._downsampler is not None
+                        big_batch_output = self._model.model(data)
+                        downsampled_indexes, weights = self._downsampler.sample(big_batch_output, target)
+                        data, target, sample_ids = get_tensors_subset(downsampled_indexes, data, target, sample_ids)
+                        # TODO(#219) Investigate if we can avoid 2 forward passes
 
-            # TODO(#163): where to perform lr_scheduler.step? make it configurable
-            if self._lr_scheduler is not None:
-                self._lr_scheduler.step()
+                    output = self._model.model(data)
+                    if self._weighted_opt:
+                        # weighted gradient descent
+                        assert weights is not None
+                        loss = torch.dot(self._criterion_nored(output, target), weights / weights.sum())
+                    else:
+                        loss = self._criterion(output, target)
 
-            pre_downsampling_size = target.shape[0]
+                self._scaler.scale(loss).backward()
 
-            with torch.autocast(self._device_type, enabled=self._amp):
-                if self._downsampling_enabled:
-                    # TODO(#218) Persist information on the sample IDs/weights when downsampling is performed
-                    assert self._downsampler is not None
-                    big_batch_output = self._model.model(data)
-                    downsampled_indexes, weights = self._downsampler.sample(big_batch_output, target)
-                    data, target, sample_ids = get_tensors_subset(downsampled_indexes, data, target, sample_ids)
-                    # TODO(#219) Investigate if we can avoid 2 forward passes
+                for _, callback in self._callbacks.items():
+                    callback.on_batch_before_update(
+                        self._model.model, self._optimizers, batch_number, sample_ids, data, target, output, loss
+                    )
 
-                output = self._model.model(data)
-                if self._weighted_opt:
-                    # weighted gradient descent
-                    assert weights is not None
-                    loss = torch.dot(self._criterion_nored(output, target), weights / weights.sum())
-                else:
-                    loss = self._criterion(output, target)
+                for _, optimizer in self._optimizers.items():
+                    self._scaler.step(optimizer)
 
-            self._scaler.scale(loss).backward()
+                self._scaler.update()
 
-            for _, callback in self._callbacks.items():
-                callback.on_batch_before_update(
-                    self._model.model, self._optimizers, batch_number, sample_ids, data, target, output, loss
-                )
+                if self._checkpoint_interval > 0 and batch_number % self._checkpoint_interval == 0:
+                    checkpoint_file_name = self._checkpoint_path / f"model_{batch_number}.modyn"
+                    self.save_state(checkpoint_file_name, batch_number)
 
-            for _, optimizer in self._optimizers.items():
-                self._scaler.step(optimizer)
+                self._num_samples += pre_downsampling_size
 
-            self._scaler.update()
-
-            if self._checkpoint_interval > 0 and batch_number % self._checkpoint_interval == 0:
-                checkpoint_file_name = self._checkpoint_path / f"model_{batch_number}.modyn"
-                self.save_state(checkpoint_file_name, batch_number)
-
-            self._num_samples += pre_downsampling_size
-
-            for _, callback in self._callbacks.items():
-                callback.on_batch_end(
-                    self._model.model, self._optimizers, batch_number, sample_ids, data, target, output, loss
-                )
+                for _, callback in self._callbacks.items():
+                    callback.on_batch_end(
+                        self._model.model, self._optimizers, batch_number, sample_ids, data, target, output, loss
+                    )
 
         self._info(f"Finished training: {self._num_samples} samples, {batch_number} batches.")
         for _, callback in self._callbacks.items():
@@ -353,6 +356,7 @@ def train(
     exception_queue: mp.Queue,
     status_query_queue: mp.Queue,
     status_response_queue: mp.Queue,
+    epochs_per_trigger: int,
 ) -> None:
     logging.basicConfig(
         level=logging.DEBUG,
@@ -364,7 +368,9 @@ def train(
     logger.addHandler(file_handler)
 
     try:
-        trainer = PytorchTrainer(training_info, device, status_query_queue, status_response_queue, logger)
+        trainer = PytorchTrainer(
+            training_info, device, status_query_queue, status_response_queue, logger, epochs_per_trigger
+        )
         trainer.train()
     except Exception:  # pylint: disable=broad-except
         exception_msg = traceback.format_exc()


### PR DESCRIPTION
Right now there is a static mapping 1 trigger 1 epoch and this might not be sufficient if we reset the model every trigger. A new pipeline parameter is added (epochs_per_trigger). If not present, the default behaviour is kept (1 epoch per trigger)