### PR TITLE
Fix Apex Build

### DIFF
--- a/docker/Trainer_Server/Dockerfile
+++ b/docker/Trainer_Server/Dockerfile
@@ -5,7 +5,7 @@ FROM modyndependencies:latest as apex-image
 # TODO(#104): Make this easily configurable here
 # RUN mamba run -n modyn pip install packaging
 # RUN git clone https://github.com/NVIDIA/apex ./apex
-# RUN mamba run -v -n modyn pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./apex
+# RUN mamba run -v -n modyn pip install -v --no-build-isolation --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./apex
 
 FROM modynbase:latest AS trainerserver-image
 


### PR DESCRIPTION
As discussed in https://github.com/NVIDIA/apex/issues/1594, it appears the only solution to make apex build on a recent release is to ignore the build dependencies during packaging... Otherwise, we get the error that the `packaging` package is missing, although we explicitly install it.