### PR TITLE
fix mypy type checking error due to mypy version update from 1.6.0 to 1.7.0

### DIFF
--- a/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/freshness_sampling_strategy.py
@@ -178,7 +178,7 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
                         assert not any(used_data), "Queried unused data, but got used data."
 
                 else:
-                    keys = []
+                    keys = ()
 
                 yield list(keys)
 
@@ -202,7 +202,7 @@ class FreshnessSamplingStrategy(AbstractSelectionStrategy):
                     keys, used = zip(*chunk)
                     assert not any(used), "Queried unused data, but got used data."
                 else:
-                    keys, used = [], []
+                    keys, used = (), ()
 
                 yield list(keys)
 


### PR DESCRIPTION
This PR fixes a mypy type checking error in selector/internal/selector_strategies/freshness_sampling_strategy.py.
mypy got a version update from 1.6.0 to 1.7.0, which causes the error.