### PR TITLE
Record the time span of a trigger

### DIFF
--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -79,7 +79,8 @@ class PipelineExecutor:
         self.num_triggers = 0
         self.current_training_id: Optional[int] = None
         self.triggers: list[int] = []
-        # this is to store the first and last timestamp of remaining data in _handle_triggers_within_batch
+        # this is to store the first and last timestamp of the remaining data after handling all triggers in
+        # _handle_triggers_within_batch
         self.remaining_data_range: Optional[tuple[int, int]] = None
 
     def _update_pipeline_stage_and_enqueue_msg(
@@ -183,18 +184,9 @@ class PipelineExecutor:
             {"batch_size": len(batch), "time": self._sw.stop("trigger_inform"), "num_triggers": num_triggers}
         )
 
-        if num_triggers > 0:
-            logger.info(f"There are {num_triggers} triggers in this batch.")
-            self._handle_triggers_within_batch(batch, triggering_indices)
-            return True
-
-        self._sw.start("selector_inform", overwrite=True)
-        selector_log = self.grpc.inform_selector(self.pipeline_id, batch)
-        self.pipeline_log["supervisor"]["selector_informs"].append(
-            {"total_selector_time": self._sw.stop(), "selector_log": selector_log}
-        )
-
-        return False
+        logger.info(f"There are {num_triggers} triggers in this batch.")
+        self._handle_triggers_within_batch(batch, triggering_indices)
+        return num_triggers > 0
 
     def _run_training(self, trigger_id: int) -> None:
         """Run training for trigger on GPU and block until done."""
@@ -255,6 +247,29 @@ class PipelineExecutor:
             writers = [self._init_evaluation_writer(name, trigger_id) for name in writer_names]
             self.grpc.store_evaluation_results(writers, evaluations)
 
+    def _get_trigger_timespan(
+        self, is_first_triggering_data: bool, triggering_data: list[tuple[int, int, int]]
+    ) -> tuple[int, int]:
+        if is_first_triggering_data:
+            # now it is the first trigger in this batch. Triggering_data can be empty.
+            # when it is indeed empty, then there is remaining data in the last batch
+            # because num_samples_in_trigger is not 0.
+            assert len(triggering_data) > 0 or self.remaining_data_range is not None
+
+            if self.remaining_data_range is not None:
+                first_timestamp = self.remaining_data_range[0]
+                last_timestamp = self.remaining_data_range[1] if len(triggering_data) == 0 else triggering_data[-1][1]
+            else:
+                first_timestamp = triggering_data[0][1]
+                last_timestamp = triggering_data[-1][1]
+        else:
+            assert len(triggering_data) > 0
+            # since num_samples_in_trigger is not 0, we are sure that triggering_data is not empty
+            first_timestamp = triggering_data[0][1]
+            last_timestamp = triggering_data[-1][1]
+
+        return first_timestamp, last_timestamp
+
     def _handle_triggers_within_batch(self, batch: list[tuple[int, int, int]], triggering_indices: list[int]) -> None:
         previous_trigger_idx = 0
         logger.info("Handling triggers within batch.")
@@ -279,60 +294,46 @@ class PipelineExecutor:
 
             num_samples_in_trigger = self.grpc.get_number_of_samples(self.pipeline_id, trigger_id)
             if num_samples_in_trigger > 0:
-                if i > 0:
-                    # since num_samples_in_trigger is not 0, we are sure that triggering_data is not empty
-                    first_timestamp = triggering_data[0][1]
-                    last_timestamp = triggering_data[-1][1]
-                else:
-                    # now it is the first trigger in this batch. Triggering_data can be empty.
-                    # when it is indeed empty, then there is remaining data in the last batch
-                    # because num_samples_in_trigger is not 0.
-                    assert len(triggering_data) > 0 or self.remaining_data_range is not None
-
-                    if self.remaining_data_range is not None:
-                        first_timestamp = self.remaining_data_range[0]
-                        last_timestamp = (
-                            self.remaining_data_range[1] if len(triggering_data) == 0 else triggering_data[-1][1]
-                        )
-                    else:
-                        first_timestamp = triggering_data[0][1]
-                        last_timestamp = triggering_data[-1][1]
-
+                first_timestamp, last_timestamp = self._get_trigger_timespan(i == 0, triggering_data)
                 self.pipeline_log["supervisor"]["triggers"][trigger_id]["first_timestamp"] = first_timestamp
                 self.pipeline_log["supervisor"]["triggers"][trigger_id]["last_timestamp"] = last_timestamp
