### PR TITLE
Decouple StorageBackend from SelectionStrategies

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -89,7 +89,7 @@ jobs:
           micromamba run -n modyn black --check modyn --verbose --config black.toml
 
   unittests:
-    timeout-minutes: 20
+    timeout-minutes: 25
     runs-on: ubuntu-latest
 
     steps:

--- a/benchmark/criteo_1TB/pipelines/exp0_finetune.yml
+++ b/benchmark/criteo_1TB/pipelines/exp0_finetune.yml
@@ -95,6 +95,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 2000000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/benchmark/criteo_1TB/pipelines/exp1_finetune_ablation.yml
+++ b/benchmark/criteo_1TB/pipelines/exp1_finetune_ablation.yml
@@ -95,6 +95,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 2000000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/benchmark/criteo_1TB/pipelines/exp2_retrain_keep_model.yml
+++ b/benchmark/criteo_1TB/pipelines/exp2_retrain_keep_model.yml
@@ -95,6 +95,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 2000000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: False
 data:

--- a/benchmark/criteo_1TB/pipelines/exp3_retrain_new_model.yml
+++ b/benchmark/criteo_1TB/pipelines/exp3_retrain_new_model.yml
@@ -95,6 +95,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 2000000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: False
 data:

--- a/benchmark/criteo_1TB/pipelines/exp4_current_day_only.yml
+++ b/benchmark/criteo_1TB/pipelines/exp4_current_day_only.yml
@@ -95,6 +95,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 500000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/benchmark/mnist/mnist.yaml
+++ b/benchmark/mnist/mnist.yaml
@@ -35,6 +35,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 1000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
@@ -36,6 +36,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 10000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/benchmark/wildtime_benchmarks/example_pipelines/fmow.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/fmow.yaml
@@ -35,6 +35,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 1000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
@@ -36,6 +36,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 1000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
@@ -36,6 +36,7 @@ training:
     name: NewDataStrategy
     maximum_keys_in_memory: 1000
     config:
+      storage_backend: "database"
       limit: -1
       reset_after_trigger: True
 data:

--- a/black.toml
+++ b/black.toml
@@ -8,4 +8,7 @@ extend-exclude = """\
     .*/generated/.*\
     .*/benchmark/.*\
     .*/plotting/.*\
+    .*/build/.*\
+    .*/libbuild/.*\
+    .*/clang-tidy-build/.*\
 """

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,9 @@ services:
       context: .
       dockerfile: docker/Selector/Dockerfile
     volumes:
-       - selector-data:/tmp/trigger_samples # Remove when using a fast other storage directory (line below)
+       - selector-localstorage-data:/tmp/local_storage # Remove when using a fast other storage directory (lines below)
+       - selector-data:/tmp/trigger_samples # Remove when using a fast other storage directory (lines below)
+#      - /mnt/ssd/local_storage:/tmp/local_storage
 #      - /mnt/ssd/trigger_samples:/tmp/trigger_samples
 #      - .:/modyn_host
 #    shm_size: 4gb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,5 +164,6 @@ services:
 volumes:
   storage-data:
   selector-data:
+  selector-localstorage-data:
   downsampling-data:
   model_storage-data:

