### PR TITLE
Add create_tracker message if evaluate on fixed datasets

### DIFF
--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -544,6 +544,7 @@ class GRPCHandler:
                     evaluations[evaluation_id] = EvaluationStatusReporter(
                         self.eval_status_queue, evaluation_id, dataset_id, fixed_eval_response.dataset_size
                     )
+                    evaluations[evaluation_id].create_tracker()
 
             return evaluations
 


### PR DESCRIPTION
Add missing `EvaluationStatusReporter.create_tracker()` for fixed eval datasets (`pipeline_id is None`) in supervisor grpc_handler `start_evaluation()`