### PR TITLE
Use python image in CI due to space issues on Github Runners

### DIFF
--- a/.github/actions/base/action.yml
+++ b/.github/actions/base/action.yml
@@ -14,11 +14,6 @@ runs:
         cache-from: type=gha
         cache-to: type=gha
 
-    - name: Clean cache
-      run: |
-        yes | docker system prune -a
-      shell: bash
-
     - name: Load base image locally
       run: |
         docker load --input /tmp/modyndependencies.tar

--- a/.github/actions/base/action.yml
+++ b/.github/actions/base/action.yml
@@ -4,6 +4,12 @@ runs:
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@v2
     
+    # Necessary to e.g. patch which container image is being used
+    - name: Apply initial setup
+      run: |
+        bash ./initial_setup.sh
+      shell: bash
+
     - name: Build dependencies and push
       uses: docker/build-push-action@v3
       with:

--- a/.github/actions/base/action.yml
+++ b/.github/actions/base/action.yml
@@ -14,6 +14,11 @@ runs:
         cache-from: type=gha
         cache-to: type=gha
 
+    - name: Clean cache
+      run: |
+        yes | docker system prune -a
+      shell: bash
+
     - name: Load base image locally
       run: |
         docker load --input /tmp/modyndependencies.tar

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -4,8 +4,10 @@ if [[ -f ".modyn_configured" ]]; then
 fi
 
 CUDA_VERSION=11.7
-CUDA_CONTAINER=nvidia/cuda:11.7.1-devel-ubuntu22.04
 # Make sure to use devel image!
+CUDA_CONTAINER=nvidia/cuda:11.7.1-devel-ubuntu22.04
+# container used in CI - cannot use cuda because it is too big.
+CI_CONTAINER=python:3.10-slim
 
 echo "This is the first time running Modyn, we're tweaking some nuts and bolts for your system."
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -23,8 +25,12 @@ if [ "$IS_MAC" = true ] || [ "$(dpkg --print-architecture)" = "arm64" ] || [ "$(
     sed -i '' -e 's/pytorch:://g' $SCRIPT_DIR/environment.yml # Do not use Pytorch Channel (broken)
 fi
 
-# On CI, we stop here
+# On CI, we change the base image from CUDA to Python and stop here
 if [[ ! -z "$CI" ]]; then
+    dockerContent=$(tail -n "+1" $SCRIPT_DIR/docker/Dependencies/Dockerfile)
+    mv $SCRIPT_DIR/docker/Dependencies/Dockerfile $SCRIPT_DIR/docker/Dependencies/Dockerfile.original
+    echo "FROM ${CI_CONTAINER}" > $SCRIPT_DIR/docker/Dependencies/Dockerfile
+    echo "$dockerContent" >> $SCRIPT_DIR/docker/Dependencies/Dockerfile
     echo "Found CI server, exiting."
     touch ".modyn_configured"
     exit 0


### PR DESCRIPTION
When using the regular cuda image, tests fail due to no space being left on the device.