### PR TITLE
Install `grpcio` via pip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,8 @@ dependencies:
   - tqdm
   - conda-forge::enlighten
   - protobuf
-  - grpcio
+  - pip:
+    - grpcio
   - jsonschema
   - psycopg2
   - sqlalchemy>=2.0

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_gradnorm_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_gradnorm_downsampling.py
@@ -33,7 +33,11 @@ class RemoteGradNormDownsampling(AbstractRemoteDownsamplingStrategy):
                 # softmax to the forward output to obtain the probabilities
                 probs = torch.nn.functional.softmax(forward_output, dim=1)
                 num_classes = forward_output.shape[-1]
-                one_hot_targets = torch.nn.functional.one_hot(target, num_classes=num_classes)
+                # Pylint complains torch.nn.functional.one_hot is not callable for whatever reason
+                one_hot_targets = torch.nn.functional.one_hot(  # pylint: disable=not-callable
+                    target, num_classes=num_classes
+                )
+
                 scores = torch.norm(probs - one_hot_targets, dim=-1)
         else:
             sample_losses = self.per_sample_loss_fct(forward_output, target)


### PR DESCRIPTION
It appears that `grpcio` 1.57.0 on conda breaks communication between our components. The pip version does not have that behavior. We should (temporarily) switch to install grpcio from pip.