--- a/integrationtests/online_dataset/test_online_dataset.py
+++ b/integrationtests/online_dataset/test_online_dataset.py
@@ -198,7 +198,7 @@ def prepare_selector(num_dataworkers: int, keys: list[int]) -> Tuple[int, int]:
     strategy_config = {
         "name": "NewDataStrategy",
         "maximum_keys_in_memory": 2,
-        "config": {"limit": -1, "reset_after_trigger": True},
+        "config": {"limit": -1, "reset_after_trigger": True, "storage_backend": "database"},
     }
 
     pipeline_id = selector.register_pipeline(

--- a/integrationtests/selector/integrationtest_selector.py
+++ b/integrationtests/selector/integrationtest_selector.py
@@ -43,6 +43,7 @@ def test_label_balanced_presampling_huge() -> None:
         "name": "CoresetStrategy",
         "maximum_keys_in_memory": 250,
         "config": {
+            "storage_backend": "database",  # TODO(#324): Support local backend
             "limit": -1,
             "reset_after_trigger": True,
             "presampling_config": {"strategy": "LabelBalancedPresamplingStrategy", "ratio": 50},
@@ -126,6 +127,7 @@ def test_label_balanced_force_same_size():
         "name": "CoresetStrategy",
         "maximum_keys_in_memory": 100,
         "config": {
+            "storage_backend": "database",  # TODO(#324): Support local backend
             "limit": -1,
             "reset_after_trigger": False,
             "presampling_config": {
@@ -217,6 +219,7 @@ def test_label_balanced_force_all_samples():
         "name": "CoresetStrategy",
         "maximum_keys_in_memory": 100,
         "config": {
+            "storage_backend": "database",  # TODO(#324): Support local backend
             "limit": -1,
             "reset_after_trigger": False,
             "presampling_config": {
@@ -318,10 +321,11 @@ def test_newdata() -> None:
     # We test the NewData strategy for finetuning on the new data, i.e., we reset without limit
     # We also enforce high partitioning (maximum_keys_in_memory == 2) to ensure that works
 
+    # TODO(MaxiBoether): use local strategy here as well after implementing it
     strategy_config = {
         "name": "NewDataStrategy",
         "maximum_keys_in_memory": 2,
-        "config": {"limit": -1, "reset_after_trigger": True},
+        "config": {"limit": -1, "reset_after_trigger": True, "storage_backend": "database"},
     }
 
     pipeline_id = selector.register_pipeline(
@@ -459,6 +463,7 @@ def test_abstract_downsampler(reset_after_trigger) -> None:
         "name": "CoresetStrategy",
         "maximum_keys_in_memory": 50000,
         "config": {
+            "storage_backend": "database",  # TODO(#324): Support local backend
             "limit": -1,
             "reset_after_trigger": reset_after_trigger,
             "presampling_config": {"ratio": 20, "strategy": "Random"},
@@ -620,10 +625,11 @@ def test_empty_triggers() -> None:
     selector = SelectorStub(selector_channel)
     # We test without reset, i.e., after an empty trigger we get the same data
 
+    # TODO(MaxiBoether): use local strategy here as well after implementing it
     strategy_config = {
         "name": "NewDataStrategy",
         "maximum_keys_in_memory": 2,
-        "config": {"limit": -1, "reset_after_trigger": False},
+        "config": {"limit": -1, "reset_after_trigger": False, "storage_backend": "database"},
     }
 
     pipeline_id = selector.register_pipeline(
@@ -795,10 +801,11 @@ def test_many_samples_evenly_distributed():
     selector = SelectorStub(selector_channel)
     # We test without reset, i.e., after an empty trigger we get the same data
 
+    # TODO(MaxiBoether): use local strategy here as well after implementing it
     strategy_config = {
         "name": "NewDataStrategy",
         "maximum_keys_in_memory": 5000,
-        "config": {"limit": -1, "reset_after_trigger": False},
+        "config": {"limit": -1, "reset_after_trigger": False, "storage_backend": "database"},
     }
 
     pipeline_id = selector.register_pipeline(
@@ -872,10 +879,11 @@ def test_many_samples_unevenly_distributed():
     selector = SelectorStub(selector_channel)
     # We test without reset, i.e., after an empty trigger we get the same data
 
+    # TODO(MaxiBoether): use local strategy here as well after implementing it
     strategy_config = {
         "name": "NewDataStrategy",
         "maximum_keys_in_memory": 4999,
-        "config": {"limit": -1, "reset_after_trigger": False},
+        "config": {"limit": -1, "reset_after_trigger": False, "storage_backend": "database"},
     }
 
     pipeline_id = selector.register_pipeline(
@@ -950,10 +958,11 @@ def test_get_available_labels(reset_after_trigger: bool):
     selector_channel = connect_to_selector_servicer()
     selector = SelectorStub(selector_channel)
 
+    # TODO(MaxiBoether): use local strategy here as well after implementing it
     strategy_config = {
         "name": "NewDataStrategy",
         "maximum_keys_in_memory": 2,
-        "config": {"limit": -1, "reset_after_trigger": reset_after_trigger},
+        "config": {"limit": -1, "reset_after_trigger": reset_after_trigger, "storage_backend": "database"},
     }
 
     pipeline_id = selector.register_pipeline(

--- a/modyn/config/examples/example-pipeline.yaml
+++ b/modyn/config/examples/example-pipeline.yaml
@@ -57,6 +57,7 @@ training:
     config:
       limit: -1
       reset_after_trigger: True
+      storage_backend: local
     processor_type: basic_processor_strategy
 data:
   dataset_id: mnist

--- a/modyn/config/examples/example-pipeline.yaml
+++ b/modyn/config/examples/example-pipeline.yaml
@@ -57,7 +57,7 @@ training:
     config:
       limit: -1
       reset_after_trigger: True
-      storage_backend: local
+      storage_backend: database
     processor_type: basic_processor_strategy
 data:
   dataset_id: mnist

--- a/modyn/config/examples/modyn_config.yaml
+++ b/modyn/config/examples/modyn_config.yaml
@@ -161,7 +161,7 @@ selector:
   insertion_threads: 16
   trigger_sample_directory: "/tmp/trigger_samples"
   local_storage_directory: "/tmp/local_storage"
-  cleanup_trigger_samples_after_shutdown: true
+  cleanup_storage_directories_after_shutdown: true
   ignore_existing_trigger_samples: false
 
 trainer_server:

--- a/modyn/config/examples/modyn_config.yaml
+++ b/modyn/config/examples/modyn_config.yaml
@@ -160,6 +160,7 @@ selector:
   sample_batch_size: 500000
   insertion_threads: 16
   trigger_sample_directory: "/tmp/trigger_samples"
+  local_storage_directory: "/tmp/local_storage"
   cleanup_trigger_samples_after_shutdown: true
   ignore_existing_trigger_samples: false
 

--- a/modyn/config/schema/modyn_config_schema.yaml
+++ b/modyn/config/schema/modyn_config_schema.yaml
@@ -315,8 +315,15 @@ properties:
         trigger_sample_directory:
           type: string
           description: |
-            The directory where the trigger samples are stored.
-        cleanup_trigger_samples_after_shutdown:
+            The directory where the the TriggerTrainingSet (fixed set of samples to train on for one trigger) is stored.
+        local_storage_directory:
+          type: string
+          description: |
+            The directory where selection strategies that use the local storage backend persist data to.
+        # TODO(mboether): search for cleanup cleanup_trigger_samples_after_shutdown and ignore_existing_trigger_samples in repo, adjust.
+        # Furthermore, actually implement the two new flags for both local storage and trigger sample directory.
+        # Furthermore, fix that on container shutdown (force exit), we do not clean up (e.g., try atexit)
+        cleanup_storage_directories_after_shutdown:
           type: boolean
           description: |
             Whether to cleanup the trigger samples by deleting the directory after the selector has been shut down.
@@ -331,6 +338,7 @@ properties:
         - sample_batch_size
         - insertion_threads
         - trigger_sample_directory
+        - local_storage_directory
     trainer_server:
       type: object
       properties:

--- a/modyn/config/schema/modyn_config_schema.yaml
+++ b/modyn/config/schema/modyn_config_schema.yaml
@@ -320,9 +320,6 @@ properties:
           type: string
           description: |
             The directory where selection strategies that use the local storage backend persist data to.
-        # TODO(mboether): search for cleanup cleanup_trigger_samples_after_shutdown and ignore_existing_trigger_samples in repo, adjust.
-        # Furthermore, actually implement the two new flags for both local storage and trigger sample directory.
-        # Furthermore, fix that on container shutdown (force exit), we do not clean up (e.g., try atexit)
         cleanup_storage_directories_after_shutdown:
           type: boolean
           description: |

--- a/modyn/config/schema/pipeline-schema.yaml
+++ b/modyn/config/schema/pipeline-schema.yaml
@@ -159,6 +159,10 @@ properties:
                 type: number
                 description: |
                   This limits how many data points we train on at maximum on a trigger. Set to -1 to disable limit.
+              storage_backend:
+                type: string
+                description: |
+                  Defines the storage backend to use. Most strategies currently support `database`, and the NewDataStrategy supports `local` as well.
               uses_weights:
                 type: boolean
                 description: |

--- a/modyn/selector/internal/grpc/selector_server.py
+++ b/modyn/selector/internal/grpc/selector_server.py
@@ -23,7 +23,7 @@ class SelectorGRPCServer(GenericGRPCServer):
 
         callback_kwargs = {"selector_manager": self.selector_manager}
         super().__init__(modyn_config, modyn_config["selector"]["port"], SelectorGRPCServer.callback, callback_kwargs)
-        atexit.register(self._cleanup)
+        #atexit.register(self._cleanup)
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()

--- a/modyn/selector/internal/grpc/selector_server.py
+++ b/modyn/selector/internal/grpc/selector_server.py
@@ -1,5 +1,6 @@
 import atexit
 import logging
+import os
 from typing import Any
 
 from modyn.common.grpc import GenericGRPCServer
@@ -23,7 +24,9 @@ class SelectorGRPCServer(GenericGRPCServer):
 
         callback_kwargs = {"selector_manager": self.selector_manager}
         super().__init__(modyn_config, modyn_config["selector"]["port"], SelectorGRPCServer.callback, callback_kwargs)
-        atexit.register(self._cleanup)
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            # In tests, atexit leads to pytest running forever...
+            atexit.register(self._cleanup)
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()

--- a/modyn/selector/internal/grpc/selector_server.py
+++ b/modyn/selector/internal/grpc/selector_server.py
@@ -23,7 +23,7 @@ class SelectorGRPCServer(GenericGRPCServer):
 
         callback_kwargs = {"selector_manager": self.selector_manager}
         super().__init__(modyn_config, modyn_config["selector"]["port"], SelectorGRPCServer.callback, callback_kwargs)
-        #atexit.register(self._cleanup)
+        atexit.register(self._cleanup)
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
@@ -50,3 +50,5 @@ class SelectorGRPCServer(GenericGRPCServer):
         """
         super().__exit__(exc_type, exc_val, exc_tb)
         self._cleanup()
+        atexit.unregister(self._cleanup)
+

--- a/modyn/selector/internal/grpc/selector_server.py
+++ b/modyn/selector/internal/grpc/selector_server.py
@@ -51,4 +51,3 @@ class SelectorGRPCServer(GenericGRPCServer):
         super().__exit__(exc_type, exc_val, exc_tb)
         self._cleanup()
         atexit.unregister(self._cleanup)
-

--- a/modyn/selector/internal/selector_manager.py
+++ b/modyn/selector/internal/selector_manager.py
@@ -251,9 +251,18 @@ class SelectorManager:
 
     def cleanup_trigger_samples(self) -> None:
         if (
-            "cleanup_trigger_samples_after_shutdown" in self._modyn_config["selector"]
+            "cleanup_storage_directories_after_shutdown" in self._modyn_config["selector"]
             and "trigger_sample_directory" in self._modyn_config["selector"]
         ):
             shutil.rmtree(self._modyn_config["selector"]["trigger_sample_directory"])
             Path(self._modyn_config["selector"]["trigger_sample_directory"]).mkdir(parents=True, exist_ok=True)
             logger.info("Deleted the trigger sample directory.")
+
+    def cleanup_local_storage(self) -> None:
+        if (
+            "cleanup_storage_directories_after_shutdown" in self._modyn_config["selector"]
+            and "local_storage_directory" in self._modyn_config["selector"]
+        ):
+            shutil.rmtree(self._modyn_config["selector"]["local_storage_directory"])
+            Path(self._modyn_config["selector"]["local_storage_directory"]).mkdir(parents=True, exist_ok=True)
+            logger.info("Deleted the local storage directory.")

--- a/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
+++ b/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
@@ -395,7 +395,7 @@ class AbstractSelectionStrategy(ABC):
         swt = Stopwatch()
 
         # First persist the trigger which also creates the partition tables
-        #  This is done outside of subprocesses to avoid issues with duplicate table creation
+        # This is done outside of subprocesses to avoid issues with duplicate table creation
         swt.start("trigger_creation")
         with MetadataDatabaseConnection(self._modyn_config) as database:
             database.add_selector_state_metadata_trigger(self._pipeline_id, self._next_trigger_id)

--- a/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
+++ b/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
@@ -110,11 +110,11 @@ class AbstractSelectionStrategy(ABC):
         self._trigger_sample_directory = self._modyn_config["selector"]["trigger_sample_directory"]
 
     @property
-    def maximum_keys_in_memory(self):
+    def maximum_keys_in_memory(self) -> int:
         return self._maximum_keys_in_memory
 
     @maximum_keys_in_memory.setter
-    def maximum_keys_in_memory(self, value):
+    def maximum_keys_in_memory(self, value: int) -> None:
         self._maximum_keys_in_memory = value
 
         # Forward update of maximum keys in memory if needed
@@ -150,6 +150,15 @@ class AbstractSelectionStrategy(ABC):
             keys (list[str]): A list of keys of the data
             timestamps (list[int]): A list of timestamps of the data.
             labels list[int]: A list of labels
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_available_labels(self) -> list[int]:
+        """Returns the list of all labels that could be returned in the latest trigger training set
+
+        If the labels from the current "in progress" trigger should be included, first,
+        we need to trigger, and then call this function, since this only includes data from the last finished trigger.
         """
         raise NotImplementedError
 

--- a/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
+++ b/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
@@ -10,7 +10,7 @@ import numpy as np
 from modyn.common.benchmark.stopwatch import Stopwatch
 from modyn.common.trigger_sample import TriggerSampleStorage
 from modyn.metadata_database.metadata_database_connection import MetadataDatabaseConnection
-from modyn.metadata_database.models import SelectorStateMetadata, Trigger, TriggerPartition
+from modyn.metadata_database.models import Trigger, TriggerPartition
 from sqlalchemy import func
 
 logger = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ class AbstractSelectionStrategy(ABC):
     @property
     def maximum_keys_in_memory(self):
         return self._maximum_keys_in_memory
-    
+
     @maximum_keys_in_memory.setter
     def maximum_keys_in_memory(self, value):
         self._maximum_keys_in_memory = value

--- a/modyn/selector/internal/selector_strategies/coreset_strategy.py
+++ b/modyn/selector/internal/selector_strategies/coreset_strategy.py
@@ -21,10 +21,6 @@ class CoresetStrategy(AbstractSelectionStrategy):
     def __init__(self, config: dict, modyn_config: dict, pipeline_id: int, maximum_keys_in_memory: int):
         super().__init__(config, modyn_config, pipeline_id, maximum_keys_in_memory)
 
-        # Every coreset method has a presampling strategy to select datapoints to train on
-        self.presampling_strategy: AbstractPresamplingStrategy = instantiate_presampler(
-            config, modyn_config, pipeline_id
-        )
         # and a downsampler scheduler to downsample the data at the trainer server. The scheduler might just be a single
         # strategy.
         self.downsampling_scheduler: DownsamplingScheduler = instantiate_scheduler(config, maximum_keys_in_memory)
@@ -46,6 +42,11 @@ class CoresetStrategy(AbstractSelectionStrategy):
             self._storage_backend = DatabaseStorageBackend(
                 self._pipeline_id, self._modyn_config, self._maximum_keys_in_memory
             )
+
+        # Every coreset method has a presampling strategy to select datapoints to train on
+        self.presampling_strategy: AbstractPresamplingStrategy = instantiate_presampler(
+            config, modyn_config, pipeline_id, self._storage_backend
+        )
 
     def inform_data(self, keys: list[int], timestamps: list[int], labels: list[int]) -> dict[str, object]:
         assert len(keys) == len(timestamps)

--- a/modyn/selector/internal/selector_strategies/coreset_strategy.py
+++ b/modyn/selector/internal/selector_strategies/coreset_strategy.py
@@ -102,13 +102,13 @@ class CoresetStrategy(AbstractSelectionStrategy):
         def _session_callback(session: Session) -> Any:
             return (
                 session.query(SelectorStateMetadata.sample_key)
-                # TODO(#182): Index on used?
                 .filter(
                     SelectorStateMetadata.pipeline_id == self._pipeline_id,
                     SelectorStateMetadata.seen_in_trigger_id >= self._next_trigger_id - self.tail_triggers
                     if self.tail_triggers is not None
                     else True,
-                ).count()
+                )
+                .count()
             )
 
         return self._storage_backend._execute_on_session(_session_callback)

--- a/modyn/selector/internal/selector_strategies/coreset_strategy.py
+++ b/modyn/selector/internal/selector_strategies/coreset_strategy.py
@@ -28,7 +28,7 @@ class CoresetStrategy(AbstractSelectionStrategy):
         self._storage_backend: AbstractStorageBackend
         if "storage_backend" in config:
             if config["storage_backend"] == "local":
-                # TODO(create issue): Support local backend on CoresetStrategy
+                # TODO(#324): Support local backend on CoresetStrategy
                 raise NotImplementedError("The CoresetStrategy currently does not support the local backend.")
 
             if config["storage_backend"] == "database":

--- a/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
@@ -6,13 +6,11 @@ from math import isclose
 from typing import Any, Iterable, Iterator
 
 from modyn.common.benchmark.stopwatch import Stopwatch
-from modyn.metadata_database.metadata_database_connection import MetadataDatabaseConnection
 from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.abstract_selection_strategy import AbstractSelectionStrategy
 from modyn.selector.internal.storage_backend import AbstractStorageBackend
 from modyn.selector.internal.storage_backend.database import DatabaseStorageBackend
-from modyn.selector.internal.storage_backend.local import LocalStorageBackend
-from sqlalchemy import asc, exc, func, select, update
+from sqlalchemy import exc, func, update
 from sqlalchemy.sql.selectable import Select
 
 logger = logging.getLogger(__name__)

--- a/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
@@ -53,7 +53,7 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
         self._storage_backend: AbstractStorageBackend
         if "storage_backend" in config:
             if config["storage_backend"] == "local":
-                # TODO(create issue): Support local backend on FreshnessSamplingStrategy
+                # TODO(#324): Support local backend on FreshnessSamplingStrategy
                 raise NotImplementedError("The FreshnessSamplingStrategy currently does not support the local backend.")
 
             if config["storage_backend"] == "database":

--- a/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
@@ -203,7 +203,7 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
             )
 
         yield_per = max(int(self._maximum_keys_in_memory / 2), 1)
-        # Change to yield_from when we actually use the log returned here.
+        # Change to `yield from` when we actually use the log returned here.
         for keys, _ in self._storage_backend._get_pipeline_data(
             (SelectorStateMetadata.used == used,),
             yield_per=yield_per,

--- a/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
@@ -9,7 +9,11 @@ from modyn.common.benchmark.stopwatch import Stopwatch
 from modyn.metadata_database.metadata_database_connection import MetadataDatabaseConnection
 from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.abstract_selection_strategy import AbstractSelectionStrategy
+from modyn.selector.internal.storage_backend import AbstractStorageBackend
+from modyn.selector.internal.storage_backend.database import DatabaseStorageBackend
+from modyn.selector.internal.storage_backend.local import LocalStorageBackend
 from sqlalchemy import asc, exc, func, select, update
+from sqlalchemy.sql.selectable import Select
 
 logger = logging.getLogger(__name__)
 
@@ -47,13 +51,32 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
                 "FreshnessSamplingStrategy cannot reset state after trigger, because then no old data would be available to sample from."
             )
 
+        self._storage_backend: AbstractStorageBackend
+        if "storage_backend" in config:
+            if config["storage_backend"] == "local":
+                # TODO(create issue): Support local backend on FreshnessSamplingStrategy
+                raise NotImplementedError("The FreshnessSamplingStrategy currently does not support the local backend.")
+            elif config["storage_backend"] == "database":
+                self._storage_backend = DatabaseStorageBackend(
+                    self._pipeline_id, self._modyn_config, self._maximum_keys_in_memory
+                )
+            else:
+                raise NotImplementedError(
+                    f"Unknown storage backend \"{config['storage_backend']}\". Supported: database"
+                )
+        else:
+            logger.info("FreshnessSamplingStrategy defaulting to database backend.")
+            self._storage_backend = DatabaseStorageBackend(
+                self._pipeline_id, self._modyn_config, self._maximum_keys_in_memory
+            )
+
     def inform_data(self, keys: list[int], timestamps: list[int], labels: list[int]) -> dict[str, Any]:
         assert len(keys) == len(timestamps)
         assert len(timestamps) == len(labels)
 
         swt = Stopwatch()
         swt.start("persist_samples")
-        persist_log = self._persist_samples(keys, timestamps, labels)
+        persist_log = self._storage_backend.persist_samples(self._next_trigger_id, keys, timestamps, labels)
         return {"total_persist_time": swt.stop(), "persist_log": persist_log}
 
     def _on_trigger(self) -> Iterable[tuple[list[tuple[int, float]], dict[str, Any]]]:
@@ -86,12 +109,14 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
         assert self._is_first_trigger
         self._is_first_trigger = False
 
-        for samples in self._get_all_unused_data():
+        if self.has_limit:
             # TODO(#179): this assumes limit < len(samples)
-            if self.has_limit and self.training_set_size_limit < len(samples):
-                samples = random.sample(samples, self.training_set_size_limit)
-
-            yield samples
+            for samples in self._get_all_unused_data():
+                yield random.sample(samples, self.training_set_size_limit) if self.training_set_size_limit < len(
+                    samples
+                ) else samples
+        else:
+            yield from self._get_all_unused_data()
 
     def _get_trigger_data(self) -> Iterable[list[int]]:
         assert not self._is_first_trigger
@@ -159,28 +184,33 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
         Returns:
             list[str]: Keys of used samples
         """
-        with MetadataDatabaseConnection(self._modyn_config) as database:
-            stmt = (
-                select(SelectorStateMetadata.sample_key, SelectorStateMetadata.used)
-                # Enables batching of results in chunks. See https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#orm-queryguide-yield-per
-                .execution_options(yield_per=max(int(self._maximum_keys_in_memory / 2), 1))
-                .filter(SelectorStateMetadata.pipeline_id == self._pipeline_id, SelectorStateMetadata.used == used)
+        assert isinstance(
+            self._storage_backend, DatabaseStorageBackend
+        ), "FreshnessStrategy currently only supports DatabaseBackend"
+
+        def _chunk_callback(chunk):
+            _, used_data = zip(*chunk)
+            if used:
+                assert all(used_data), "Queried used data, but got unused data."
+            else:
+                assert not any(used_data), "Queried unused data, but got used data."
+
+        def _statement_modifier(stmt: Select):
+            return (
+                stmt.add_columns(SelectorStateMetadata.used)
                 .order_by(func.random())  # pylint: disable=not-callable
                 .limit(sample_size)
             )
 
-            for chunk in database.session.execute(stmt).partitions():
-                if len(chunk) > 0:
-                    keys, used_data = zip(*chunk)
-                    if used:
-                        assert all(used_data), "Queried used data, but got unused data."
-                    else:
-                        assert not any(used_data), "Queried unused data, but got used data."
-
-                else:
-                    keys = []
-
-                yield list(keys)
+        yield_per = max(int(self._maximum_keys_in_memory / 2), 1)
+        # Change to yield_from when we actually use the log returned here.
+        for keys, _ in self._storage_backend._get_pipeline_data(
+            (SelectorStateMetadata.used == used,),
+            yield_per=yield_per,
+            statement_modifier=_statement_modifier,
+            chunk_callback=_chunk_callback,
+        ):
+            yield keys
 
     def _get_all_unused_data(self) -> Iterator[list[int]]:
         """Returns all unused samples
@@ -188,23 +218,24 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
         Returns:
             list[str]: Keys of unused samples
         """
-        with MetadataDatabaseConnection(self._modyn_config) as database:
-            stmt = (
-                select(SelectorStateMetadata.sample_key, SelectorStateMetadata.used)
-                # Enables batching of results in chunks. See https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#orm-queryguide-yield-per
-                .execution_options(yield_per=self._maximum_keys_in_memory)
-                .filter(SelectorStateMetadata.pipeline_id == self._pipeline_id, SelectorStateMetadata.used == False)
-                .order_by(asc(SelectorStateMetadata.timestamp))
-            )
+        assert isinstance(
+            self._storage_backend, DatabaseStorageBackend
+        ), "FreshnessStrategy currently only supports DatabaseBackend"
 
-            for chunk in database.session.execute(stmt).partitions():
-                if len(chunk) > 0:
-                    keys, used = zip(*chunk)
-                    assert not any(used), "Queried unused data, but got used data."
-                else:
-                    keys, used = [], []
+        def _chunk_callback(chunk):
+            _, used = zip(*chunk)
+            assert not any(used), "Queried unused data, but got used data."
 
-                yield list(keys)
+        def _statement_modifier(stmt: Select):
+            return stmt.add_columns(SelectorStateMetadata.used)
+
+        # Change to yield_from when we actually use the log returned here.
+        for keys, _ in self._storage_backend._get_pipeline_data(
+            (SelectorStateMetadata.used == False,),
+            statement_modifier=_statement_modifier,
+            chunk_callback=_chunk_callback,
+        ):
+            yield keys
 
     def _get_count_of_data(self, used: bool) -> int:
         """Returns all unused samples
@@ -212,28 +243,39 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
         Returns:
             list[str]: Keys of unused samples
         """
-        with MetadataDatabaseConnection(self._modyn_config) as database:
+        assert isinstance(
+            self._storage_backend, DatabaseStorageBackend
+        ), "FreshnessStrategy currently only supports DatabaseBackend"
+
+        def _session_callback(session):
             return (
-                database.session.query(SelectorStateMetadata.sample_key)
+                session.query(SelectorStateMetadata.sample_key)
                 # TODO(#182): Index on used?
                 .filter(
                     SelectorStateMetadata.pipeline_id == self._pipeline_id, SelectorStateMetadata.used == used
                 ).count()
             )
 
+        return self._storage_backend._execute_on_session(_session_callback)
+
     def _mark_used(self, keys: list[int]) -> None:
         """Sets samples to used"""
         if len(keys) == 0:
             return
+        assert isinstance(
+            self._storage_backend, DatabaseStorageBackend
+        ), "FreshnessStrategy currently only supports DatabaseBackend"
 
-        with MetadataDatabaseConnection(self._modyn_config) as database:
+        def _session_callback(session):
             try:
                 stmt = update(SelectorStateMetadata).where(SelectorStateMetadata.sample_key.in_(keys)).values(used=True)
-                database.session.execute(stmt)
-                database.session.commit()
+                session.execute(stmt)
+                session.commit()
             except exc.SQLAlchemyError as exception:
                 logger.error(f"Could not set metadata: {exception}")
-                database.session.rollback()
+                session.rollback()
+
+        return self._storage_backend._execute_on_session(_session_callback)
 
     def _reset_state(self) -> None:
         raise NotImplementedError("This strategy does not support resets.")

--- a/modyn/selector/internal/selector_strategies/new_data_strategy.py
+++ b/modyn/selector/internal/selector_strategies/new_data_strategy.py
@@ -106,6 +106,7 @@ class NewDataStrategy(AbstractSelectionStrategy):
         assert self.reset_after_trigger
 
         if self.has_limit:
+            # TODO(#179): this assumes limit < len(samples)
             swt = Stopwatch()
             for samples, partition_log in self._get_current_trigger_data():
                 swt.start("sample_time")

--- a/modyn/selector/internal/selector_strategies/new_data_strategy.py
+++ b/modyn/selector/internal/selector_strategies/new_data_strategy.py
@@ -54,7 +54,9 @@ class NewDataStrategy(AbstractSelectionStrategy):
 
         self._storage_backend: AbstractStorageBackend
         if config["storage_backend"] == "local":
-            self._storage_backend = LocalStorageBackend()
+            self._storage_backend = LocalStorageBackend(
+                self._pipeline_id, self._modyn_config, self._maximum_keys_in_memory
+            )
         elif config["storage_backend"] == "database":
             self._storage_backend = DatabaseStorageBackend(
                 self._pipeline_id, self._modyn_config, self._maximum_keys_in_memory
@@ -191,3 +193,6 @@ class NewDataStrategy(AbstractSelectionStrategy):
 
     def _reset_state(self) -> None:
         pass  # As we currently hold everything in database (#116), this currently is a noop.
+
+    def get_available_labels(self) -> list[int]:
+        return self._storage_backend.get_available_labels(self._next_trigger_id, tail_triggers=self.tail_triggers)

--- a/modyn/selector/internal/selector_strategies/new_data_strategy.py
+++ b/modyn/selector/internal/selector_strategies/new_data_strategy.py
@@ -5,10 +5,10 @@ import random
 from typing import Iterable
 
 from modyn.common.benchmark.stopwatch import Stopwatch
-from modyn.metadata_database.metadata_database_connection import MetadataDatabaseConnection
-from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.abstract_selection_strategy import AbstractSelectionStrategy
-from sqlalchemy import asc, select
+from modyn.selector.internal.storage_backend import AbstractStorageBackend
+from modyn.selector.internal.storage_backend.database import DatabaseStorageBackend
+from modyn.selector.internal.storage_backend.local import LocalStorageBackend
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,9 @@ class NewDataStrategy(AbstractSelectionStrategy):
     """
 
     def __init__(self, config: dict, modyn_config: dict, pipeline_id: int, maximum_keys_in_memory: int):
-        super().__init__(config, modyn_config, pipeline_id, maximum_keys_in_memory)
+        super().__init__(
+            config, modyn_config, pipeline_id, maximum_keys_in_memory, required_configs=["storage_backend"]
+        )
 
         if self.has_limit and not self.reset_after_trigger and "limit_reset" not in config:
             raise ValueError("Please define how to deal with the limit without resets using the 'limit_reset' option.")
@@ -50,13 +52,25 @@ class NewDataStrategy(AbstractSelectionStrategy):
             if self.limit_reset_strategy not in self.supported_limit_reset_strategies:
                 raise ValueError(f"Unsupported limit reset strategy: {self.limit_reset_strategy}")
 
+        self._storage_backend: AbstractStorageBackend
+        if config["storage_backend"] == "local":
+            self._storage_backend = LocalStorageBackend()
+        elif config["storage_backend"] == "database":
+            self._storage_backend = DatabaseStorageBackend(
+                self._pipeline_id, self._modyn_config, self._maximum_keys_in_memory
+            )
+        else:
+            raise NotImplementedError(
+                f"Unknown storage backend \"{config['storage_backend']}\". Supported: local, database"
+            )
+
     def inform_data(self, keys: list[int], timestamps: list[int], labels: list[int]) -> dict[str, object]:
         assert len(keys) == len(timestamps)
         assert len(timestamps) == len(labels)
 
         swt = Stopwatch()
         swt.start("persist_samples")
-        persist_log = self._persist_samples(keys, timestamps, labels)
+        persist_log = self._storage_backend.persist_samples(self._next_trigger_id, keys, timestamps, labels)
         return {"total_persist_time": swt.stop(), "persist_log": persist_log}
 
     def _on_trigger(self) -> Iterable[tuple[list[tuple[int, float]], dict[str, object]]]:
@@ -88,41 +102,45 @@ class NewDataStrategy(AbstractSelectionStrategy):
 
     def _get_data_reset(self) -> Iterable[tuple[list[int], dict[str, object]]]:
         assert self.reset_after_trigger
-        swt = Stopwatch()
 
-        for samples, partition_log in self._get_current_trigger_data():
-            # TODO(#179): this assumes limit < len(samples)
-            if self.has_limit:
+        if self.has_limit:
+            swt = Stopwatch()
+            for samples, partition_log in self._get_current_trigger_data():
                 swt.start("sample_time")
                 samples = random.sample(samples, min(len(samples), self.training_set_size_limit))
                 partition_log["sample_time"] = swt.stop()
-
-            yield samples, partition_log
+                yield samples, partition_log
+        else:
+            yield from self._get_current_trigger_data()
 
     def _get_data_tail(self) -> Iterable[tuple[list[int], dict[str, object]]]:
         assert not self.reset_after_trigger and self.tail_triggers > 0
-        swt = Stopwatch()
 
-        for samples, partition_log in self._get_tail_triggers_data():
+        if self.has_limit:
+            swt = Stopwatch()
             # TODO(#179): this assumes limit < len(samples)
-            if self.has_limit:
+            for samples, partition_log in self._get_tail_triggers_data():
                 swt.start("sample_time")
                 samples = random.sample(samples, min(len(samples), self.training_set_size_limit))
                 partition_log["sample_time"] = swt.stop()
-
-            yield samples, partition_log
+                yield samples, partition_log
+        else:
+            yield from self._get_tail_triggers_data()
 
     def _get_data_no_reset(self) -> Iterable[tuple[list[int], dict[str, object]]]:
         assert not self.reset_after_trigger
-        swt = Stopwatch()
-        for samples, partition_log in self._get_all_data():
-            # TODO(#179): this assumes limit < len(samples)
-            if self.has_limit:
+
+        if self.has_limit:
+            swt = Stopwatch()
+            for samples, partition_log in self._get_all_data():
+                # TODO(#179): this assumes limit < len(samples)
                 swt.start("handle_limit_time", overwrite=True)
                 samples = self._handle_limit_no_reset(samples)
                 partition_log["handle_limit_time"] = swt.stop()
 
-            yield samples, partition_log
+                yield samples, partition_log
+        else:
+            yield from self._get_all_data()
 
     def _handle_limit_no_reset(self, samples: list[int]) -> list[int]:
         assert self.limit_reset_strategy is not None
@@ -148,35 +166,12 @@ class NewDataStrategy(AbstractSelectionStrategy):
         return random.sample(samples, min(len(samples), self.training_set_size_limit))
 
     def _get_current_trigger_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
-        """Returns all sample for current trigger
+        """Returns all samples seen during current trigger.
 
         Returns:
-            list[int]: Keys of used samples
+            Iterable[tuple[list[int], dict[str, object]]]: Iterator over a tuple of a list of integers (maximum _maximum_keys_in_memory) and a log dict
         """
-        swt = Stopwatch()
-
-        with MetadataDatabaseConnection(self._modyn_config) as database:
-            stmt = (
-                select(SelectorStateMetadata.sample_key)
-                # Enables batching of results in chunks. See https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#orm-queryguide-yield-per
-                .execution_options(yield_per=self._maximum_keys_in_memory)
-                .filter(
-                    SelectorStateMetadata.pipeline_id == self._pipeline_id,
-                    SelectorStateMetadata.seen_in_trigger_id == self._next_trigger_id,
-                )
-                .order_by(asc(SelectorStateMetadata.timestamp))
-            )
-
-            swt.start("get_chunk")
-            for chunk in database.session.execute(stmt).partitions():
-                log = {"get_chunk_time": swt.stop()}
-
-                if len(chunk) > 0:
-                    yield [res[0] for res in chunk], log
-                else:
-                    yield [], log
-
-                swt.start("get_chunk", overwrite=True)
+        yield from self._storage_backend.get_trigger_data(self._next_trigger_id)
 
     def _get_tail_triggers_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
         """Returns all sample for current trigger
@@ -184,29 +179,7 @@ class NewDataStrategy(AbstractSelectionStrategy):
         Returns:
             list[int]: Keys of used samples
         """
-        swt = Stopwatch()
-        with MetadataDatabaseConnection(self._modyn_config) as database:
-            stmt = (
-                select(SelectorStateMetadata.sample_key)
-                # Enables batching of results in chunks. See https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#orm-queryguide-yield-per
-                .execution_options(yield_per=self._maximum_keys_in_memory)
-                .filter(
-                    SelectorStateMetadata.pipeline_id == self._pipeline_id,
-                    SelectorStateMetadata.seen_in_trigger_id >= self._next_trigger_id - self.tail_triggers,
-                )
-                .order_by(asc(SelectorStateMetadata.timestamp))
-            )
-
-            swt.start("get_chunk")
-            for chunk in database.session.execute(stmt).partitions():
-                log = {"get_chunk_time": swt.stop()}
-
-                if len(chunk) > 0:
-                    yield [res[0] for res in chunk], log
-                else:
-                    yield [], log
-
-                swt.start("get_chunk", overwrite=True)
+        yield from self._storage_backend.get_data_since_trigger(self._next_trigger_id - self.tail_triggers)
 
     def _get_all_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
         """Returns all sample
@@ -214,26 +187,7 @@ class NewDataStrategy(AbstractSelectionStrategy):
         Returns:
             list[str]: Keys of used samples
         """
-        swt = Stopwatch()
-        with MetadataDatabaseConnection(self._modyn_config) as database:
-            stmt = (
-                select(SelectorStateMetadata.sample_key)
-                # Enables batching of results in chunks. See https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#orm-queryguide-yield-per
-                .execution_options(yield_per=self._maximum_keys_in_memory)
-                .filter(SelectorStateMetadata.pipeline_id == self._pipeline_id)
-                .order_by(asc(SelectorStateMetadata.timestamp))
-            )
-
-            swt.start("get_chunk")
-            for chunk in database.session.execute(stmt).partitions():
-                log = {"get_chunk_time": swt.stop()}
-
-                if len(chunk) > 0:
-                    yield [res[0] for res in chunk], log
-                else:
-                    yield [], log
-
-                swt.start("get_chunk", overwrite=True)
+        yield from self._storage_backend.get_all_data()
 
     def _reset_state(self) -> None:
         pass  # As we currently hold everything in database (#116), this currently is a noop.

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_balanced_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_balanced_strategy.py
@@ -46,7 +46,7 @@ class AbstractBalancedPresamplingStrategy(AbstractPresamplingStrategy):
         self.force_column_balancing = presampling_config.get("force_column_balancing", False)
         self.balanced_column = balanced_column
 
-        # TODO(create issue): Support local backend on AbstractBalancedStrategy
+        # TODO(#324): Support local backend on AbstractBalancedStrategy
         assert isinstance(
             self._storage_backend, DatabaseStorageBackend
         ), "AbstractBalancedPresamplingStrategy currently only supports the DatabaseStorageBackend"

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_balanced_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_balanced_strategy.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import sqlalchemy
 from modyn.metadata_database.models import SelectorStateMetadata
@@ -8,6 +8,7 @@ from modyn.selector.internal.selector_strategies.presampling_strategies.abstract
 from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 from modyn.selector.internal.storage_backend.database.database_storage_backend import DatabaseStorageBackend
 from sqlalchemy import Select, asc, func, select
+from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import func as sql_func
 
 
@@ -133,7 +134,7 @@ class AbstractBalancedPresamplingStrategy(AbstractPresamplingStrategy):
 
         """
 
-        def _session_callback(session):
+        def _session_callback(session: Session) -> Any:
             query = (
                 session.query(self.balanced_column, func.count())  # pylint: disable=not-callable
                 .filter(

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_presampling_strategy.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 from sqlalchemy import Select
 
 
 class AbstractPresamplingStrategy(ABC):
-    def __init__(self, presampling_config: dict, modyn_config: dict, pipeline_id: int):
+    def __init__(
+        self, presampling_config: dict, modyn_config: dict, pipeline_id: int, storage_backend: AbstractStorageBackend
+    ):
         self.modyn_config = modyn_config
         self.pipeline_id = pipeline_id
+        self._storage_backend = storage_backend
 
         if "ratio" not in presampling_config:
             raise ValueError("Please specify the presampling ratio.")

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/label_balanced_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/label_balanced_presampling_strategy.py
@@ -1,7 +1,10 @@
 from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.presampling_strategies import AbstractBalancedPresamplingStrategy
+from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 
 
 class LabelBalancedPresamplingStrategy(AbstractBalancedPresamplingStrategy):
-    def __init__(self, presampling_config: dict, modyn_config: dict, pipeline_id: int):
-        super().__init__(presampling_config, modyn_config, pipeline_id, SelectorStateMetadata.label)
+    def __init__(
+        self, presampling_config: dict, modyn_config: dict, pipeline_id: int, storage_backend: AbstractStorageBackend
+    ):
+        super().__init__(presampling_config, modyn_config, pipeline_id, storage_backend, SelectorStateMetadata.label)

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/no_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/no_presampling_strategy.py
@@ -2,15 +2,18 @@ from typing import Optional
 
 from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.presampling_strategies import AbstractPresamplingStrategy
+from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 from sqlalchemy import Select, asc, select
 
 
 class NoPresamplingStrategy(AbstractPresamplingStrategy):
-    def __init__(self, presampling_config: dict, modyn_config: dict, pipeline_id: int):
+    def __init__(
+        self, presampling_config: dict, modyn_config: dict, pipeline_id: int, storage_backend: AbstractStorageBackend
+    ):
         if "ratio" in presampling_config and presampling_config["ratio"] != 100:
             raise ValueError("Using NoPresamplingStrategy, the presampling_ratio is implicitly 100%")
         presampling_config["ratio"] = 100
-        super().__init__(presampling_config, modyn_config, pipeline_id)
+        super().__init__(presampling_config, modyn_config, pipeline_id, storage_backend)
 
     def get_presampling_query(
         self,

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
@@ -23,7 +23,7 @@ class RandomNoReplacementPresamplingStrategy(AbstractPresamplingStrategy):
         # TODO(#324): Support local backend on RandomNoReplacementPresamplingStrategy
         assert isinstance(
             self._storage_backend, DatabaseStorageBackend
-        ), "AbstractBalancedPresamplingStrategy currently only supports the DatabaseStorageBackend"
+        ), "RandomNoReplacementPresamplingStrategy currently only supports the DatabaseStorageBackend"
 
     def get_presampling_query(
         self,

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
@@ -7,6 +7,7 @@ from modyn.selector.internal.selector_strategies.presampling_strategies.abstract
 from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 from modyn.selector.internal.storage_backend.database.database_storage_backend import DatabaseStorageBackend
 from sqlalchemy import Select, asc, func, select
+from sqlalchemy.orm.session import Session
 
 
 class RandomNoReplacementPresamplingStrategy(AbstractPresamplingStrategy):
@@ -83,7 +84,7 @@ class RandomNoReplacementPresamplingStrategy(AbstractPresamplingStrategy):
         return subq
 
     def _update_last_used_in_trigger(self, next_trigger_id: int, subq: Select) -> None:
-        def _session_callback(session):
+        def _session_callback(session: Session) -> None:
             session.query(SelectorStateMetadata).filter(
                 SelectorStateMetadata.pipeline_id == self.pipeline_id,
                 SelectorStateMetadata.sample_key.in_(subq),
@@ -93,7 +94,7 @@ class RandomNoReplacementPresamplingStrategy(AbstractPresamplingStrategy):
         self._storage_backend._execute_on_session(_session_callback)
 
     def _count_number_of_sampled_points(self, next_trigger_id: int) -> int:
-        def _session_callback(session):
+        def _session_callback(session: Session) -> None:
             return (
                 session.query(SelectorStateMetadata.sample_key)
                 .filter(

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
@@ -1,20 +1,28 @@
 from typing import Optional
 
-from modyn.metadata_database.metadata_database_connection import MetadataDatabaseConnection
 from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.presampling_strategies.abstract_presampling_strategy import (
     AbstractPresamplingStrategy,
 )
+from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
+from modyn.selector.internal.storage_backend.database.database_storage_backend import DatabaseStorageBackend
 from sqlalchemy import Select, asc, func, select
 
 
 class RandomNoReplacementPresamplingStrategy(AbstractPresamplingStrategy):
-    def __init__(self, presampling_config: dict, modyn_config: dict, pipeline_id: int):
-        super().__init__(presampling_config, modyn_config, pipeline_id)
+    def __init__(
+        self, presampling_config: dict, modyn_config: dict, pipeline_id: int, storage_backend: AbstractStorageBackend
+    ):
+        super().__init__(presampling_config, modyn_config, pipeline_id, storage_backend)
         self.requires_trigger_dataset_size = True
 
         # a complete_trigger is the last time when all the datapoints (in the db at that time) have been seen
         self.last_complete_trigger = 0
+
+        # TODO(create issue): Support local backend on AbstractBalancedStrategy
+        assert isinstance(
+            self._storage_backend, DatabaseStorageBackend
+        ), "AbstractBalancedPresamplingStrategy currently only supports the DatabaseStorageBackend"
 
     def get_presampling_query(
         self,
@@ -75,20 +83,24 @@ class RandomNoReplacementPresamplingStrategy(AbstractPresamplingStrategy):
         return subq
 
     def _update_last_used_in_trigger(self, next_trigger_id: int, subq: Select) -> None:
-        with MetadataDatabaseConnection(self.modyn_config) as database:
-            database.session.query(SelectorStateMetadata).filter(
+        def _session_callback(session):
+            session.query(SelectorStateMetadata).filter(
                 SelectorStateMetadata.pipeline_id == self.pipeline_id,
                 SelectorStateMetadata.sample_key.in_(subq),
             ).update({"last_used_in_trigger": next_trigger_id})
-            database.session.commit()
+            session.commit()
+
+        self._storage_backend._execute_on_session(_session_callback)
 
     def _count_number_of_sampled_points(self, next_trigger_id: int) -> int:
-        with MetadataDatabaseConnection(self.modyn_config) as database:
+        def _session_callback(session):
             return (
-                database.session.query(SelectorStateMetadata.sample_key)
+                session.query(SelectorStateMetadata.sample_key)
                 .filter(
                     SelectorStateMetadata.pipeline_id == self.pipeline_id,
                     SelectorStateMetadata.last_used_in_trigger == next_trigger_id,
                 )
                 .count()
             )
+
+        return self._storage_backend._execute_on_session(_session_callback)

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/random_no_replacement_presampling_strategy.py
@@ -20,7 +20,7 @@ class RandomNoReplacementPresamplingStrategy(AbstractPresamplingStrategy):
         # a complete_trigger is the last time when all the datapoints (in the db at that time) have been seen
         self.last_complete_trigger = 0
 
-        # TODO(create issue): Support local backend on AbstractBalancedStrategy
+        # TODO(#324): Support local backend on RandomNoReplacementPresamplingStrategy
         assert isinstance(
             self._storage_backend, DatabaseStorageBackend
         ), "AbstractBalancedPresamplingStrategy currently only supports the DatabaseStorageBackend"

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/random_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/random_presampling_strategy.py
@@ -4,12 +4,15 @@ from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.presampling_strategies.abstract_presampling_strategy import (
     AbstractPresamplingStrategy,
 )
+from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 from sqlalchemy import Select, asc, func, select
 
 
 class RandomPresamplingStrategy(AbstractPresamplingStrategy):
-    def __init__(self, presampling_config: dict, modyn_config: dict, pipeline_id: int):
-        super().__init__(presampling_config, modyn_config, pipeline_id)
+    def __init__(
+        self, presampling_config: dict, modyn_config: dict, pipeline_id: int, storage_backend: AbstractStorageBackend
+    ):
+        super().__init__(presampling_config, modyn_config, pipeline_id, storage_backend)
         self.requires_trigger_dataset_size = True
 
     def get_presampling_query(

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/trigger_balanced_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/trigger_balanced_presampling_strategy.py
@@ -2,12 +2,17 @@ from typing import Optional
 
 from modyn.metadata_database.models import SelectorStateMetadata
 from modyn.selector.internal.selector_strategies.presampling_strategies import AbstractBalancedPresamplingStrategy
+from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 from sqlalchemy import Select
 
 
 class TriggerBalancedPresamplingStrategy(AbstractBalancedPresamplingStrategy):
-    def __init__(self, presampling_config: dict, modyn_config: dict, pipeline_id: int):
-        super().__init__(presampling_config, modyn_config, pipeline_id, SelectorStateMetadata.seen_in_trigger_id)
+    def __init__(
+        self, presampling_config: dict, modyn_config: dict, pipeline_id: int, storage_backend: AbstractStorageBackend
+    ):
+        super().__init__(
+            presampling_config, modyn_config, pipeline_id, storage_backend, SelectorStateMetadata.seen_in_trigger_id
+        )
 
     def get_presampling_query(
         self,

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/utils.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/utils.py
@@ -1,8 +1,11 @@
 from modyn.selector.internal.selector_strategies.presampling_strategies import AbstractPresamplingStrategy
+from modyn.selector.internal.storage_backend.abstract_storage_backend import AbstractStorageBackend
 from modyn.utils import instantiate_class
 
 
-def instantiate_presampler(config: dict, modyn_config: dict, pipeline_id: int) -> AbstractPresamplingStrategy:
+def instantiate_presampler(
+    config: dict, modyn_config: dict, pipeline_id: int, storage_backend: AbstractStorageBackend
+) -> AbstractPresamplingStrategy:
     if "presampling_config" not in config or "strategy" not in config["presampling_config"]:
         presampling_strategy = "NoPresamplingStrategy"
         presampling_config = {}
@@ -17,6 +20,7 @@ def instantiate_presampler(config: dict, modyn_config: dict, pipeline_id: int) -
             presampling_config,
             modyn_config,
             pipeline_id,
+            storage_backend,
         )
     except ValueError:
         # Try to instantiate the class even if the short name is used
@@ -26,5 +30,6 @@ def instantiate_presampler(config: dict, modyn_config: dict, pipeline_id: int) -
             presampling_config,
             modyn_config,
             pipeline_id,
+            storage_backend,
         )
     return presampling_class

--- a/modyn/selector/internal/storage_backend/__init__.py
+++ b/modyn/selector/internal/storage_backend/__init__.py
@@ -3,6 +3,8 @@ This submodule provides backends for storing the seen samples during a pipeline.
 """
 import os
 
+from .abstract_storage_backend import AbstractStorageBackend  # noqa: F401
+
 files = os.listdir(os.path.dirname(__file__))
 files.remove("__init__.py")
 __all__ = [f[:-3] for f in files if f.endswith(".py")]

--- a/modyn/selector/internal/storage_backend/abstract_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/abstract_storage_backend.py
@@ -1,0 +1,32 @@
+import logging
+import os
+import platform
+from abc import ABC, abstractmethod
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class AbstractStorageBackend(ABC):
+    def __init__(self, pipeline_id: int, modyn_config: dict, maximum_keys_in_memory: int):
+        self._modyn_config = modyn_config
+        self._maximum_keys_in_memory = maximum_keys_in_memory
+        self._pipeline_id = pipeline_id
+
+        self._insertion_threads = modyn_config["selector"]["insertion_threads"]
+        self._is_test = "PYTEST_CURRENT_TEST" in os.environ
+        self._is_mac = platform.system() == "Darwin"
+        self._disable_mt = self._insertion_threads <= 0
+
+        if self._maximum_keys_in_memory < 1:
+            raise ValueError(f"Invalid setting for maximum_keys_in_memory: {self._maximum_keys_in_memory}")
+
+    @abstractmethod
+    def persist_samples(
+        self, seen_in_trigger_id: int, keys: list[int], timestamps: list[int], labels: list[int]
+    ) -> dict[str, Any]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_available_labels(self) -> list[int]:
+        raise NotImplementedError()

--- a/modyn/selector/internal/storage_backend/abstract_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/abstract_storage_backend.py
@@ -2,7 +2,7 @@ import logging
 import os
 import platform
 from abc import ABC, abstractmethod
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class AbstractStorageBackend(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_available_labels(self) -> list[int]:
+    def get_available_labels(self, next_trigger_id: int, tail_triggers: Optional[int] = None) -> list[int]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/modyn/selector/internal/storage_backend/abstract_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/abstract_storage_backend.py
@@ -2,7 +2,7 @@ import logging
 import os
 import platform
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -29,4 +29,18 @@ class AbstractStorageBackend(ABC):
 
     @abstractmethod
     def get_available_labels(self) -> list[int]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_trigger_data(self, trigger_id: int) -> Iterable[tuple[list[int], dict[str, object]]]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_data_since_trigger(
+        self, smallest_included_trigger_id: int
+    ) -> Iterable[tuple[list[int], dict[str, object]]]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_all_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
         raise NotImplementedError()

--- a/modyn/selector/internal/storage_backend/database/__init__.py
+++ b/modyn/selector/internal/storage_backend/database/__init__.py
@@ -1,0 +1,10 @@
+"""
+This submodule provides backends for storing the seen samples during a pipeline.
+"""
+import os
+
+from .database_storage_backend import DatabaseStorageBackend  # noqa: F401
+
+files = os.listdir(os.path.dirname(__file__))
+files.remove("__init__.py")
+__all__ = [f[:-3] for f in files if f.endswith(".py")]

--- a/modyn/selector/internal/storage_backend/database/database_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/database/database_storage_backend.py
@@ -1,0 +1,126 @@
+import logging
+import multiprocessing as mp
+from typing import Any
+
+from modyn.common.benchmark.stopwatch import Stopwatch
+from modyn.metadata_database.metadata_database_connection import MetadataDatabaseConnection
+from modyn.metadata_database.models import SelectorStateMetadata
+from modyn.selector.internal.storage_backend import AbstractStorageBackend
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseStorageBackend(AbstractStorageBackend):
+    def __init__(self, pipeline_id: int, modyn_config: dict, maximum_keys_in_memory: int):
+        super().__init__(pipeline_id, modyn_config, maximum_keys_in_memory)
+
+    def persist_samples(
+        self, seen_in_trigger_id: int, keys: list[int], timestamps: list[int], labels: list[int]
+    ) -> dict[str, Any]:
+        assert len(keys) == len(timestamps) and len(keys) == len(labels)
+
+        log = {}
+        swt = Stopwatch()
+
+        # First persist the trigger which also creates the partition tables
+        # This is done outside of subprocesses to avoid issues with duplicate table creation
+        swt.start("trigger_creation")
+        with MetadataDatabaseConnection(self._modyn_config) as database:
+            database.add_selector_state_metadata_trigger(self._pipeline_id, seen_in_trigger_id)
+        log["trigger_creation_time"] = swt.stop()
+
+        if self._disable_mt or (self._is_test and self._is_mac):
+            swt.start("persist_samples_time")
+            DatabaseStorageBackend._persist_samples_impl(
+                keys, timestamps, labels, self._pipeline_id, self._modyn_config, seen_in_trigger_id
+            )
+            log["persist_samples_time"] = swt.stop()
+        else:
+            self._mt_persist_samples_impl(keys, timestamps, labels, seen_in_trigger_id, log)
+
+        return log
+
+    def _mt_persist_samples_impl(
+        self, 
+        keys: list[int],
+        timestamps: list[int],
+        labels: list[int],
+        seen_in_trigger_id: int,
+        log: dict
+    ):
+        swt = Stopwatch()
+        samples_per_proc = int(len(keys) / self._insertion_threads)
+        processes: list[mp.Process] = []
+        swt.start("persist_samples_time")
+
+        for i in range(self._insertion_threads):
+            start_idx = i * samples_per_proc
+            end_idx = start_idx + samples_per_proc if i < self._insertion_threads - 1 else len(keys)
+            proc_keys = keys[start_idx:end_idx]
+            proc_timestamps = timestamps[start_idx:end_idx]
+            proc_labels = labels[start_idx:end_idx]
+
+            if len(proc_keys) > 0:
+                logger.debug(f"Starting persisting process for {len(proc_keys)} samples.")
+                proc = mp.Process(
+                    target=DatabaseStorageBackend._persist_samples_impl,
+                    args=(
+                        proc_keys,
+                        proc_timestamps,
+                        proc_labels,
+                        self._pipeline_id,
+                        self._modyn_config,
+                        seen_in_trigger_id,
+                    ),
+                )
+                proc.start()
+                processes.append(proc)
+
+        for proc in processes:
+            proc.join()
+
+        log["persist_samples_time"] = swt.stop()
+
+
+    @staticmethod
+    def _persist_samples_impl(
+        keys: list[int],
+        timestamps: list[int],
+        labels: list[int],
+        pipeline_id: int,
+        modyn_config: dict,
+        seen_in_trigger_id: int,
+    ):
+        with MetadataDatabaseConnection(modyn_config) as database:
+            database.session.bulk_insert_mappings(
+                SelectorStateMetadata,
+                [
+                    {
+                        "pipeline_id": pipeline_id,
+                        "sample_key": key,
+                        "timestamp": timestamp,
+                        "label": label,
+                        "seen_in_trigger_id": seen_in_trigger_id,
+                    }
+                    for key, timestamp, label in zip(keys, timestamps, labels)
+                ],
+            )
+            database.session.commit()
+
+    def get_available_labels(self) -> list[int]:
+        with MetadataDatabaseConnection(self._modyn_config) as database:
+            result = (
+                database.session.query(SelectorStateMetadata.label)
+                .filter(
+                    SelectorStateMetadata.pipeline_id == self._pipeline_id,
+                    SelectorStateMetadata.seen_in_trigger_id < self._next_trigger_id,
+                    SelectorStateMetadata.seen_in_trigger_id >= self._next_trigger_id - self.tail_triggers - 1
+                    if self.tail_triggers is not None
+                    else True,
+                )
+                .distinct()
+                .all()
+            )
+            available_labels = [result_tuple[0] for result_tuple in result]
+
+        return available_labels

--- a/modyn/selector/internal/storage_backend/local/__init__.py
+++ b/modyn/selector/internal/storage_backend/local/__init__.py
@@ -3,6 +3,8 @@ This submodule provides backends for storing the seen samples during a pipeline.
 """
 import os
 
+from .local_storage_backend import LocalStorageBackend  # noqa: F401
+
 files = os.listdir(os.path.dirname(__file__))
 files.remove("__init__.py")
 __all__ = [f[:-3] for f in files if f.endswith(".py")]

--- a/modyn/selector/internal/storage_backend/local/local_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/local/local_storage_backend.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Iterable, Optional
 
 from modyn.selector.internal.storage_backend import AbstractStorageBackend
 
@@ -6,4 +7,21 @@ logger = logging.getLogger(__name__)
 
 
 class LocalStorageBackend(AbstractStorageBackend):
-    pass
+    def persist_samples(
+        self, seen_in_trigger_id: int, keys: list[int], timestamps: list[int], labels: list[int]
+    ) -> dict[str, Any]:
+        raise NotImplementedError()
+
+    def get_available_labels(self, next_trigger_id: int, tail_triggers: Optional[int] = None) -> list[int]:
+        raise NotImplementedError()
+
+    def get_trigger_data(self, trigger_id: int) -> Iterable[tuple[list[int], dict[str, object]]]:
+        raise NotImplementedError()
+
+    def get_data_since_trigger(
+        self, smallest_included_trigger_id: int
+    ) -> Iterable[tuple[list[int], dict[str, object]]]:
+        raise NotImplementedError()
+
+    def get_all_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
+        raise NotImplementedError()

--- a/modyn/selector/internal/storage_backend/local/local_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/local/local_storage_backend.py
@@ -1,0 +1,9 @@
+import logging
+
+from modyn.selector.internal.storage_backend import AbstractStorageBackend
+
+logger = logging.getLogger(__name__)
+
+
+class LocalStorageBackend(AbstractStorageBackend):
+    pass

--- a/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_random_presampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_random_presampling_strategy.py
@@ -9,6 +9,7 @@ from modyn.selector.internal.selector_strategies import CoresetStrategy
 from modyn.selector.internal.selector_strategies.presampling_strategies.random_presampling_strategy import (
     RandomPresamplingStrategy,
 )
+from modyn.selector.internal.storage_backend.database.database_storage_backend import DatabaseStorageBackend
 
 database_path = pathlib.Path(os.path.abspath(__file__)).parent / "test_storage.db"
 
@@ -48,13 +49,17 @@ def setup_and_teardown():
 
 
 def test_constructor():
-    strat = RandomPresamplingStrategy(get_config(), get_minimal_modyn_config(), 10)
+    strat = RandomPresamplingStrategy(
+        get_config(), get_minimal_modyn_config(), 10, DatabaseStorageBackend(0, get_minimal_modyn_config(), 123)
+    )
     assert strat.presampling_ratio == 50
     assert strat.requires_trigger_dataset_size
 
 
 def test_target_size():
-    strat = RandomPresamplingStrategy(get_config(), get_minimal_modyn_config(), 10)
+    strat = RandomPresamplingStrategy(
+        get_config(), get_minimal_modyn_config(), 10, DatabaseStorageBackend(0, get_minimal_modyn_config(), 123)
+    )
     assert strat.get_target_size(100, None) == 50
     assert strat.get_target_size(20, None) == 10
     assert strat.get_target_size(19, None) == 9
@@ -70,7 +75,9 @@ def test_target_size():
 
 
 def test_get_query_wrong():
-    strat = RandomPresamplingStrategy(get_config(), get_minimal_modyn_config(), 10)
+    strat = RandomPresamplingStrategy(
+        get_config(), get_minimal_modyn_config(), 10, DatabaseStorageBackend(0, get_minimal_modyn_config(), 123)
+    )
 
     # missing size
     with pytest.raises(AssertionError):
@@ -90,12 +97,16 @@ def test_constructor_throws_on_invalid_config():
     conf["ratio"] = 0
 
     with pytest.raises(ValueError):
-        RandomPresamplingStrategy(conf, get_minimal_modyn_config(), 10)
+        RandomPresamplingStrategy(
+            conf, get_minimal_modyn_config(), 10, DatabaseStorageBackend(0, get_minimal_modyn_config(), 123)
+        )
 
     conf["ratio"] = 101
 
     with pytest.raises(ValueError):
-        RandomPresamplingStrategy(conf, get_minimal_modyn_config(), 10)
+        RandomPresamplingStrategy(
+            conf, get_minimal_modyn_config(), 10, DatabaseStorageBackend(0, get_minimal_modyn_config(), 123)
+        )
 
 
 def test_dataset_size_various_scenarios():

--- a/modyn/tests/selector/internal/selector_strategies/test_coreset_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/test_coreset_strategy.py
@@ -141,7 +141,7 @@ def test_on_trigger_multi_chunks():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 4
+    strat.maximum_keys_in_memory = 4
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -154,7 +154,7 @@ def test_on_trigger_multi_chunks_unbalanced():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 2
+    strat.maximum_keys_in_memory = 2
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -169,7 +169,7 @@ def test_on_trigger_multi_chunks_bis():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 2
+    strat.maximum_keys_in_memory = 2
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -188,7 +188,7 @@ def test_no_presampling():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 5
+    strat.maximum_keys_in_memory = 5
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -205,7 +205,7 @@ def test_chunking():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 2
+    strat.maximum_keys_in_memory = 2
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -223,7 +223,7 @@ def test_chunking_with_stricter_limit():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 2
+    strat.maximum_keys_in_memory = 2
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -239,7 +239,7 @@ def test_chunking_with_stricter_presampling():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 5
+    strat.maximum_keys_in_memory = 5
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -320,7 +320,7 @@ def test_no_presampling_with_limit():
     strat = CoresetStrategy(config, get_minimal_modyn_config(), 0, 1000)
 
     strat.inform_data([10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5], ["dog", "dog", "cat", "bird", "snake", "bird"])
-    strat._maximum_keys_in_memory = 5
+    strat.maximum_keys_in_memory = 5
 
     generator = strat._on_trigger()
     indexes = [data for data, _ in generator]
@@ -336,7 +336,7 @@ def test_get_all_data():
 
     assert list(generator) == [[10, 11, 12]]
 
-    strat._maximum_keys_in_memory = 2
+    strat.maximum_keys_in_memory = 2
 
     generator = strat._get_data()
 

--- a/modyn/tests/selector/internal/selector_strategies/test_freshness_sampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/test_freshness_sampling_strategy.py
@@ -345,12 +345,12 @@ def test__get_all_unused_data():
 
 def test__get_all_unused_data_partitioning():
     strat = FreshnessSamplingStrategy(get_freshness_config(), get_minimal_modyn_config(), 0, 1000)
-    strat._maximum_keys_in_memory = 1
+    strat.maximum_keys_in_memory = 1
     strat.inform_data([10, 11, 12], [0, 1, 2], ["dog", "dog", "cat"])
     strat._mark_used([10])
 
     result = list(strat._get_all_unused_data())
-    assert len(result) == 2
+    assert len(result) == 2, f"result = {result}"
     result = flatten(result)
 
     assert set(result) == set([11, 12])

--- a/modyn/tests/selector/internal/selector_strategies/test_new_data_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/test_new_data_strategy.py
@@ -35,11 +35,13 @@ def get_minimal_modyn_config():
 
 
 def get_config():
-    return {"reset_after_trigger": False, "limit": -1}
+    # TODO(MaxiBoether): also test local
+    return {"reset_after_trigger": False, "limit": -1, "storage_backend": "database"}
 
 
 def get_config_tail():
-    return {"reset_after_trigger": False, "limit": -1, "tail_triggers": 1}
+    # TODO(MaxiBoether): also test local
+    return {"reset_after_trigger": False, "limit": -1, "tail_triggers": 1, "storage_backend": "database"}
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/modyn/tests/selector/internal/storage_backend/database/test_database_storage_backend.py
+++ b/modyn/tests/selector/internal/storage_backend/database/test_database_storage_backend.py
@@ -1,0 +1,243 @@
+import os
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+from modyn.metadata_database.metadata_database_connection import MetadataDatabaseConnection
+from modyn.metadata_database.models import SelectorStateMetadata
+from modyn.selector.internal.storage_backend.database import DatabaseStorageBackend
+from modyn.utils.utils import flatten
+from sqlalchemy import select
+
+database_path = pathlib.Path(os.path.abspath(__file__)).parent / "test_storage.db"
+TMP_DIR = tempfile.mkdtemp()
+
+
+def get_minimal_modyn_config():
+    return {
+        "metadata_database": {
+            "drivername": "sqlite",
+            "username": "",
+            "password": "",
+            "host": "",
+            "port": "0",
+            "database": f"{database_path}",
+        },
+        "selector": {"insertion_threads": 8, "trigger_sample_directory": TMP_DIR},
+    }
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_and_teardown():
+    pathlib.Path(TMP_DIR).mkdir(parents=True, exist_ok=True)
+
+    with MetadataDatabaseConnection(get_minimal_modyn_config()) as database:
+        database.create_tables()
+    yield
+
+    os.remove(database_path)
+    shutil.rmtree(TMP_DIR)
+
+
+def test_persist_samples():
+    backend = DatabaseStorageBackend(42, get_minimal_modyn_config(), 1000)
+    backend.persist_samples(0, [10, 11, 12], [0, 1, 2], [40, 41, 42])
+
+    with MetadataDatabaseConnection(get_minimal_modyn_config()) as database:
+        data = database.session.query(
+            SelectorStateMetadata.sample_key,
+            SelectorStateMetadata.timestamp,
+            SelectorStateMetadata.label,
+            SelectorStateMetadata.pipeline_id,
+            SelectorStateMetadata.used,
+        ).all()
+
+        assert len(data) == 3
+
+        keys, timestamps, labels, pipeline_ids, useds = zip(*data)
+
+        assert not any(useds)
+        for pip_id in pipeline_ids:
+            assert pip_id == 42
+
+        assert keys[0] == 10 and keys[1] == 11 and keys[2] == 12
+        assert timestamps[0] == 0 and timestamps[1] == 1 and timestamps[2] == 2
+        assert labels[0] == 40 and labels[1] == 41 and labels[2] == 42
+
+
+def test_get_data_since_trigger():
+    backend = DatabaseStorageBackend(42, get_minimal_modyn_config(), 2)
+    backend.persist_samples(0, [10, 11, 12], [0, 1, 2], [40, 41, 42])
+    backend.persist_samples(1, [13, 14, 15], [3, 4, 5], [40, 41, 42])
+    backend.persist_samples(2, [16, 17, 18], [6, 7, 8], [40, 41, 42])
+
+    data_since_trigger_one = [keys for keys, _ in backend.get_data_since_trigger(1)]
+    assert len(data_since_trigger_one) == 3  # Validate partitioning
+    assert flatten(data_since_trigger_one) == [13, 14, 15, 16, 17, 18]  # Validate content
+
+
+def test_get_trigger_data():
+    backend = DatabaseStorageBackend(42, get_minimal_modyn_config(), 2)
+    backend.persist_samples(0, [10, 11, 12], [0, 1, 2], [40, 41, 42])
+    backend.persist_samples(1, [13, 14, 15], [3, 4, 5], [40, 41, 42])
+    backend.persist_samples(2, [16, 17, 18], [6, 7, 8], [40, 41, 42])
+
+    trigger_zero_data = [keys for keys, _ in backend.get_trigger_data(0)]
+    trigger_one_data = [keys for keys, _ in backend.get_trigger_data(1)]
+    trigger_three_data = [keys for keys, _ in backend.get_trigger_data(3)]
+
+    assert len(trigger_zero_data) == 2  # Validate partitioning
+    assert flatten(trigger_zero_data) == [10, 11, 12]  # Validate content
+
+    assert len(trigger_one_data) == 2  # Validate partitioning
+    assert flatten(trigger_one_data) == [13, 14, 15]  # Validate content
+
+    assert len(trigger_three_data) == 0
+
+
+def test_get_all_data():
+    backend = DatabaseStorageBackend(42, get_minimal_modyn_config(), 2)
+    backend.persist_samples(0, [10, 11, 12], [0, 1, 2], [40, 41, 42])
+    backend.persist_samples(1, [13, 14, 15], [3, 4, 5], [40, 41, 42])
+    backend.persist_samples(2, [16, 17, 18], [6, 7, 8], [40, 41, 42])
+
+    all_data = [keys for keys, _ in backend.get_all_data()]
+
+    assert len(all_data) == 5  # Validate partitioning
+    assert flatten(all_data) == [10, 11, 12, 13, 14, 15, 16, 17, 18]  # Validate content
+
+
+def test_get_available_labels_with_tail():
+    backend = DatabaseStorageBackend(1, get_minimal_modyn_config(), 42)
+    # Next trigger is 0
+    assert sorted(backend.get_available_labels(0)) == []
+
+    with MetadataDatabaseConnection(get_minimal_modyn_config()) as database:
+        # first trigger
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=0, seen_in_trigger_id=0, timestamp=0, label=1)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=1, seen_in_trigger_id=0, timestamp=0, label=18)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=2, seen_in_trigger_id=0, timestamp=0, label=1)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=3, seen_in_trigger_id=0, timestamp=0, label=0)
+        )
+        database.session.commit()
+
+    # Next trigger is 1, trigger 0 has data now
+    assert sorted(backend.get_available_labels(1)) == [0, 1, 18]
+
+    with MetadataDatabaseConnection(get_minimal_modyn_config()) as database:
+        # second trigger
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=4, seen_in_trigger_id=1, timestamp=0, label=0)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=5, seen_in_trigger_id=1, timestamp=0, label=890)
+        )
+        database.session.commit()
+
+    # Next trigger is 2, trigger 1 has data now
+    assert sorted(backend.get_available_labels(2, tail_triggers=0)) == [0, 890]
+
+
+def test_get_available_labels_no_tail():
+    backend = DatabaseStorageBackend(1, get_minimal_modyn_config(), 42)
+    # Next trigger is 0
+    assert sorted(backend.get_available_labels(0)) == []
+
+    with MetadataDatabaseConnection(get_minimal_modyn_config()) as database:
+        # first trigger
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=0, seen_in_trigger_id=0, timestamp=0, label=1)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=1, seen_in_trigger_id=0, timestamp=0, label=18)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=2, seen_in_trigger_id=0, timestamp=0, label=1)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=3, seen_in_trigger_id=0, timestamp=0, label=0)
+        )
+        database.session.commit()
+
+    # Next trigger is 1, trigger 0 has data now
+    assert sorted(backend.get_available_labels(1)) == [0, 1, 18]
+
+    with MetadataDatabaseConnection(get_minimal_modyn_config()) as database:
+        # second trigger
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=4, seen_in_trigger_id=1, timestamp=0, label=0)
+        )
+        database.session.add(
+            SelectorStateMetadata(pipeline_id=1, sample_key=5, seen_in_trigger_id=1, timestamp=0, label=890)
+        )
+        database.session.commit()
+
+    # Next trigger is 2, trigger 1 has data now
+    assert sorted(backend.get_available_labels(2)) == [0, 1, 18, 890]
+
+
+# BEGIN TESTS OF INTERNAL FUNCTIONS #
+
+
+def test__get_pipeline_data_yield_per():
+    backend = DatabaseStorageBackend(42, get_minimal_modyn_config(), 2)
+    backend.persist_samples(0, [10, 11, 12], [0, 1, 2], [40, 41, 42])
+
+    all_data_yp1 = [keys for keys, _ in backend._get_pipeline_data((), yield_per=1)]
+    all_data_yp2 = [keys for keys, _ in backend._get_pipeline_data((), yield_per=2)]
+    all_data_yp3 = [keys for keys, _ in backend._get_pipeline_data((), yield_per=3)]
+
+    assert flatten(all_data_yp1) == flatten(all_data_yp2)
+    assert flatten(all_data_yp2) == flatten(all_data_yp3)
+    assert flatten(all_data_yp3) == [10, 11, 12]
+
+    assert len(all_data_yp1) == 3
+    assert len(all_data_yp2) == 2
+    assert len(all_data_yp3) == 1
+
+
+def test__get_pipeline_data_filter():
+    backend = DatabaseStorageBackend(42, get_minimal_modyn_config(), 2)
+    backend.persist_samples(0, [10, 11, 12], [0, 1, 2], [40, 41, 42])
+
+    filtered_data = [keys for keys, _ in backend._get_pipeline_data((SelectorStateMetadata.sample_key == 11,))]
+    assert flatten(filtered_data) == [11]
+
+
+# This is a test, we do not want to have this global at the module level
+# As we delete it afterwards, this is safe
+# pylint: disable=global-variable-undefined
+
+
+def test__partitioned_execute_stmt():
+    backend = DatabaseStorageBackend(42, get_minimal_modyn_config(), 2)
+    backend.persist_samples(0, [10, 11, 12], [0, 1, 2], [40, 41, 42])
+
+    # We need a global here such that it is available in the callback
+    global dbsb_test_part_exec_callback_call_count
+    dbsb_test_part_exec_callback_call_count = 0
+
+    def callback(_):
+        global dbsb_test_part_exec_callback_call_count
+        dbsb_test_part_exec_callback_call_count += 1
+
+    stmt = (
+        select(SelectorStateMetadata.sample_key)
+        .execution_options(yield_per=1)
+        .filter(SelectorStateMetadata.pipeline_id == 42)
+    )
+
+    selected_data = [keys for keys, _ in backend._partitioned_execute_stmt(stmt, 1, callback)]
+    assert flatten(selected_data) == [10, 11, 12]
+    assert len(selected_data) == 3
+    assert dbsb_test_part_exec_callback_call_count == 3
+
+    del dbsb_test_part_exec_callback_call_count  # Cleanup global

--- a/modyn/tests/selector/internal/test_selector_manager.py
+++ b/modyn/tests/selector/internal/test_selector_manager.py
@@ -40,6 +40,9 @@ class MockStrategy(AbstractSelectionStrategy):
     def _reset_state(self) -> None:  # pylint: disable=unused-argument
         pass
 
+    def get_available_labels(self) -> list[int]:
+        return []
+
 
 class MockDatabaseConnection:
     def __init__(self, modyn_config: dict):  # pylint: disable=super-init-not-called,unused-argument

--- a/modyn/tests/selector/test_selector.py
+++ b/modyn/tests/selector/test_selector.py
@@ -19,6 +19,9 @@ class MockStrategy(AbstractSelectionStrategy):
     def _reset_state(self) -> None:
         pass
 
+    def get_available_labels(self) -> list[int]:
+        return []
+
 
 def test_init():
     selec = Selector(MockStrategy(), 42, 2, {})

--- a/scripts/python_compliance.sh
+++ b/scripts/python_compliance.sh
@@ -33,7 +33,7 @@ mamba run -n modyn black modyn integrationtests --verbose --config black.toml > 
 
 echo "Running linters"
 
-if mamba run -n modyn flake8 ; then
+if mamba run -n modyn flake8 modyn ; then
     echo "No flake8 errors"
 else
     echo "flake8 errors"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,10 @@ max-line-length = 120
 exclude = *_grpc.py,
           *_pb2.py,
           benchmark/**/*,
-          plotting/**/*
+          plotting/**/*,
+          build/**/*,
+          libbuild/**/*,
+          clang-tidy-build/**/*
 
 extend-ignore = E203 
 # E203 is not pep8-compliant

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,12 @@ project_slug = "modyn"
 
 EXTENSION_BUILD_DIR = pathlib.Path(here) / "libbuild"
 
+
 def _get_env_variable(name, default='OFF'):
     if name not in os.environ.keys():
         return default
     return os.environ[name]
+
 
 class CMakeExtension(Extension):
     def __init__(self, name, cmake_lists_dir='.', sources=[], **kwa):
@@ -66,10 +68,10 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def copy_extensions_to_source(self):
         pass
-    
+
     def build_extensions(self):
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError('Cannot find CMake executable')
 


### PR DESCRIPTION
This PR separates the usage of the database from the strategies. In general, most strategies for now just support the database backend. As the next step, we will actually implement the LocalStorageBackend and support it in the NewDataStrategy.