### PR TITLE
Pin version for `grpcio`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - conda-forge::enlighten
   - protobuf
   - pip:
-    - grpcio
+    - grpcio==1.59.0
   - jsonschema
   - psycopg2
   - sqlalchemy>=2.0


### PR DESCRIPTION
It appears that currently any version above 1.59.0 breaks for us.