### PR TITLE
Add `Stopwatch` for performance benchmarks

### DIFF
--- a/modyn/common/benchmark/__init__.py
+++ b/modyn/common/benchmark/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+from .stopwatch import Stopwatch  # noqa: F401
+
+files = os.listdir(os.path.dirname(__file__))
+files.remove("__init__.py")
+__all__ = [f[:-3] for f in files if f.endswith(".py")]

--- a/modyn/common/benchmark/stopwatch.py
+++ b/modyn/common/benchmark/stopwatch.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+from modyn.utils import current_time_millis
+
+
+class Stopwatch:
+    """Stopwatch to be used in benchmarking.
+
+    Using a stopwatch, you can do several named measurements using a start/stop
+    interface and export all measurements as a dictionary.
+    """
+
+    def __init__(self):
+        self.measurements: dict[str, int] = {}  # Unit is milliseconds
+        self._running_measurements: dict[str, int] = {}
+        self._last_started_measurement: Optional[str] = None
+
+    def start(self, name: str) -> None:
+        assert name not in self.measurements, "Measurement already done"
+        assert name not in self._running_measurements, "Measurement already running"
+
+        self._running_measurements[name] = current_time_millis()
+        self._last_started_measurement = name
+
+    def stop(self, name: Optional[str] = None) -> int:
+        time = current_time_millis()
+
+        if name is None:
+            assert self._last_started_measurement is not None, "Cannot stop before starting a measurement"
+            name = self._last_started_measurement
+
+        assert name in self._running_measurements, "Measurement not running"
+        assert name not in self.measurements, "Measurement already done"
+
+        self.measurements[name] = time - self._running_measurements[name]
+
+        if name == self._last_started_measurement:
+            self._last_started_measurement = None
+
+        return self.measurements[name]

--- a/modyn/common/benchmark/stopwatch.py
+++ b/modyn/common/benchmark/stopwatch.py
@@ -15,8 +15,8 @@ class Stopwatch:
         self._running_measurements: dict[str, int] = {}
         self._last_started_measurement: Optional[str] = None
 
-    def start(self, name: str) -> None:
-        assert name not in self.measurements, "Measurement already done"
+    def start(self, name: str, resume: bool = False) -> None:
+        assert name not in self.measurements or resume, "Measurement already done"
         assert name not in self._running_measurements, "Measurement already running"
 
         self._running_measurements[name] = current_time_millis()
@@ -30,10 +30,10 @@ class Stopwatch:
             name = self._last_started_measurement
 
         assert name in self._running_measurements, "Measurement not running"
-        assert name not in self.measurements, "Measurement already done"
 
-        self.measurements[name] = time - self._running_measurements[name]
+        self.measurements[name] = self.measurements.get(name, 0) + time - self._running_measurements[name]
 
+        del self._running_measurements[name]
         if name == self._last_started_measurement:
             self._last_started_measurement = None
 

--- a/modyn/storage/internal/file_watcher/new_file_watcher.py
+++ b/modyn/storage/internal/file_watcher/new_file_watcher.py
@@ -328,7 +328,7 @@ class NewFileWatcher:
             current_len += len(file_df)
 
             stopwatch.stop()
-            insertion_func_measurements = {}
+            insertion_func_measurements: dict[str, int] = {}
 
             if current_len >= sample_dbinsertion_batchsize or num_file == len(valid_files) - 1:
                 logger.debug(f"[Process {process_id}] Inserting {current_len} samples.")
@@ -376,7 +376,7 @@ class NewFileWatcher:
 
         data_file_extension = json.loads(dataset.file_wrapper_config)["file_extension"]
         file_paths = filesystem_wrapper.list(path, recursive=True)
-        sw = Stopwatch()
+        stopwatch = Stopwatch()
 
         assert self.__dataset_id == dataset.dataset_id
 
@@ -398,7 +398,7 @@ class NewFileWatcher:
             )
             return
 
-        sw.start("processes")
+        stopwatch.start("processes")
 
         files_per_proc = int(len(file_paths) / self._insertion_threads)
         processes: list[mp.Process] = []
@@ -432,7 +432,7 @@ class NewFileWatcher:
         for proc in processes:
             proc.join()
 
-        runtime = round(sw.stop() / 1000, 2)
+        runtime = round(stopwatch.stop() / 1000, 2)
         if runtime > 5:
             logger.debug(f"Processes finished running in in {runtime}s.")
 

--- a/modyn/storage/internal/file_watcher/new_file_watcher.py
+++ b/modyn/storage/internal/file_watcher/new_file_watcher.py
@@ -276,7 +276,7 @@ class NewFileWatcher:
         current_len = 0
 
         for num_file, file_path in enumerate(valid_files):
-            stopwatch.start("init")
+            stopwatch.start("init", resume=True)
 
             file_wrapper = get_file_wrapper(
                 file_wrapper_type, file_path, dataset.file_wrapper_config, filesystem_wrapper
@@ -287,7 +287,7 @@ class NewFileWatcher:
             )
 
             stopwatch.stop()
