### PR TITLE
Reject unknown properties in the pipeline config

### DIFF
--- a/integrationtests/utils.py
+++ b/integrationtests/utils.py
@@ -63,7 +63,6 @@ def get_minimal_pipeline_config(
             "use_previous_model": True,
             "initial_model": "random",
             "initial_pass": {"activated": False},
-            "learning_rate": 0.1,
             "batch_size": 42,
             "optimizers": [
                 {"name": "default1", "algorithm": "SGD", "source": "PyTorch", "param_groups": [{"module": "model"}]},

--- a/modyn/config/examples/example-pipeline.yaml
+++ b/modyn/config/examples/example-pipeline.yaml
@@ -37,7 +37,6 @@ training:
     name: "CrossEntropyLoss"
   lr_scheduler:
     name: "StepLR"
-    custom: True
     optimizers: ["default"]
     config:
       step_size: 10

--- a/modyn/config/schema/pipeline.py
+++ b/modyn/config/schema/pipeline.py
@@ -5,10 +5,16 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from modyn.supervisor.internal.eval_strategies import OffsetEvalStrategy
 from modyn.utils import validate_timestr
-from pydantic import BaseModel, Field, NonNegativeInt, field_validator, model_validator
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import Field, NonNegativeInt, field_validator, model_validator
 from typing_extensions import Self
 
 # ----------------------------------------------------- PIPELINE ----------------------------------------------------- #
+
+
+class BaseModel(PydanticBaseModel):
+    class Config:
+        extra = "forbid"
 
 
 class Pipeline(BaseModel):
@@ -258,7 +264,7 @@ class OptimizationCriterion(BaseModel):
     config: Dict[str, Any] = Field(default_factory=dict, description="Optional configuration of the criterion.")
 
 
-LrSchedulerSource = Literal["PyTorch", "custom"]
+LrSchedulerSource = Literal["PyTorch", "Custom"]
 
 
 class LrSchedulerConfig(BaseModel):
@@ -312,7 +318,6 @@ class TrainingConfig(BaseModel):
         description="The number of data loader workers on the trainer node that fetch data from storage.", ge=1
     )
     batch_size: float = Field(description="The batch size to be used during training.", ge=1)
-    learning_rate: float = Field(0.1, description="The learning rate to be used during training.")
     use_previous_model: bool = Field(
         description=(
             "If True, on trigger, we continue training on the model outputted by the previous trigger. If False, "

--- a/modyn/tests/conftest.py
+++ b/modyn/tests/conftest.py
@@ -139,7 +139,6 @@ def pipeline_training_config() -> TrainingConfig:
         dataloader_workers=1,
         use_previous_model=True,
         initial_model="random",
-        learning_rate=0.1,
         batch_size=42,
         optimizers=[
             OptimizerConfig(

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -32,7 +32,6 @@ def get_minimal_training_config() -> dict:
         "dataloader_workers": 1,
         "use_previous_model": True,
         "initial_model": "random",
-        "learning_rate": 0.1,
         "batch_size": 42,
         "optimizers": [
             {"name": "default1", "algorithm": "SGD", "source": "PyTorch", "param_groups": [{"module": "model"}]},

--- a/modyn/tests/supervisor/internal/triggers/test_datadrifttrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_datadrifttrigger.py
@@ -21,7 +21,6 @@ def get_minimal_training_config() -> dict:
         "dataloader_workers": 1,
         "use_previous_model": True,
         "initial_model": "random",
-        "learning_rate": 0.1,
         "batch_size": 42,
         "optimizers": [
             {"name": "default1", "algorithm": "SGD", "source": "PyTorch", "param_groups": [{"module": "model"}]},

--- a/modynclient/tests/client/test_client.py
+++ b/modynclient/tests/client/test_client.py
@@ -22,7 +22,6 @@ def get_minimal_pipeline_config() -> dict:
             "use_previous_model": True,
             "initial_model": "random",
             "initial_pass": {"activated": False},
-            "learning_rate": 0.1,
             "batch_size": 42,
             "optimizers": [
                 {"name": "default1", "algorithm": "SGD", "source": "PyTorch", "param_groups": [{"module": "model"}]},


### PR DESCRIPTION
Some configs in the pipeline config are optional, for example `num_samples_to_pass`. If it is not specified, training is limited by another config `epochs_per_trigger`.

It is common for users to make a typo. I once typed `num_sample_to_pass`. The current validation allows additional properties unspecified in the Pydantic model. This leads to the consequence that the pipeline with typo `num_sample_to_pass` passed through, and is executed as if `num_samples_to_pass` is not specified and `epochs_per_trigger` is used. It wastes me one day to find it out.