+                # reset the remaining data range since we have processed it now
+                self.remaining_data_range = None
                 self._run_training(trigger_id)  # Blocks until training is done.
                 self._update_pipeline_stage_and_enqueue_msg(
                     PipelineStage.HANDLE_TRIGGERS_WITHIN_BATCH, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id)
                 )
             else:
                 logger.info(f"Skipping training on empty trigger {trigger_id}]")
-            # If no other trigger is coming in this batch,
-            # we have to inform the Selector about the remaining data in this batch.
-            if i == len(triggering_indices) - 1:
-                remaining_data = batch[triggering_idx + 1 :]
-                logger.info(f"There are {len(remaining_data)} data points remaining after the trigger.")
-
-                if len(remaining_data) > 0:
-                    # These data points will be included in the next trigger
-                    # because we inform the Selector about them,
-                    # just like other batches with no trigger at all are included.
-                    self._update_pipeline_stage_and_enqueue_msg(
-                        PipelineStage.INFORM_SELECTOR_REMAINING_DATA, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id)
-                    )
-                    self._sw.start("selector_inform", overwrite=True)
-                    selector_log = self.grpc.inform_selector(self.pipeline_id, remaining_data)
-                    self.pipeline_log["supervisor"]["selector_informs"].append(
-                        {"total_selector_time": self._sw.stop(), "selector_log": selector_log}
-                    )
-                    self.remaining_data_range = (remaining_data[0][1], remaining_data[-1][1])
-                else:
-                    self.remaining_data_range = None
-
             self._persist_pipeline_log()
 
             self.num_triggers = self.num_triggers + 1
             if self.maximum_triggers is not None and self.num_triggers >= self.maximum_triggers:
                 break
+
+        # we have to inform the Selector about the remaining data in this batch.
+        if len(triggering_indices) == 0:
+            remaining_data = batch
+        else:
+            remaining_data = batch[triggering_indices[-1] + 1 :]
+
+        logger.info(f"There are {len(remaining_data)} data points remaining after the trigger.")
+        if len(remaining_data) > 0:
+            # These data points will be included in the next trigger
+            # because we inform the Selector about them,
+            # just like other batches with no trigger at all are included.
+            self._sw.start("selector_inform", overwrite=True)
+            selector_log = self.grpc.inform_selector(self.pipeline_id, remaining_data)
+            self.pipeline_log["supervisor"]["selector_informs"].append(
+                {"total_selector_time": self._sw.stop(), "selector_log": selector_log}
+            )
+            if self.remaining_data_range is not None:
+                # extend the range from last time
+                self.remaining_data_range = (self.remaining_data_range[0], remaining_data[-1][1])
+            else:
+                self.remaining_data_range = (remaining_data[0][1], remaining_data[-1][1])
+        else:
+            self.remaining_data_range = None
 
     def _init_evaluation_writer(self, name: str, trigger_id: int) -> LogResultWriter:
         return self.supervisor_supported_eval_result_writers[name](self.pipeline_id, trigger_id, self.eval_directory)

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -290,8 +290,9 @@ class PipelineExecutor:
 
                     if self.remaining_data_range is not None:
                         first_timestamp = self.remaining_data_range[0]
-                        last_timestamp = self.remaining_data_range[1] \
-                            if len(triggering_data) == 0 else triggering_data[-1][1]
+                        last_timestamp = (
+                            self.remaining_data_range[1] if len(triggering_data) == 0 else triggering_data[-1][1]
+                        )
                     else:
                         first_timestamp = triggering_data[0][1]
                         last_timestamp = triggering_data[-1][1]
@@ -307,7 +308,7 @@ class PipelineExecutor:
             # If no other trigger is coming in this batch,
             # we have to inform the Selector about the remaining data in this batch.
             if i == len(triggering_indices) - 1:
-                remaining_data = batch[triggering_idx + 1: ]
+                remaining_data = batch[triggering_idx + 1 :]
                 logger.info(f"There are {len(remaining_data)} data points remaining after the trigger.")
 
                 if len(remaining_data) > 0:

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -79,6 +79,7 @@ class PipelineExecutor:
         self.num_triggers = 0
         self.current_training_id: Optional[int] = None
         self.triggers: list[int] = []
