### PR TITLE
Temporary endianess fix for yearbook and add missing tracker

### DIFF
--- a/benchmark/wildtime_benchmarks/data_generation_yearbook.py
+++ b/benchmark/wildtime_benchmarks/data_generation_yearbook.py
@@ -87,7 +87,7 @@ class YearbookDownloader(Dataset):
                 features_size = len(features_bytes)
                 assert features_size == 4096
 
-                f.write(int.to_bytes(label_integer, length=4, byteorder="big"))
+                f.write(int.to_bytes(label_integer, length=4, byteorder="little"))
                 f.write(features_bytes)
 
         os.utime(output_file_name, (timestamp, timestamp))

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -544,6 +544,7 @@ class GRPCHandler:
                     evaluations[evaluation_id] = EvaluationStatusReporter(
                         self.eval_status_queue, evaluation_id, dataset_id, fixed_eval_response.dataset_size
                     )
+                    evaluations[evaluation_id].create_tracker()
 
             return evaluations
 


### PR DESCRIPTION
Fix two small bugs before adding DataDriftTrigger.
1. Temporary fix to endianness in yearbook data generation.
2. Add create_tracker() for fixed eval dataset.