### PR TITLE
fix volume path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       context: .
       dockerfile: docker/Supervisor/Dockerfile
     volumes:
-      - supervisor-evaluation-data:/evaluation_results
+      - supervisor-evaluation-data:/tmp/evaluation_results
 #      - .:/modyn_host
     container_name: supervisor
     ports:


### PR DESCRIPTION
Actually where evaluation results are stored is `/tmp/evaluation_results`... This is a bug.

The bug causes that the pipeline log is not persistent if supervisor container exits.