+        # this is to store the first and last timestamp of remaining data in _handle_triggers_within_batch
         self.remaining_data_range: Optional[tuple[int, int]] = None
 
     def _update_pipeline_stage_and_enqueue_msg(

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -278,12 +278,12 @@ class PipelineExecutor:
 
             num_samples_in_trigger = self.grpc.get_number_of_samples(self.pipeline_id, trigger_id)
             if num_samples_in_trigger > 0:
-                if trigger_id > 0:
+                if i > 0:
                     # since num_samples_in_trigger is not 0, we are sure that triggering_data is not empty
                     first_timestamp = triggering_data[0][1]
                     last_timestamp = triggering_data[-1][1]
                 else:
-                    # now trigger_id == 0, it is the first trigger in this batch. Triggering_data can be empty.
+                    # now it is the first trigger in this batch. Triggering_data can be empty.
                     # when it is indeed empty, then there is remaining data in the last batch
                     # because num_samples_in_trigger is not 0.
                     assert len(triggering_data) > 0 or self.remaining_data_range is not None

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -362,7 +362,7 @@ def test__handle_triggers_within_batch_empty_triggers(
     trigger_ids = [(0, {}), (1, {}), (2, {})]
     test_inform_selector_and_trigger.side_effect = trigger_ids
     test_inform_selector.return_value = {}
-    test_get_number_of_samples.return_value = len(batch)
+    test_get_number_of_samples.side_effect = [0, 0, 4]
 
     pe._handle_triggers_within_batch(batch, triggering_indices)
 
@@ -374,8 +374,8 @@ def test__handle_triggers_within_batch_empty_triggers(
     assert test_inform_selector_and_trigger.call_count == 3
     assert test_inform_selector_and_trigger.call_args_list == inform_selector_and_trigger_expected_args
 
-    run_training_expected_args = [call(0), call(1), call(2)]
-    assert test__run_training.call_count == 3
+    run_training_expected_args = [call(2)]
+    assert test__run_training.call_count == 1
     assert test__run_training.call_args_list == run_training_expected_args
 
     assert test_inform_selector.call_count == 1

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -428,7 +428,7 @@ def test__handle_triggers_within_batch_trigger_timespan(
         (17, 8, 5),
         (18, 9, 5),
         # remaining data
-        (19, 10, 5)
+        (19, 10, 5),
     ]
     triggering_indices = [-1, 1]
     test_get_number_of_samples.side_effect = [3, 2]  # the size of trigger 3, 4

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -396,20 +396,20 @@ def test__handle_triggers_within_batch_trigger_timespan(
 
     # each tuple is (key, timestamp, label)
     first_batch = [
+        # trigger 0
         (10, 1, 5),
         (11, 2, 5),
-        # trigger 0
         # trigger 1 is empty
+        # trigger 2
         (12, 3, 5),
         (13, 4, 5),
-        # trigger 2
+        # remaining data
         (14, 5, 5),
         (15, 6, 5),
         (16, 7, 5),
-        # remaining data
     ]
     triggering_indices = [1, 1, 3]
-    test_get_number_of_samples.side_effect = [2, 0, 2]
+    test_get_number_of_samples.side_effect = [2, 0, 2]  # the size of trigger 0, 1, 2
 
     pe._handle_triggers_within_batch(first_batch, triggering_indices)
     assert pe.pipeline_log["supervisor"]["triggers"][0]["first_timestamp"] == 1
@@ -424,14 +424,14 @@ def test__handle_triggers_within_batch_trigger_timespan(
 
     second_batch = [
         # trigger 3 covers remaining data from last batch
+        # trigger 4
         (17, 8, 5),
         (18, 9, 5),
-        # trigger 4
-        (19, 10, 5),
         # remaining data
+        (19, 10, 5)
     ]
     triggering_indices = [-1, 1]
-    test_get_number_of_samples.side_effect = [3, 2]
+    test_get_number_of_samples.side_effect = [3, 2]  # the size of trigger 3, 4
     pe._handle_triggers_within_batch(second_batch, triggering_indices)
     assert pe.pipeline_log["supervisor"]["triggers"][3]["first_timestamp"] == 5
     assert pe.pipeline_log["supervisor"]["triggers"][3]["last_timestamp"] == 7
@@ -441,7 +441,7 @@ def test__handle_triggers_within_batch_trigger_timespan(
 
     third_batch = [(20, 11, 5), (21, 12, 5), (22, 13, 5)]  # trigger 5, also includes remaining data from last batch
     triggering_indices = [2]
-    test_get_number_of_samples.side_effect = [4]
+    test_get_number_of_samples.side_effect = [4]  # the size of trigger 5
     pe._handle_triggers_within_batch(third_batch, triggering_indices)
     assert pe.pipeline_log["supervisor"]["triggers"][5]["first_timestamp"] == 10
     assert pe.pipeline_log["supervisor"]["triggers"][5]["last_timestamp"] == 13


### PR DESCRIPTION
This PR makes a way to record the first and last timestamp of the data within a trigger.

This information is crucial for flexible evaluation: the first and last timestamps of the data in a trigger will be passed to the evaluation strategy introduced in https://github.com/eth-easl/modyn/pull/426, to decide what time slices of the evaluation dataset we want to evaluate against.

This PR is part of https://github.com/eth-easl/modyn/pull/422.