### PR TITLE
Postgres: Allow incoming connections by default

### DIFF
--- a/conf/default_postgresql.conf
+++ b/conf/default_postgresql.conf
@@ -63,7 +63,7 @@ listen_addresses = '*'
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
 #port = 5432				# (change requires restart)
-#max_connections = 100			# (change requires restart)
+max_connections = 300			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 #unix_socket_directories = '/tmp'	# comma-separated list of directories
 					# (change requires restart)

--- a/conf/init_pg_hba.sh
+++ b/conf/init_pg_hba.sh
@@ -1,0 +1,2 @@
+# This script gets run inside the postgres containers
+cp /tmp/pg_hba.conf /var/lib/postgresql/data/pg_hba.conf

--- a/conf/pg_hba.conf
+++ b/conf/pg_hba.conf
@@ -1,0 +1,16 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+host  all  all 0.0.0.0/0 scram-sha-256
+
+### This should be changed for production deployments!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     volumes:
       - ./metadata-postgres-data:/var/lib/postgresql/data
       - ./conf/metadata_postgresql.conf:/etc/postgresql/postgresql.conf
+      - ./conf/pg_hba.conf:/tmp/pg_hba.conf
+      - ./conf/init_pg_hba.sh:/docker-entrypoint-initdb.d/init_pg_hba.sh
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -38,6 +40,8 @@ services:
     volumes:
       - ./storage-postgres-data:/var/lib/postgresql/data
       - ./conf/storage_postgresql.conf:/etc/postgresql/postgresql.conf
+      - ./conf/pg_hba.conf:/tmp/pg_hba.conf
+      - ./conf/init_pg_hba.sh:/docker-entrypoint-initdb.d/init_pg_hba.sh
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s


### PR DESCRIPTION
For development, we allow all incoming connections on postgres to enable the containers to communicate. For sure not safe for production deployment, but does the trick for now.