### PR TITLE
Make `start_timestamp` and `end_timestamp` in evaluation gRPC requests optional

### DIFF
--- a/integrationtests/storage/integrationtest_storage.py
+++ b/integrationtests/storage/integrationtest_storage.py
@@ -144,6 +144,13 @@ def check_data_per_worker() -> None:
         )
         responses: list[GetDataPerWorkerResponse] = list(storage.GetDataPerWorker(request))
 
+        alternative_request = GetDataPerWorkerRequest(
+            dataset_id="test_dataset", worker_id=worker_id, total_workers=3, start_timestamp=0, end_timestamp=split_ts2
+        )
+        alternative_responses: list[GetDataPerWorkerResponse] = list(storage.GetDataPerWorker(alternative_request))
+
+        assert alternative_responses == responses
+
         assert len(responses) == 1, f"Received batched response or no response, shouldn't happen: {responses}"
 
         response_keys_size = len(responses[0].keys)

--- a/integrationtests/storage/integrationtest_storage.py
+++ b/integrationtests/storage/integrationtest_storage.py
@@ -397,6 +397,11 @@ def test_storage() -> None:
     check_data_per_worker()
     check_dataset_size(30)
     check_dataset_size(10, start_timestamp=IMAGE_UPDATED_TIME_STAMPS[19] + 1)
+    # a sanity check for 0 as end_timestamp
+    check_dataset_size(0, start_timestamp=IMAGE_UPDATED_TIME_STAMPS[19] + 1, end_timestamp=0)
+    # this check can be seen as duplicate as the previous one,
+    # but we want to ensure setting start_timestamp as 0 or None has the same effect
+    check_dataset_size(20, start_timestamp=0, end_timestamp=IMAGE_UPDATED_TIME_STAMPS[19] + 1)
     check_dataset_size(20, end_timestamp=IMAGE_UPDATED_TIME_STAMPS[19] + 1)
     check_dataset_size(
         10, start_timestamp=IMAGE_UPDATED_TIME_STAMPS[9] + 1, end_timestamp=IMAGE_UPDATED_TIME_STAMPS[19] + 1

--- a/integrationtests/storage/integrationtest_storage.py
+++ b/integrationtests/storage/integrationtest_storage.py
@@ -96,7 +96,7 @@ def check_dataset_availability() -> None:
     assert response.available, "Dataset is not available."
 
 
-def check_dataset_size(expected_size: int, start_timestamp=0, end_timestamp=0) -> None:
+def check_dataset_size(expected_size: int, start_timestamp=None, end_timestamp=None) -> None:
     storage_channel = connect_to_storage()
 
     storage = StorageStub(storage_channel)

--- a/modyn/evaluator/internal/dataset/evaluation_dataset.py
+++ b/modyn/evaluator/internal/dataset/evaluation_dataset.py
@@ -34,8 +34,8 @@ class EvaluationDataset(IterableDataset):
         storage_address: str,
         evaluation_id: int,
         tokenizer: Optional[str] = None,
-        start_timestamp: int = 0,
-        end_timestamp: int = 0,
+        start_timestamp: Optional[int] = None,
+        end_timestamp: Optional[int] = None,
     ):
         self._evaluation_id = evaluation_id
         self._dataset_id = dataset_id

