### PR TITLE
Fix Wildtime benchmark_utils create_timestamp() timezone to be UTC

### DIFF
--- a/benchmark/wildtime_benchmarks/benchmark_utils.py
+++ b/benchmark/wildtime_benchmarks/benchmark_utils.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import pathlib
-from datetime import datetime
+from datetime import datetime, timezone
 
 import gdown
 
@@ -62,4 +62,4 @@ def create_fake_timestamp(year: int, base_year: int) -> int:
 
 
 def create_timestamp(year: int, month: int = 1, day: int = 1) -> int:
-    return int(datetime(year=year, month=month, day=day).timestamp())
+    return int(datetime(year=year, month=month, day=day, tzinfo=timezone.utc).timestamp())


### PR DESCRIPTION
# Bug
The `create_timestamp()` function in `benchmark/wildtime_benchmarks/benchmark_utils.py` uses the **local** timezone. The generated timestamp thus is **not UTC**. 
However, modyn Storage assumes a UTC timestamp so that 1970/1/1 corresponds to 0.
Therefore, if the files are generated in Zurich local time, then 1970/1/1 is converted to -3600 in the `files` table. 

# Fix
Fix tzinfo to be UTC timezone in `create_timestamp()`.