### PR TITLE
reduce files copied into image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
 #      - .:/modyn_host
     container_name: supervisor
     ports:
-      - 3000:50062
+      - "3000:50063"
   tests:
     depends_on:
       supervisor:

--- a/docker/Base/Dockerfile
+++ b/docker/Base/Dockerfile
@@ -4,9 +4,8 @@ FROM modyndependencies
 COPY modyn /src/modyn
 COPY cmake /src/cmake
 COPY modynclient /src/modynclient
-COPY setup.py /src
-COPY CMakeLists.txt /src
-COPY dev-requirements.txt /src
+COPY integrationtests /src/integrationtests
+COPY setup.py setup.cfg CMakeLists.txt dev-requirements.txt /src/
 
 RUN mamba run -n modyn pip install -e /src
 WORKDIR /src

--- a/docker/Base/Dockerfile
+++ b/docker/Base/Dockerfile
@@ -6,6 +6,7 @@ COPY cmake /src/cmake
 COPY modynclient /src/modynclient
 COPY setup.py /src
 COPY CMakeLists.txt /src
+COPY dev-requirements.txt /src
 
 RUN mamba run -n modyn pip install -e /src
 WORKDIR /src

--- a/docker/Base/Dockerfile
+++ b/docker/Base/Dockerfile
@@ -1,7 +1,11 @@
 FROM modyndependencies
 
 # Copy source code into container
-COPY . /src
+COPY modyn /src/modyn
+COPY cmake /src/cmake
+COPY modynclient /src/modynclient
+COPY setup.py /src
+COPY CMakeLists.txt /src
 
 RUN mamba run -n modyn pip install -e /src
 WORKDIR /src


### PR DESCRIPTION
Per the title, I reduced files copied into the docker image.

Currently almost all files in the repository are copied into the image. This has the downside that whenever I changed a irrelevant file (a file not used to build the image environment), docker invalidates previous image caches and has to build the image from scratch, which takes 1-2 unnecessary minutes. Now this time is saved.

Also a port mistake is corrected 