### PR TITLE
Add a Dummy model for integration tests

### DIFF
--- a/integrationtests/supervisor/integrationtest_supervisor.py
+++ b/integrationtests/supervisor/integrationtest_supervisor.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     try:
         dataset_helper.setup_dataset()
         test_start_one_experiment_pipeline()
-        # test_start_two_experiment_pipelines()
+        test_start_two_experiment_pipelines()
         time.sleep(TIMEOUT)
         # TODO(#317): implement get_status proto. check for pipeline execution success.
     finally:

--- a/integrationtests/supervisor/integrationtest_supervisor.py
+++ b/integrationtests/supervisor/integrationtest_supervisor.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     try:
         dataset_helper.setup_dataset()
         test_start_one_experiment_pipeline()
-        test_start_two_experiment_pipelines()
+        # test_start_two_experiment_pipelines()
         time.sleep(TIMEOUT)
         # TODO(#317): implement get_status proto. check for pipeline execution success.
     finally:

--- a/integrationtests/utils.py
+++ b/integrationtests/utils.py
@@ -37,7 +37,7 @@ def get_minimal_pipeline_config(
 ) -> dict:
     return {
         "pipeline": {"name": "Test"},
-        "model": {"id": "ResNet18"},
+        "model": {"id": "Dummy"},
         "model_storage": model_storage_config,
         "training": {
             "gpus": 1,

--- a/modyn/models/__init__.py
+++ b/modyn/models/__init__.py
@@ -5,6 +5,7 @@ import os
 
 from .articlenet.articlenet import ArticleNet  # noqa: F401
 from .dlrm.dlrm import DLRM  # noqa: F401
+from .dummy.dummy import Dummy  # noqa: F401
 from .fmownet.fmownet import FmowNet  # noqa: F401
 from .resnet18.resnet18 import ResNet18  # noqa: F401
 from .yearbooknet.yearbooknet import YearbookNet  # noqa: F401

--- a/modyn/models/dummy/__init__.py
+++ b/modyn/models/dummy/__init__.py
@@ -1,0 +1,8 @@
+"""
+Dummy
+"""
+import os
+
+files = os.listdir(os.path.dirname(__file__))
+files.remove("__init__.py")
+__all__ = [f[:-3] for f in files if f.endswith(".py")]

--- a/modyn/models/dummy/dummy.py
+++ b/modyn/models/dummy/dummy.py
@@ -3,8 +3,6 @@ from typing import Any
 from modyn.models.coreset_methods_support import CoresetSupportingModule
 from torch import nn
 
-# from torchvision.models.resnet import BasicBlock, ResNet
-
 
 class Dummy:
     # pylint: disable-next=unused-argument

--- a/modyn/models/dummy/dummy.py
+++ b/modyn/models/dummy/dummy.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from modyn.models.coreset_methods_support import CoresetSupportingModule
+from torch import nn
+
+# from torchvision.models.resnet import BasicBlock, ResNet
+
+
+class Dummy:
+    # pylint: disable-next=unused-argument
+    def __init__(self, model_configuration: dict[str, Any], device: str, amp: bool) -> None:
+        self.model = DummyModyn(model_configuration)
+        self.model.to(device)
+
+
+class DummyModyn(nn.Identity, CoresetSupportingModule):
+    # pylint: disable-next=unused-argument
+    def __init__(self, model_configuration: dict[str, Any]) -> None:
+        super().__init__()
+
+    def get_last_layer(self) -> nn.Module:
+        return nn.Identity()

--- a/modyn/tests/models/test_dummy.py
+++ b/modyn/tests/models/test_dummy.py
@@ -1,0 +1,17 @@
+import torch
+from modyn.models import Dummy
+
+
+def test_empty_forward():
+    net = Dummy({"num_classes": 10}, "cpu", False)
+    input_data = torch.rand(30, 3, 32, 32)
+    output = net.model(input_data)
+    assert output.shape == (30, 3, 32, 32)
+    assert net.model.embedding is None
+    assert torch.equal(output, input_data)
+
+
+def test_get_last_layer():
+    net = Dummy({"num_classes": 10}, "cpu", False)
+    last_layer = net.model.get_last_layer()
+    assert isinstance(last_layer, torch.nn.Identity)


### PR DESCRIPTION
This PR adds a Dummy model that has only an Identity layer to the models.
The Dummy model is used instead of ResNet18 in integration tests to reduce CI resource consumption.