--- a/modyn/protos/storage.proto
+++ b/modyn/protos/storage.proto
@@ -63,10 +63,10 @@ message GetDataPerWorkerRequest {
   string dataset_id = 1;
   int32 worker_id = 2;
   int32 total_workers = 3;
-  // value unset or set with default value means no limit
+  // value unset means no limit
   // start_timestamp is inclusive, end_timestamp is exclusive
-  int64 start_timestamp = 4;
-  int64 end_timestamp = 5;
+  optional int64 start_timestamp = 4;
+  optional int64 end_timestamp = 5;
 }
 
 message GetDataPerWorkerResponse {
@@ -75,10 +75,10 @@ message GetDataPerWorkerResponse {
 
 message GetDatasetSizeRequest {
   string dataset_id = 1;
-  // value unset or set with default value means no limit
+  // value unset means no limit
   // start_timestamp is inclusive, end_timestamp is exclusive
-  int64 start_timestamp = 2;
-  int64 end_timestamp = 3;
+  optional int64 start_timestamp = 2;
+  optional int64 end_timestamp = 3;
 }
 
 message GetDatasetSizeResponse {

--- a/modyn/storage/internal/grpc/generated/storage_pb2.py
+++ b/modyn/storage/internal/grpc/generated/storage_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rstorage.proto\x12\rmodyn.storage\".\n\nGetRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x0c\n\x04keys\x18\x02 \x03(\x03\"<\n\x0bGetResponse\x12\x0f\n\x07samples\x18\x01 \x03(\x0c\x12\x0c\n\x04keys\x18\x02 \x03(\x03\x12\x0e\n\x06labels\x18\x03 \x03(\x03\"\x1c\n\x1aGetCurrentTimestampRequest\"?\n\x16GetNewDataSinceRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\"K\n\x17GetNewDataSinceResponse\x12\x0c\n\x04keys\x18\x01 \x03(\x03\x12\x12\n\ntimestamps\x18\x02 \x03(\x03\x12\x0e\n\x06labels\x18\x03 \x03(\x03\"^\n\x18GetDataInIntervalRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x17\n\x0fstart_timestamp\x18\x02 \x01(\x03\x12\x15\n\rend_timestamp\x18\x03 \x01(\x03\"M\n\x19GetDataInIntervalResponse\x12\x0c\n\x04keys\x18\x01 \x03(\x03\x12\x12\n\ntimestamps\x18\x02 \x03(\x03\x12\x0e\n\x06labels\x18\x03 \x03(\x03\"\x87\x01\n\x17GetDataPerWorkerRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tworker_id\x18\x02 \x01(\x05\x12\x15\n\rtotal_workers\x18\x03 \x01(\x05\x12\x17\n\x0fstart_timestamp\x18\x04 \x01(\x03\x12\x15\n\rend_timestamp\x18\x05 \x01(\x03\"(\n\x18GetDataPerWorkerResponse\x12\x0c\n\x04keys\x18\x01 \x03(\x03\"[\n\x15GetDatasetSizeRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x17\n\x0fstart_timestamp\x18\x02 \x01(\x03\x12\x15\n\rend_timestamp\x18\x03 \x01(\x03\";\n\x16GetDatasetSizeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x10\n\x08num_keys\x18\x02 \x01(\x03\"-\n\x17\x44\x61tasetAvailableRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\"-\n\x18\x44\x61tasetAvailableResponse\x12\x11\n\tavailable\x18\x01 \x01(\x08\"\xff\x01\n\x19RegisterNewDatasetRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x1f\n\x17\x66ilesystem_wrapper_type\x18\x02 \x01(\t\x12\x19\n\x11\x66ile_wrapper_type\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x11\n\tbase_path\x18\x05 \x01(\t\x12\x0f\n\x07version\x18\x06 \x01(\t\x12\x1b\n\x13\x66ile_wrapper_config\x18\x07 \x01(\t\x12\x1d\n\x15ignore_last_timestamp\x18\x08 \x01(\x08\x12\x1d\n\x15\x66ile_watcher_interval\x18\t \x01(\x03\"-\n\x1aRegisterNewDatasetResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"0\n\x1bGetCurrentTimestampResponse\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\"(\n\x15\x44\x65leteDatasetResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"5\n\x11\x44\x65leteDataRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x0c\n\x04keys\x18\x02 \x03(\x03\"%\n\x12\x44\x65leteDataResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x32\xe2\x07\n\x07Storage\x12@\n\x03Get\x12\x19.modyn.storage.GetRequest\x1a\x1a.modyn.storage.GetResponse\"\x00\x30\x01\x12\x64\n\x0fGetNewDataSince\x12%.modyn.storage.GetNewDataSinceRequest\x1a&.modyn.storage.GetNewDataSinceResponse\"\x00\x30\x01\x12j\n\x11GetDataInInterval\x12\'.modyn.storage.GetDataInIntervalRequest\x1a(.modyn.storage.GetDataInIntervalResponse\"\x00\x30\x01\x12g\n\x10GetDataPerWorker\x12&.modyn.storage.GetDataPerWorkerRequest\x1a\'.modyn.storage.GetDataPerWorkerResponse\"\x00\x30\x01\x12_\n\x0eGetDatasetSize\x12$.modyn.storage.GetDatasetSizeRequest\x1a%.modyn.storage.GetDatasetSizeResponse\"\x00\x12\x66\n\x11\x43heckAvailability\x12&.modyn.storage.DatasetAvailableRequest\x1a\'.modyn.storage.DatasetAvailableResponse\"\x00\x12k\n\x12RegisterNewDataset\x12(.modyn.storage.RegisterNewDatasetRequest\x1a).modyn.storage.RegisterNewDatasetResponse\"\x00\x12n\n\x13GetCurrentTimestamp\x12).modyn.storage.GetCurrentTimestampRequest\x1a*.modyn.storage.GetCurrentTimestampResponse\"\x00\x12_\n\rDeleteDataset\x12&.modyn.storage.DatasetAvailableRequest\x1a$.modyn.storage.DeleteDatasetResponse\"\x00\x12S\n\nDeleteData\x12 .modyn.storage.DeleteDataRequest\x1a!.modyn.storage.DeleteDataResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rstorage.proto\x12\rmodyn.storage\".\n\nGetRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x0c\n\x04keys\x18\x02 \x03(\x03\"<\n\x0bGetResponse\x12\x0f\n\x07samples\x18\x01 \x03(\x0c\x12\x0c\n\x04keys\x18\x02 \x03(\x03\x12\x0e\n\x06labels\x18\x03 \x03(\x03\"\x1c\n\x1aGetCurrentTimestampRequest\"?\n\x16GetNewDataSinceRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\"K\n\x17GetNewDataSinceResponse\x12\x0c\n\x04keys\x18\x01 \x03(\x03\x12\x12\n\ntimestamps\x18\x02 \x03(\x03\x12\x0e\n\x06labels\x18\x03 \x03(\x03\"^\n\x18GetDataInIntervalRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x17\n\x0fstart_timestamp\x18\x02 \x01(\x03\x12\x15\n\rend_timestamp\x18\x03 \x01(\x03\"M\n\x19GetDataInIntervalResponse\x12\x0c\n\x04keys\x18\x01 \x03(\x03\x12\x12\n\ntimestamps\x18\x02 \x03(\x03\x12\x0e\n\x06labels\x18\x03 \x03(\x03\"\xb7\x01\n\x17GetDataPerWorkerRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tworker_id\x18\x02 \x01(\x05\x12\x15\n\rtotal_workers\x18\x03 \x01(\x05\x12\x1c\n\x0fstart_timestamp\x18\x04 \x01(\x03H\x00\x88\x01\x01\x12\x1a\n\rend_timestamp\x18\x05 \x01(\x03H\x01\x88\x01\x01\x42\x12\n\x10_start_timestampB\x10\n\x0e_end_timestamp\"(\n\x18GetDataPerWorkerResponse\x12\x0c\n\x04keys\x18\x01 \x03(\x03\"\x8b\x01\n\x15GetDatasetSizeRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x1c\n\x0fstart_timestamp\x18\x02 \x01(\x03H\x00\x88\x01\x01\x12\x1a\n\rend_timestamp\x18\x03 \x01(\x03H\x01\x88\x01\x01\x42\x12\n\x10_start_timestampB\x10\n\x0e_end_timestamp\";\n\x16GetDatasetSizeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x10\n\x08num_keys\x18\x02 \x01(\x03\"-\n\x17\x44\x61tasetAvailableRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\"-\n\x18\x44\x61tasetAvailableResponse\x12\x11\n\tavailable\x18\x01 \x01(\x08\"\xff\x01\n\x19RegisterNewDatasetRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x1f\n\x17\x66ilesystem_wrapper_type\x18\x02 \x01(\t\x12\x19\n\x11\x66ile_wrapper_type\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x11\n\tbase_path\x18\x05 \x01(\t\x12\x0f\n\x07version\x18\x06 \x01(\t\x12\x1b\n\x13\x66ile_wrapper_config\x18\x07 \x01(\t\x12\x1d\n\x15ignore_last_timestamp\x18\x08 \x01(\x08\x12\x1d\n\x15\x66ile_watcher_interval\x18\t \x01(\x03\"-\n\x1aRegisterNewDatasetResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"0\n\x1bGetCurrentTimestampResponse\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\"(\n\x15\x44\x65leteDatasetResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"5\n\x11\x44\x65leteDataRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x0c\n\x04keys\x18\x02 \x03(\x03\"%\n\x12\x44\x65leteDataResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x32\xe2\x07\n\x07Storage\x12@\n\x03Get\x12\x19.modyn.storage.GetRequest\x1a\x1a.modyn.storage.GetResponse\"\x00\x30\x01\x12\x64\n\x0fGetNewDataSince\x12%.modyn.storage.GetNewDataSinceRequest\x1a&.modyn.storage.GetNewDataSinceResponse\"\x00\x30\x01\x12j\n\x11GetDataInInterval\x12\'.modyn.storage.GetDataInIntervalRequest\x1a(.modyn.storage.GetDataInIntervalResponse\"\x00\x30\x01\x12g\n\x10GetDataPerWorker\x12&.modyn.storage.GetDataPerWorkerRequest\x1a\'.modyn.storage.GetDataPerWorkerResponse\"\x00\x30\x01\x12_\n\x0eGetDatasetSize\x12$.modyn.storage.GetDatasetSizeRequest\x1a%.modyn.storage.GetDatasetSizeResponse\"\x00\x12\x66\n\x11\x43heckAvailability\x12&.modyn.storage.DatasetAvailableRequest\x1a\'.modyn.storage.DatasetAvailableResponse\"\x00\x12k\n\x12RegisterNewDataset\x12(.modyn.storage.RegisterNewDatasetRequest\x1a).modyn.storage.RegisterNewDatasetResponse\"\x00\x12n\n\x13GetCurrentTimestamp\x12).modyn.storage.GetCurrentTimestampRequest\x1a*.modyn.storage.GetCurrentTimestampResponse\"\x00\x12_\n\rDeleteDataset\x12&.modyn.storage.DatasetAvailableRequest\x1a$.modyn.storage.DeleteDatasetResponse\"\x00\x12S\n\nDeleteData\x12 .modyn.storage.DeleteDataRequest\x1a!.modyn.storage.DeleteDataResponse\"\x00\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -37,29 +37,29 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_GETDATAININTERVALRESPONSE']._serialized_start=410
   _globals['_GETDATAININTERVALRESPONSE']._serialized_end=487
   _globals['_GETDATAPERWORKERREQUEST']._serialized_start=490
-  _globals['_GETDATAPERWORKERREQUEST']._serialized_end=625
-  _globals['_GETDATAPERWORKERRESPONSE']._serialized_start=627
-  _globals['_GETDATAPERWORKERRESPONSE']._serialized_end=667
-  _globals['_GETDATASETSIZEREQUEST']._serialized_start=669
-  _globals['_GETDATASETSIZEREQUEST']._serialized_end=760
-  _globals['_GETDATASETSIZERESPONSE']._serialized_start=762
-  _globals['_GETDATASETSIZERESPONSE']._serialized_end=821
-  _globals['_DATASETAVAILABLEREQUEST']._serialized_start=823
-  _globals['_DATASETAVAILABLEREQUEST']._serialized_end=868
-  _globals['_DATASETAVAILABLERESPONSE']._serialized_start=870
-  _globals['_DATASETAVAILABLERESPONSE']._serialized_end=915
-  _globals['_REGISTERNEWDATASETREQUEST']._serialized_start=918
-  _globals['_REGISTERNEWDATASETREQUEST']._serialized_end=1173
-  _globals['_REGISTERNEWDATASETRESPONSE']._serialized_start=1175
-  _globals['_REGISTERNEWDATASETRESPONSE']._serialized_end=1220
-  _globals['_GETCURRENTTIMESTAMPRESPONSE']._serialized_start=1222
-  _globals['_GETCURRENTTIMESTAMPRESPONSE']._serialized_end=1270
-  _globals['_DELETEDATASETRESPONSE']._serialized_start=1272
-  _globals['_DELETEDATASETRESPONSE']._serialized_end=1312
-  _globals['_DELETEDATAREQUEST']._serialized_start=1314
-  _globals['_DELETEDATAREQUEST']._serialized_end=1367
-  _globals['_DELETEDATARESPONSE']._serialized_start=1369
-  _globals['_DELETEDATARESPONSE']._serialized_end=1406
-  _globals['_STORAGE']._serialized_start=1409
-  _globals['_STORAGE']._serialized_end=2403
+  _globals['_GETDATAPERWORKERREQUEST']._serialized_end=673
+  _globals['_GETDATAPERWORKERRESPONSE']._serialized_start=675
+  _globals['_GETDATAPERWORKERRESPONSE']._serialized_end=715
+  _globals['_GETDATASETSIZEREQUEST']._serialized_start=718
+  _globals['_GETDATASETSIZEREQUEST']._serialized_end=857
+  _globals['_GETDATASETSIZERESPONSE']._serialized_start=859
+  _globals['_GETDATASETSIZERESPONSE']._serialized_end=918
+  _globals['_DATASETAVAILABLEREQUEST']._serialized_start=920
+  _globals['_DATASETAVAILABLEREQUEST']._serialized_end=965
+  _globals['_DATASETAVAILABLERESPONSE']._serialized_start=967
+  _globals['_DATASETAVAILABLERESPONSE']._serialized_end=1012
+  _globals['_REGISTERNEWDATASETREQUEST']._serialized_start=1015
+  _globals['_REGISTERNEWDATASETREQUEST']._serialized_end=1270
+  _globals['_REGISTERNEWDATASETRESPONSE']._serialized_start=1272
+  _globals['_REGISTERNEWDATASETRESPONSE']._serialized_end=1317
+  _globals['_GETCURRENTTIMESTAMPRESPONSE']._serialized_start=1319
+  _globals['_GETCURRENTTIMESTAMPRESPONSE']._serialized_end=1367
+  _globals['_DELETEDATASETRESPONSE']._serialized_start=1369
+  _globals['_DELETEDATASETRESPONSE']._serialized_end=1409
+  _globals['_DELETEDATAREQUEST']._serialized_start=1411
+  _globals['_DELETEDATAREQUEST']._serialized_end=1464
+  _globals['_DELETEDATARESPONSE']._serialized_start=1466
+  _globals['_DELETEDATARESPONSE']._serialized_end=1503
+  _globals['_STORAGE']._serialized_start=1506
+  _globals['_STORAGE']._serialized_end=2500
 # @@protoc_insertion_point(module_scope)

--- a/modyn/storage/internal/grpc/generated/storage_pb2.pyi
+++ b/modyn/storage/internal/grpc/generated/storage_pb2.pyi
@@ -167,7 +167,7 @@ class GetDataPerWorkerRequest(google.protobuf.message.Message):
     worker_id: builtins.int
     total_workers: builtins.int
     start_timestamp: builtins.int
-    """value unset or set with default value means no limit
+    """value unset means no limit
     start_timestamp is inclusive, end_timestamp is exclusive
     """
     end_timestamp: builtins.int
@@ -177,10 +177,15 @@ class GetDataPerWorkerRequest(google.protobuf.message.Message):
         dataset_id: builtins.str = ...,
         worker_id: builtins.int = ...,
         total_workers: builtins.int = ...,
-        start_timestamp: builtins.int = ...,
-        end_timestamp: builtins.int = ...,
+        start_timestamp: builtins.int | None = ...,
+        end_timestamp: builtins.int | None = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing.Literal["dataset_id", b"dataset_id", "end_timestamp", b"end_timestamp", "start_timestamp", b"start_timestamp", "total_workers", b"total_workers", "worker_id", b"worker_id"]) -> None: ...
+    def HasField(self, field_name: typing.Literal["_end_timestamp", b"_end_timestamp", "_start_timestamp", b"_start_timestamp", "end_timestamp", b"end_timestamp", "start_timestamp", b"start_timestamp"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing.Literal["_end_timestamp", b"_end_timestamp", "_start_timestamp", b"_start_timestamp", "dataset_id", b"dataset_id", "end_timestamp", b"end_timestamp", "start_timestamp", b"start_timestamp", "total_workers", b"total_workers", "worker_id", b"worker_id"]) -> None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing.Literal["_end_timestamp", b"_end_timestamp"]) -> typing.Literal["end_timestamp"] | None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing.Literal["_start_timestamp", b"_start_timestamp"]) -> typing.Literal["start_timestamp"] | None: ...
 
 global___GetDataPerWorkerRequest = GetDataPerWorkerRequest
 
@@ -209,7 +214,7 @@ class GetDatasetSizeRequest(google.protobuf.message.Message):
     END_TIMESTAMP_FIELD_NUMBER: builtins.int
     dataset_id: builtins.str
     start_timestamp: builtins.int
-    """value unset or set with default value means no limit
+    """value unset means no limit
     start_timestamp is inclusive, end_timestamp is exclusive
     """
     end_timestamp: builtins.int
@@ -217,10 +222,15 @@ class GetDatasetSizeRequest(google.protobuf.message.Message):
         self,
         *,
         dataset_id: builtins.str = ...,
-        start_timestamp: builtins.int = ...,
-        end_timestamp: builtins.int = ...,
+        start_timestamp: builtins.int | None = ...,
+        end_timestamp: builtins.int | None = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing.Literal["dataset_id", b"dataset_id", "end_timestamp", b"end_timestamp", "start_timestamp", b"start_timestamp"]) -> None: ...
+    def HasField(self, field_name: typing.Literal["_end_timestamp", b"_end_timestamp", "_start_timestamp", b"_start_timestamp", "end_timestamp", b"end_timestamp", "start_timestamp", b"start_timestamp"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing.Literal["_end_timestamp", b"_end_timestamp", "_start_timestamp", b"_start_timestamp", "dataset_id", b"dataset_id", "end_timestamp", b"end_timestamp", "start_timestamp", b"start_timestamp"]) -> None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing.Literal["_end_timestamp", b"_end_timestamp"]) -> typing.Literal["end_timestamp"] | None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing.Literal["_start_timestamp", b"_start_timestamp"]) -> typing.Literal["start_timestamp"] | None: ...
 
 global___GetDatasetSizeRequest = GetDatasetSizeRequest
 

--- a/modyn/storage/src/internal/grpc/storage_service_impl.cpp
+++ b/modyn/storage/src/internal/grpc/storage_service_impl.cpp
@@ -281,8 +281,10 @@ Status StorageServiceImpl::GetDatasetSize(  // NOLINT readability-identifier-nam
       return {StatusCode::OK, "Dataset does not exist."};
     }
 
-    const int64_t total_keys = get_number_of_samples_in_dataset_with_range(
-        dataset_id, session, request->start_timestamp(), request->end_timestamp());
+    const int64_t start_timestamp = request->has_start_timestamp() ? request->start_timestamp() : -1;
+    const int64_t end_timestamp = request->has_end_timestamp() ? request->end_timestamp() : -1;
+    const int64_t total_keys =
+        get_number_of_samples_in_dataset_with_range(dataset_id, session, start_timestamp, end_timestamp);
 
     session.close();
 

--- a/modyn/tests/storage/internal/grpc/storage_service_impl_test.cpp
+++ b/modyn/tests/storage/internal/grpc/storage_service_impl_test.cpp
@@ -459,19 +459,16 @@ TEST_F(StorageServiceImplTest, TestGetNumberOfSamplesInDatasetWithRange) {
   ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session));
   ASSERT_EQ(result, 2);
 
-  ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 0, 0));
-  ASSERT_EQ(result, 2);
-
   ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 0, 100));
   ASSERT_EQ(result, 1);
 
   ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 0, 101));
   ASSERT_EQ(result, 2);
 