-            stopwatch.start("file_creation")
+            stopwatch.start("file_creation", resume=True)
 
             try:
                 file: File = File(
@@ -311,7 +311,7 @@ class NewFileWatcher:
 
             stopwatch.stop()
 
-            stopwatch.start("label_extraction")
+            stopwatch.start("label_extraction", resume=True)
             labels = file_wrapper.get_all_labels()
             stopwatch.stop()
 
@@ -320,7 +320,7 @@ class NewFileWatcher:
                 + f" {round(stopwatch.measurements['label_extraction'] / 1000, 2)}s."
             )
 
-            stopwatch.start("df_creation")
+            stopwatch.start("df_creation", resume=True)
 
             file_df = pd.DataFrame.from_dict({"dataset_id": dataset_id, "file_id": file_id, "label": labels})
             file_df["index"] = range(len(file_df))
@@ -332,7 +332,7 @@ class NewFileWatcher:
 
             if current_len >= sample_dbinsertion_batchsize or num_file == len(valid_files) - 1:
                 logger.debug(f"[Process {process_id}] Inserting {current_len} samples.")
-                stopwatch.start("insertion_func")
+                stopwatch.start("insertion_func", resume=True)
 
                 insertion_func(process_id, dataset_id, file_dfs, insertion_func_measurements, session)
 
@@ -343,7 +343,7 @@ class NewFileWatcher:
                     + f" {round((stopwatch.measurements['insertion_func']) / 1000, 2)}s."
                 )
 
-                stopwatch.start("cleanup")
+                stopwatch.start("cleanup", resume=True)
                 current_len = 0
                 file_dfs.clear()
                 stopwatch.stop()

--- a/modyn/storage/internal/file_watcher/new_file_watcher.py
+++ b/modyn/storage/internal/file_watcher/new_file_watcher.py
@@ -12,6 +12,7 @@ import time
 from typing import Any, Optional
 
 import pandas as pd
+from modyn.common.benchmark import Stopwatch
 from modyn.storage.internal.database.models import Dataset, File, Sample
 from modyn.storage.internal.database.storage_database_connection import StorageDatabaseConnection
 from modyn.storage.internal.database.storage_database_utils import get_file_wrapper, get_filesystem_wrapper
@@ -162,7 +163,9 @@ class NewFileWatcher:
     def _postgres_copy_insertion(
         process_id: int, dataset_id: int, file_dfs: list[pd.DataFrame], time_spent: dict, session: Session
     ) -> None:
-        session_setup_start = current_time_millis()
+        stopwatch = Stopwatch()
+
+        stopwatch.start("session_setup")
 
         conn = session.connection().engine.raw_connection()
         cursor = conn.cursor()
@@ -172,10 +175,9 @@ class NewFileWatcher:
         cmd = f"COPY {table_name}{table_columns} FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
 
         logger.debug(f"[Process {process_id}] Dumping CSV in buffer.")
+        stopwatch.stop()
 
-        time_spent["other"] += current_time_millis() - session_setup_start
-
-        csv_creation_start = current_time_millis()
+        stopwatch.start("csv_creation")
         output = io.StringIO()
         for file_df in file_dfs:
             file_df.to_csv(
@@ -183,14 +185,15 @@ class NewFileWatcher:
             )
 
         output.seek(0)
-        time_spent["csv_creation"] += current_time_millis() - csv_creation_start
+        stopwatch.stop()
 
-        db_insertion_start = current_time_millis()
+        stopwatch.start("db_insertion")
         logger.debug(f"[Process {process_id}] Copying to DB.")
         cursor.copy_expert(cmd, output)
         conn.commit()
+        stopwatch.stop()
 
-        time_spent["db_insertion"] += current_time_millis() - db_insertion_start
+        time_spent.update(stopwatch.measurements)
 
     @staticmethod
     def _fallback_copy_insertion(
@@ -198,20 +201,22 @@ class NewFileWatcher:
     ) -> None:
         del process_id
         del dataset_id
+        stopwatch = Stopwatch()
 
-        dict_creation_start = current_time_millis()
-
+        stopwatch.start("dict_creation")
         for file_df in file_dfs:
             file_df["sample_id"] = None
 
         data = list(itertools.chain.from_iterable([file_df.to_dict("records") for file_df in file_dfs]))
 
-        time_spent["dict_creation"] += current_time_millis() - dict_creation_start
+        stopwatch.stop()
 
-        db_insertion_start = current_time_millis()
+        stopwatch.start("db_insertion")
         session.bulk_insert_mappings(Sample, data)
         session.commit()
-        time_spent["db_insertion"] += current_time_millis() - db_insertion_start
+        stopwatch.stop()
+
+        time_spent.update(stopwatch.measurements)
 
     # pylint: disable=too-many-locals,too-many-statements
 
@@ -237,6 +242,7 @@ class NewFileWatcher:
         assert sample_dbinsertion_batchsize > 0, "Invalid sample_dbinsertion_batchsize"
 
         db_connection: Optional[StorageDatabaseConnection] = None
+        stopwatch = Stopwatch()
 
         if session is None:  # Multithreaded
             db_connection = StorageDatabaseConnection(modyn_config)
