### PR TITLE
fix: Load file labels with appropriate `byteorder`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,9 @@ plots/
 cmake-build-debug/
 clang-tidy-build/
 libbuild/
+
+
+# Data & config files
+
+.data/
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
 #    shm_size: 24gb
     volumes:
-      - ./metadata-postgres-data:/var/lib/postgresql/data
+      - .data/metadata-postgres-data:/var/lib/postgresql/data
       - ./conf/metadata_postgresql.conf:/etc/postgresql/postgresql.conf
       - ./conf/pg_hba.conf:/tmp/pg_hba.conf
       - ./conf/init_pg_hba.sh:/docker-entrypoint-initdb.d/init_pg_hba.sh
@@ -38,7 +38,7 @@ services:
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
 #    shm_size: 8gb
     volumes:
-      - ./storage-postgres-data:/var/lib/postgresql/data
+      - .data/storage-postgres-data:/var/lib/postgresql/data
       - ./conf/storage_postgresql.conf:/etc/postgresql/postgresql.conf
       - ./conf/pg_hba.conf:/tmp/pg_hba.conf
       - ./conf/init_pg_hba.sh:/docker-entrypoint-initdb.d/init_pg_hba.sh
@@ -57,6 +57,7 @@ services:
       dockerfile: docker/Storage/Dockerfile
     volumes:
       - storage-data:/app/storage
+      - ./modyn/config/examples:/src/modyn/config/examples/
 #      - /mnt/datasets:/datasets
 #      - .:/modyn_host
   metadata_processor:

--- a/modyn/config/examples/modyn_config.yaml
+++ b/modyn/config/examples/modyn_config.yaml
@@ -58,7 +58,7 @@ storage:
         file_wrapper_config:
           {
             byteorder: "big",
-            record_size: 4100,
+            record_size: 12292,
             label_size: 4,
             file_extension: ".bin"
           },

--- a/modyn/storage/include/internal/file_wrapper/binary_file_wrapper.hpp
+++ b/modyn/storage/include/internal/file_wrapper/binary_file_wrapper.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <fstream>
 #include <iostream>
+#include <cctype>
 
 #include "internal/file_wrapper/file_wrapper.hpp"
 #include "modyn/utils/utils.hpp"
@@ -24,6 +25,7 @@ class BinaryFileWrapper : public FileWrapper {
     sample_size_ = record_size_ - label_size_;
     validate_file_extension();
     file_size_ = filesystem_wrapper_->get_file_size(path);
+    little_endian_ = fw_config["byteorder"].as<std::string>() == "little";
 
     ASSERT(static_cast<int64_t>(record_size_ - label_size_) >= 1,
            "Each record must have at least 1 byte of data other than the label.");
@@ -53,12 +55,14 @@ class BinaryFileWrapper : public FileWrapper {
 
  private:
   static void validate_request_indices(uint64_t total_samples, const std::vector<uint64_t>& indices);
-  static int64_t int_from_bytes(const unsigned char* begin, const unsigned char* end);
+  static int64_t int_from_bytes_little_endian(const unsigned char* begin, const unsigned char* end);
+  static int64_t int_from_bytes_big_endian(const unsigned char* begin, const unsigned char* end);
   std::ifstream* get_stream();
   uint64_t record_size_;
   uint64_t label_size_;
   uint64_t file_size_;
   uint64_t sample_size_;
+  bool little_endian_;
   std::shared_ptr<std::ifstream> stream_;
 };
 }  // namespace modyn::storage


### PR DESCRIPTION
# Motivation

`BinaryFileWrapper::int_from_bytes` previously used hard-coded preprocessor definitions for determining the endianness. We now want to use the `byteorder` specified in the `filesystem_wrapper_config`.