### PR TITLE
Fix yearbook data generation endianness (temporary solution)

### DIFF
--- a/benchmark/wildtime_benchmarks/data_generation_yearbook.py
+++ b/benchmark/wildtime_benchmarks/data_generation_yearbook.py
@@ -87,7 +87,7 @@ class YearbookDownloader(Dataset):
                 features_size = len(features_bytes)
                 assert features_size == 4096
 
-                f.write(int.to_bytes(label_integer, length=4, byteorder="big"))
+                f.write(int.to_bytes(label_integer, length=4, byteorder="little"))
                 f.write(features_bytes)
 
         os.utime(output_file_name, (timestamp, timestamp))


### PR DESCRIPTION
Temporary fix to yearbook dataset endianness. 
Change `byteorder` to "little" in benchmark/wildtime_benchmarks/data_generate_yearbook.py.
Should check again when the C++ storage is fix.