@@ -269,19 +275,8 @@ class NewFileWatcher:
         file_dfs = []
         current_len = 0
 
-        time_spent = {
-            "init": 0,
-            "file_creation": 0,
-            "label_extraction": 0,
-            "df_creation": 0,
-            "csv_creation": 0,
-            "dict_creation": 0,
-            "db_insertion": 0,
-            "other": 0,
-        }
-
         for num_file, file_path in enumerate(valid_files):
-            init_start = current_time_millis()
+            stopwatch.start("init")
 
             file_wrapper = get_file_wrapper(
                 file_wrapper_type, file_path, dataset.file_wrapper_config, filesystem_wrapper
@@ -291,9 +286,8 @@ class NewFileWatcher:
                 f"[Process {process_id}] Found new, unknown file: {file_path} with {number_of_samples} samples."
             )
 
-            time_spent["init"] += current_time_millis() - init_start
-
-            file_creation_start = current_time_millis()
+            stopwatch.stop()
+            stopwatch.start("file_creation")
 
             try:
                 file: File = File(
@@ -315,47 +309,51 @@ class NewFileWatcher:
                 f"[Process {process_id}] Extracting and inserting samples for file {file_path} (id = {file_id})"
             )
 
-            time_spent["file_creation"] += current_time_millis() - file_creation_start
-            label_extraction_start = current_time_millis()
+            stopwatch.stop()
 
+            stopwatch.start("label_extraction")
             labels = file_wrapper.get_all_labels()
+            stopwatch.stop()
+
             logger.debug(
                 f"[Process {process_id}] Labels extracted in"
-                + f" {round((current_time_millis() - label_extraction_start) / 1000, 2)}s."
+                + f" {round(stopwatch.measurements['label_extraction'] / 1000, 2)}s."
             )
 
-            time_spent["label_extraction"] += current_time_millis() - label_extraction_start
-            df_creation_start = current_time_millis()
+            stopwatch.start("df_creation")
 
             file_df = pd.DataFrame.from_dict({"dataset_id": dataset_id, "file_id": file_id, "label": labels})
             file_df["index"] = range(len(file_df))
             file_dfs.append(file_df)
             current_len += len(file_df)
 
-            time_spent["df_creation"] += current_time_millis() - df_creation_start
+            stopwatch.stop()
+            insertion_func_measurements = {}
 
             if current_len >= sample_dbinsertion_batchsize or num_file == len(valid_files) - 1:
                 logger.debug(f"[Process {process_id}] Inserting {current_len} samples.")
-                insertion_func_start = current_time_millis()
-                insertion_func(process_id, dataset_id, file_dfs, time_spent, session)
+                stopwatch.start("insertion_func")
+
+                insertion_func(process_id, dataset_id, file_dfs, insertion_func_measurements, session)
+
+                stopwatch.stop()
 
                 logger.debug(
                     f"[Process {process_id}] Inserted {current_len} samples in"
-                    + f" {round((current_time_millis() - insertion_func_start) / 1000, 2)}s."
+                    + f" {round((stopwatch.measurements['insertion_func']) / 1000, 2)}s."
                 )
 
-                cleanup_start = current_time_millis()
-
+                stopwatch.start("cleanup")
                 current_len = 0
                 file_dfs.clear()
-
-                time_spent["other"] += current_time_millis() - cleanup_start
+                stopwatch.stop()
 
         if dump_measurements and len(valid_files) > 0:
+            measurements = {**stopwatch.measurements, **insertion_func_measurements}
             with open(
                 f"/tmp/modyn_{current_time_millis()}_process{process_id}_stats.json", "w", encoding="utf-8"
             ) as statsfile:
-                json.dump(time_spent, statsfile)
+                json.dump(measurements, statsfile)
 
         if db_connection is not None:
             db_connection.terminate_connection()
@@ -378,6 +376,7 @@ class NewFileWatcher:
 
         data_file_extension = json.loads(dataset.file_wrapper_config)["file_extension"]
         file_paths = filesystem_wrapper.list(path, recursive=True)
+        sw = Stopwatch()
 
         assert self.__dataset_id == dataset.dataset_id
 
@@ -399,7 +398,7 @@ class NewFileWatcher:
             )
             return
 
-        process_start_time = current_time_millis()
+        sw.start("processes")
 
         files_per_proc = int(len(file_paths) / self._insertion_threads)
         processes: list[mp.Process] = []
@@ -433,7 +432,7 @@ class NewFileWatcher:
         for proc in processes:
             proc.join()
 
-        runtime = round((current_time_millis() - process_start_time) / 1000, 2)
+        runtime = round(sw.stop() / 1000, 2)
         if runtime > 5:
             logger.debug(f"Processes finished running in in {runtime}s.")
 


### PR DESCRIPTION
This adds a stopwatch for performance benchmarks. Only to be used for Modyn development (internal tooling).

Next step would be actually creating a big json containing timing for all steps in the pipeline and output this measurement json (if requested from the user) for a pipeline.

Closes #239.