### PR TITLE
Correct assertion on yearbook image size

### DIFF
--- a/benchmark/wildtime_benchmarks/data_generation_yearbook.py
+++ b/benchmark/wildtime_benchmarks/data_generation_yearbook.py
@@ -85,7 +85,7 @@ class YearbookDownloader(Dataset):
                 label_integer = tensor2.item()
 
                 features_size = len(features_bytes)
-                assert features_size == 4096
+                assert features_size == 12288
 
                 f.write(int.to_bytes(label_integer, length=4, byteorder="big"))
                 f.write(features_bytes)


### PR DESCRIPTION
In a previous PR https://github.com/eth-easl/modyn/pull/377 the number of channels in an image is changed from 1 to 3.
However the corresponding assertion on image size was not changed.
This PR changes it: `4096 = 12288`