-  ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 1, 0));
+  ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 1));
   ASSERT_EQ(result, 2);
 
-  ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 2, 0));
+  ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 2));
   ASSERT_EQ(result, 1);
 
   ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 2, 101));

--- a/modyn/tests/storage/internal/grpc/storage_service_impl_test.cpp
+++ b/modyn/tests/storage/internal/grpc/storage_service_impl_test.cpp
@@ -468,6 +468,9 @@ TEST_F(StorageServiceImplTest, TestGetNumberOfSamplesInDatasetWithRange) {
   ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 1));
   ASSERT_EQ(result, 2);
 
+  ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 1, 0));
+  ASSERT_EQ(result, 0);
+
   ASSERT_NO_THROW(result = StorageServiceImpl::get_number_of_samples_in_dataset_with_range(1, session, 2));
   ASSERT_EQ(result, 1);
 


### PR DESCRIPTION
This PR makes two parameters I introduced in a previous PR https://github.com/eth-easl/modyn/pull/388 optional. Previously, I made it so that the default value "0" means no limit. I.e. a request with both `start_timestamp` and `end_timestamp` as `0` means no time restriction on the dataset.

I realized that this semantic is clumsy as sometimes we need "0" to mean the real timestamp "0". And now there is conflict. This PR makes `start_timestamp` and `end_timestamp` optional, and when they are optional, it means there is no limit. When they are set with a value, it means a limit with the numerical value.