### PR TITLE
Correct arxiv settings in modyn_config and corresponding pipeline config

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Pytest
         run: |
           set -o pipefail
-          micromamba run -n modyn pytest modyn --cache-clear --cov-report term --cov-fail-under=100 | tee pytest-coverage.txt
+          micromamba run -n modyn pytest modyn --cache-clear --cov-report term --cov-fail-under=90 | tee pytest-coverage.txt
 
       - name: Comment coverage
         uses: coroo/pytest-coverage-commentator@v1.0.2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Pytest
         run: |
-          micromamba run -n modyn pytest modyn --cache-clear --cov-report term --cov-fail-under=90 | tee pytest-coverage.txt
+          micromamba run -n modyn pytest modyn --cache-clear --cov-report term --cov-fail-under=100 | tee pytest-coverage.txt
 
       - name: Comment coverage
         uses: coroo/pytest-coverage-commentator@v1.0.2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -105,8 +105,7 @@ jobs:
 
       - name: Pytest
         run: |
-          micromamba run -n modyn pytest modyn --cache-clear --cov-report term --cov-fail-under=90
-          micromamba run -n modyn pytest > pytest-coverage.txt
+          micromamba run -n modyn pytest modyn --cache-clear --cov-report term --cov-fail-under=90 | tee pytest-coverage.txt
 
       - name: Comment coverage
         uses: coroo/pytest-coverage-commentator@v1.0.2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Pytest
         run: |
+          set -o pipefail
           micromamba run -n modyn pytest modyn --cache-clear --cov-report term --cov-fail-under=100 | tee pytest-coverage.txt
 
       - name: Comment coverage

--- a/benchmark/mnist/mnist.yaml
+++ b/benchmark/mnist/mnist.yaml
@@ -43,7 +43,7 @@ data:
   bytes_parser_function: |
     from PIL import Image
     import io
-    def bytes_parser_function(data: bytes) -> Image:
+    def bytes_parser_function(data: memoryview) -> Image:
       return Image.open(io.BytesIO(data)).convert("RGB")
 trigger:
   id: DataAmountTrigger

--- a/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
@@ -40,7 +40,7 @@ training:
 data:
   dataset_id: arxiv
   bytes_parser_function: |
-    def bytes_parser_function(data: bytes) -> str:
+    def bytes_parser_function(data: memoryview) -> str:
       return str(data, "utf8")
   tokenizer: DistilBertTokenizerTransform
 

--- a/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
@@ -15,7 +15,7 @@ training:
   dataloader_workers: 2
   use_previous_model: True
   initial_model: random
-  batch_size: 96
+  batch_size: 128
   optimizers:
     - name: "default"
       algorithm: "SGD"
@@ -41,7 +41,7 @@ data:
   dataset_id: arxiv
   bytes_parser_function: |
     def bytes_parser_function(data: bytes) -> str:
-      return data.decode("utf-8")
+      return str(data, "utf8")
   tokenizer: DistilBertTokenizerTransform
 
 trigger:

--- a/benchmark/wildtime_benchmarks/example_pipelines/fmow.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/fmow.yaml
@@ -45,7 +45,7 @@ data:
   bytes_parser_function: |
     from PIL import Image
     import io
-    def bytes_parser_function(data: bytes) -> Image:
+    def bytes_parser_function(data: memoryview) -> Image:
       return Image.open(io.BytesIO(data)).convert("RGB")
 #change and configure it if you want day/week/month granularity
 trigger:

--- a/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
@@ -40,8 +40,8 @@ training:
 data:
   dataset_id: huffpost
   bytes_parser_function: |
-    def bytes_parser_function(data: bytes) -> str:
-      return data.decode("utf-8")
+    def bytes_parser_function(data: memoryview) -> str:
+      return str(data, "utf8")
   tokenizer: DistilBertTokenizerTransform
 
 trigger:

--- a/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
@@ -43,7 +43,7 @@ data:
   bytes_parser_function: |
     import torch
     import numpy as np
-    def bytes_parser_function(data: bytes) -> torch.Tensor:
+    def bytes_parser_function(data: memoryview) -> torch.Tensor:
       return torch.from_numpy(np.frombuffer(data, dtype=np.float32))
 
 trigger:

--- a/modyn/config/examples/modyn_config.yaml
+++ b/modyn/config/examples/modyn_config.yaml
@@ -83,22 +83,6 @@ storage:
         selector_batch_size: 1024,
       },
       {
-        name: "arxiv",
-        description: "Arxiv Dataset (from Wild-time)",
-        version: "0.0.1",
-        base_path: "/datasets/arxiv",
-        filesystem_wrapper_type: "LocalFilesystemWrapper",
-        file_wrapper_type: "SingleSampleFileWrapper",
-        file_wrapper_config:
-          {
-            file_extension: ".txt",
-            label_file_extension: ".label"
-          },
-        ignore_last_timestamp: false,
-        file_watcher_interval: 5,
-        selector_batch_size: 4096,
-      },
-      {
         name: "huffpost",
         description: "Huffpost Dataset (from Wild-time)",
         version: "0.0.1",


### PR DESCRIPTION
Currently in `modyn_config.yaml` somehow there are two definitions on the arxiv dataset, (where clearly we should have only one...) I removed the wrong one as the arxiv dataset is in `csv` format.

Also, a bug on `byte_parser_function` is corrected.