### PR TITLE
refactor: Adjust pipeline orchestration in `PipelineExecutor`

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,98 @@
+# Pipeline Logging
+
+## Motivation
+
+We want to be able to log the progress of the pipeline, so that we can conveniently analyze experiments and compare
+different pipeline configurations.
+
+## Design
+
+For that purpose, we are measuring the execution time of every pipeline step function call.
+Note that every pipeline stage corresponds to one function in `pipeline_executor.py`.
+
+There are 4 main pydantic models in `models.py` that are used to create pipeline execution logs. We are using pydantic as it provides
+a fully typed and validated data structure that can easily be serialized and deserialized into json files.
+
+### `PipelineLogs`
+
+This is the main model that contains all the logs for a single pipeline execution. One `PipelineLogs` will produce one
+json file that contains all the logs for a single pipeline execution.
+
+### `SupervisorLogs`
+
+One member of `PipelineLogs` is a `SupervisorLog`. This model contains logs produced by / relevant to the
+superivsor. Semantically it is a wrapper for a list of `StageLog` entries and provides additional utility functions
+for conversion to pandas dataframes.
+
+### `StageLog`
+
+A `StageLog` contains the logs for a specific execution of a specific stage of the pipeline. It records information
+like the pipeline stage id, `duration`, `sample_idx`, `sample_time` etc. to able to analyze the pipeline execution quantitatively over time.
+
+These properties are available for every pipeline stage and can therefore be summarized in a pandas dataframe.
+
+Alongside these shared properties some pipeline stages might want to log additional information.
+E.g. the results of certain grpc calls to other services like the results of a model evaluation, etc.
+This additional optional information can be stored in the `info` field of the `StageLog` which requires an object
+from a subtype of `StageInfo`.
+
+### `StageInfo`
+
+Stage info is an arbitrary serializable object that can be stored in the `info` field of a `StageLog`.
+Every pipeline stage that wants to log additional information can define its own `StageInfo` subtype.
+Additionally a dataframe conversion function can be implemented in the subtype to allow for easy conversion
+of the logs of this stage to a pandas dataframe.
+
+
+## Usage
+
+### Write new information into logs
+
+1) Define a subclass of `StageInfo` in `models.py` that contains the information you want to log.
+
+E.g.
+```python
+class MyPipelineStageInfo(StageInfo):
+    my_data: int = Field(..., description="Some measurement.")
+
+    @override
+    @property
+    def df(self) -> pd.DataFrame:
+        return pd.DataFrame([(self.my_data)], columns=["my_data"])
+```
+
+2) If not already present, define your `pipline_executor` stage function in `pipeline_executor.py`.
+
+E.g.
+```python
+    @pipeline_stage(PipelineType.<StageName>, PipelineStage.<parent_stage>)
+    def _my_pipline_stage(
+        self, s: ExecutionState, log: StageLog, <arguments from the caller>
+    ) -> None:
+        <Business logic>
+
+        # Add log information
+        log.info = MyPipelineStageInfo(my_data=42)
+```
+
+This is sufficient to persist the data to the logfile.
+
+### Read & analyze logs
+
+```python
+from modyn.supervisor.internal.pipeline_executor.models import PipelineLogs
+
+# Read the logs from a file
+with open("path/to/logfile.json", "r") as f:
+    logs = PipelineLogs.model_validate_json(f.read())
+
+# Access the logs
+print(logs.supervisor_logs.df)
+print(logs.supervisor_logs.df['id'].unique())
+print(logs.supervisor_logs.df.describe())
+
+# access the logs of a specific stage (with StageInfo data)
+stage_logs = [l for l in logs.supervisor_logs.stage_runs if l.id == "STAGE_NAME"]
+stage_df = pd.concat([l.df(extended=True) for l in stage_logs])
+stage_df.describe()
+```

--- a/integrationtests/evaluator/integrationtest_evaluator.py
+++ b/integrationtests/evaluator/integrationtest_evaluator.py
@@ -5,7 +5,7 @@ import time
 from typing import Optional, Tuple
 
 import torch
-from integrationtests.utils import ImageDatasetHelper, connect_to_server, get_modyn_config
+from integrationtests.utils import MODYN_MODELS_PATH, ImageDatasetHelper, connect_to_server, get_modyn_config
 from modyn.common.ftp import delete_file, upload_file
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import (
     DatasetInfo,
@@ -29,7 +29,7 @@ from modyn.model_storage.internal.grpc.generated.model_storage_pb2_grpc import M
 from modyn.models import ResNet18
 from modyn.utils import calculate_checksum
 
-TEST_MODELS_PATH = pathlib.Path("/app") / "model_storage" / "test_models"
+TEST_MODELS_PATH = MODYN_MODELS_PATH / "test_models"
 MODYN_CONFIG = get_modyn_config()
 DATASET_ID = "image_test_dataset"
 

--- a/integrationtests/utils.py
+++ b/integrationtests/utils.py
@@ -172,6 +172,7 @@ class DatasetHelper:
         filesystem_wrapper_type: str = "LocalFilesystemWrapper",
         file_watcher_interval: int = 5,
         version: str = "0.1.0",
+        wait_for_sec: int = NEW_DATASET_TIMEOUT,
     ) -> None:
         self.dataset_id = dataset_id
         self.dataset_size = dataset_size
@@ -182,6 +183,7 @@ class DatasetHelper:
         self.filesystem_wrapper_type = filesystem_wrapper_type
         self.file_watcher_interval = file_watcher_interval
         self.version = version
+        self.wait_for_sec = wait_for_sec
 
         self.storage_channel = connect_to_server("storage")
         self.storage = StorageStub(self.storage_channel)
@@ -209,11 +211,11 @@ class DatasetHelper:
         assert response.available, "Dataset is not available."
 
     def wait_for_dataset(self, expected_size: int) -> None:
-        time.sleep(NEW_DATASET_TIMEOUT)
+        time.sleep(self.wait_for_sec)
         request = GetDatasetSizeRequest(dataset_id=self.dataset_id)
         response: GetDatasetSizeResponse = self.storage.GetDatasetSize(request)
 
-        assert response.success, f"Dataset is not available after {NEW_DATASET_TIMEOUT} sec."
+        assert response.success, f"Dataset is not available after {self.wait_for_sec} sec."
         assert response.num_keys >= expected_size
 
     def register_new_dataset(self) -> None:
@@ -296,7 +298,12 @@ class TinyDatasetHelper(DatasetHelper):
         desc: str = "Tiny dataset for integration tests.",
     ) -> None:
         super().__init__(
-            dataset_id, dataset_size, dataset_dir, desc, {"file_extension": ".csv", "label_file_extension": ".txt"}
+            dataset_id,
+            dataset_size,
+            dataset_dir,
+            desc,
+            {"file_extension": ".csv", "label_file_extension": ".txt"},
+            wait_for_sec=20,
         )
 
     def create_dataset(self) -> None:

--- a/modyn/config/__init__.py
+++ b/modyn/config/__init__.py
@@ -27,8 +27,8 @@ from .schema.config import (
 from .schema.pipeline import (
     CheckpointingConfig,
     DataConfig,
-    EvalDataConfig,
     DownsamplingConfig,
+    EvalDataConfig,
     EvaluationConfig,
     FullModelStrategy,
     IncrementalModelStrategy,

--- a/modyn/config/schema/config.py
+++ b/modyn/config/schema/config.py
@@ -127,7 +127,8 @@ class DatasetsConfig(BaseModel):
         None, description="The interval in seconds in which the file watcher checks for new files."
     )
     selector_batch_size: int = Field(
-        True, description="The number of samples per which we check for triggers and inform the selector."
+        128,
+        description="The number of samples per which we check for triggers and inform the selector.",
     )
 
 

--- a/modyn/config/schema/pipeline.py
+++ b/modyn/config/schema/pipeline.py
@@ -317,7 +317,7 @@ class TrainingConfig(BaseModel):
     dataloader_workers: int = Field(
         description="The number of data loader workers on the trainer node that fetch data from storage.", ge=1
     )
-    batch_size: float = Field(description="The batch size to be used during training.", ge=1)
+    batch_size: int = Field(description="The batch size to be used during training.", ge=1)
     use_previous_model: bool = Field(
         description=(
             "If True, on trigger, we continue training on the model outputted by the previous trigger. If False, "

--- a/modyn/config/schema/pipeline.py
+++ b/modyn/config/schema/pipeline.py
@@ -527,7 +527,11 @@ class ResultWriter(BaseModel):
     config: Optional[Dict[str, Any]] = Field(None, description="Optional configuration for the result writer.")
 
 
-ResultWriterType = Literal["json", "tensorboard", "log"]
+ResultWriterType = Literal["json", "json_dedicated", "tensorboard"]
+"""
+- json: appends the evaluations to the standard json logfile.
+- json_dedicated: dumps the results into dedicated json files for each evaluation.
+- tensorboard: output the evaluation to dedicated tensorboard files."""
 
 
 class EvaluationConfig(BaseModel):

--- a/modyn/supervisor/internal/evaluation_result_writer/__init__.py
+++ b/modyn/supervisor/internal/evaluation_result_writer/__init__.py
@@ -5,7 +5,7 @@
 import os
 
 from .abstract_evaluation_result_writer import AbstractEvaluationResultWriter  # noqa: F401
-from .json_result_writer import JsonResultWriter  # noqa: F401
+from .json_result_writer import DedicatedJsonResultWriter, JsonResultWriter  # noqa: F401
 from .tensorboard_result_writer import TensorboardResultWriter  # noqa: F401
 
 files = os.listdir(os.path.dirname(__file__))

--- a/modyn/supervisor/internal/evaluation_result_writer/abstract_evaluation_result_writer.py
+++ b/modyn/supervisor/internal/evaluation_result_writer/abstract_evaluation_result_writer.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import pathlib
 from abc import ABC, abstractmethod
+from typing import Any
 
 # pylint: disable=no-name-in-module
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import EvaluationData
@@ -28,7 +31,7 @@ class AbstractEvaluationResultWriter(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def store_results(self) -> None:
+    def store_results(self) -> Any:
         """
         Called in the end to store the results.
         """

--- a/modyn/supervisor/internal/evaluation_result_writer/json_result_writer.py
+++ b/modyn/supervisor/internal/evaluation_result_writer/json_result_writer.py
@@ -1,12 +1,13 @@
 import json
 import pathlib
+from typing import Any
 
 # pylint: disable=no-name-in-module
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import EvaluationData
 from modyn.supervisor.internal.evaluation_result_writer import AbstractEvaluationResultWriter
 
 
-class JsonResultWriter(AbstractEvaluationResultWriter):
+class _JsonResultWriter(AbstractEvaluationResultWriter):
     def __init__(self, pipeline_id: int, trigger_id: int, eval_directory: pathlib.Path):
         super().__init__(pipeline_id, trigger_id, eval_directory)
         self.results: dict = {"datasets": []}
@@ -17,7 +18,19 @@ class JsonResultWriter(AbstractEvaluationResultWriter):
             dataset_results["metrics"].append({"name": metric.metric, "result": metric.result})
         self.results["datasets"].append({dataset_id: dataset_results})
 
-    def store_results(self) -> None:
+
+class JsonResultWriter(_JsonResultWriter):
+    """Does not dump into files itself but only returns the result."""
+
+    def store_results(self) -> dict[str, Any]:
+        return self.results
+
+
+class DedicatedJsonResultWriter(_JsonResultWriter):
+    """Dumps every log result into a dedicated file."""
+
+    def store_results(self) -> pathlib.Path:
         file_name = f"{self.pipeline_id}_{self.trigger_id}.eval"
         with open(self.eval_directory / file_name, "w+", encoding="utf-8") as output_file:
             json.dump(self.results, output_file)
+        return self.eval_directory / file_name

--- a/modyn/supervisor/internal/grpc/enums.py
+++ b/modyn/supervisor/internal/grpc/enums.py
@@ -18,27 +18,68 @@ class PipelineStatus(StrEnum):
     NOTFOUND = "not found"
 
 
+class PipelineType(StrEnum):
+    MAIN = "main"
+
+    REPLAY_DATA = "replay_data"
+    SERVE_ONLINE = "wait_for_new_data"
+
+    NEW_DATA = "new_data"
+    NEW_BATCH = "new_data"
+
+    TRIGGER = "trigger"
+    TRAINING = "training"
+    EVALUATION = "evaluation"
+
+
 class PipelineStage(StrEnum):
+    """For a state transition graph checkout the `PIPELINE.md` file."""
+
+    # Setup
     INIT = "Initialize pipeline executor"
     INIT_CLUSTER_CONNECTION = "Initialize cluster connection"
-    GET_SELECTOR_BATCH_SIZE = "Get selector batch size"
-    HANDLE_NEW_DATA = "Handle new data"
-    NEW_DATA_HANDLED = "New data handled"
-    RUN_TRAINING = "Run training"
-    WAIT_FOR_TRAINING_COMPLETION = "Wait for training completion"
-    TRAINING_COMPLETED = "Training completed 🚀"
-    WAIT_FOR_EVALUATION_COMPLETION = "Wait for evaluation completion"
-    EVALUATION_COMPLETED = "Evaluation completed 🚀"
-    STORE_TRAINED_MODEL = "Store trained model"
-    EVALUATE = "Run evaluation"
-    STORE_EVALUATION_RESULTS = "Store evaluation results"
-    HANDLE_TRIGGERS_WITHIN_BATCH = "Handle triggers within batch"
-    INFORM_SELECTOR_AND_TRIGGER = "Inform selector and trigger"
-    INFORM_SELECTOR_REMAINING_DATA = "Inform selector about remaining data"
+
+    # Replay Data
     REPLAY_DATA = "Replay data"
     REPLAY_DATA_DONE = "Replay data done"
+
+    # Wait for new data
+    SERVE_ONLINE_DATA = "Serve online data"
     FETCH_NEW_DATA = "Fetch new data"
     WAIT_FOR_NEW_DATA = "Wait for new data"
+
+    # Process new data
+    PROCESS_NEW_DATA = "Process new data"
+
+    PROCESS_NEW_DATA_BATCH = "Process new data batch"
+    EVALUATE_TRIGGER_POLICIES = "Evaluate trigger on batch"
+    INFORM_SELECTOR_NO_TRIGGER = "Inform selector about no trigger"
+
+    # Trigger
+    EXECUTE_TRIGGERS = "Execute triggers within batch"
+    EXECUTE_SINGLE_TRIGGER = "Execute single trigger"
+    INFORM_SELECTOR_AND_TRIGGER = "Inform selector and trigger"
+    INFORM_SELECTOR_REMAINING_DATA = "Inform selector about remaining data"
+
+    NEW_DATA_HANDLED = "New data handled"
+
+    # Training
+    TRAIN_AND_STORE_MODEL = "Train and store model"
+    TRAIN = "Run training"
+
+    WAIT_FOR_TRAINING_COMPLETION = "Wait for training completion"
+    """Implements busy waiting for training completion."""
+
+    TRAINING_COMPLETED = "Training completed 🚀"
+    STORE_TRAINED_MODEL = "Store trained model"
+
+    # Evaluation
+    EVALUATE = "Run evaluation"
+    EVALUATE_SINGLE = "Run single evaluation"
+    WAIT_FOR_EVALUATION_COMPLETION = "Wait for evaluation completion"
+    STORE_EVALUATION_RESULTS = "Store evaluation results"
+
+    # Teardown
     DONE = "Pipeline done"
     EXIT = "Exit"
 

--- a/modyn/supervisor/internal/grpc/enums.py
+++ b/modyn/supervisor/internal/grpc/enums.py
@@ -18,22 +18,10 @@ class PipelineStatus(StrEnum):
     NOTFOUND = "not found"
 
 
-class PipelineType(StrEnum):
-    MAIN = "main"
-
-    REPLAY_DATA = "replay_data"
-    SERVE_ONLINE = "wait_for_new_data"
-
-    NEW_DATA = "new_data"
-    NEW_BATCH = "new_data"
-
-    TRIGGER = "trigger"
-    TRAINING = "training"
-    EVALUATION = "evaluation"
-
-
 class PipelineStage(StrEnum):
     """For a state transition graph checkout the `PIPELINE.md` file."""
+
+    MAIN = "Pipeline entrypoint"
 
     # Setup
     INIT = "Initialize pipeline executor"
@@ -52,13 +40,13 @@ class PipelineStage(StrEnum):
     PROCESS_NEW_DATA = "Process new data"
 
     PROCESS_NEW_DATA_BATCH = "Process new data batch"
-    EVALUATE_TRIGGER_POLICIES = "Evaluate trigger on batch"
+    EVALUATE_TRIGGER_POLICY = "Evaluate trigger on batch"
     INFORM_SELECTOR_NO_TRIGGER = "Inform selector about no trigger"
 
     # Trigger
-    EXECUTE_TRIGGERS = "Execute triggers within batch"
-    EXECUTE_SINGLE_TRIGGER = "Execute single trigger"
-    INFORM_SELECTOR_AND_TRIGGER = "Inform selector and trigger"
+    HANDLE_TRIGGERS = "Handle triggers within batch"
+    HANDLE_SINGLE_TRIGGER = "Handle single trigger"
+    INFORM_SELECTOR_ABOUT_TRIGGER = "Inform selector and trigger"
     INFORM_SELECTOR_REMAINING_DATA = "Inform selector about remaining data"
 
     NEW_DATA_HANDLED = "New data handled"

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -285,7 +285,7 @@ class GRPCHandler:
         lr_scheduler_configs = {}
         if pipeline_config["training"].get("lr_scheduler"):
             lr_scheduler_configs = pipeline_config["training"]["lr_scheduler"]
-            lr_scheduler_configs["config"] = lr_scheduler_configs.get("config", None)
+            lr_scheduler_configs["config"] = lr_scheduler_configs.get("config") or {}
 
         criterion_config = json.dumps(pipeline_config["training"]["optimization_criterion"].get("config") or {})
 

--- a/modyn/supervisor/internal/pipeline_executor/PIPELINE.md
+++ b/modyn/supervisor/internal/pipeline_executor/PIPELINE.md
@@ -1,0 +1,66 @@
+# Pipeline
+
+## Pipeline Orchestration
+
+### Current pipeline
+
+```mermaid
+stateDiagram-v2
+    [*] --> INIT
+    INIT --> INIT_CLUSTER_CONNECTION
+    state fork_state <<fork>>
+        INIT_CLUSTER_CONNECTION --> fork_state
+        fork_state --> replay_data
+        fork_state --> serve_online_data
+        state replay_data {
+            [*] --> REPLAY_DATA
+            REPLAY_DATA --> [*]
+        }
+        REPLAY_DATA --> process_new_data
+        process_new_data --> REPLAY_DATA
+        state serve_online_data {
+            [*] --> FETCH_NEW_DATA
+            FETCH_NEW_DATA --> WAIT_FOR_NEW_DATA
+            WAIT_FOR_NEW_DATA --> FETCH_NEW_DATA
+            WAIT_FOR_NEW_DATA --> [*]
+        }
+    replay_data --> DONE
+    serve_online_data --> DONE
+    state process_new_data {
+        state process_new_data_batch {
+            [*] --> EVALUATE_TRIGGER_POLICIES
+            EVALUATE_TRIGGER_POLICIES --> EXECUTE_TRIGGERS
+            state execute_single_trigger {
+                [*] --> INFORM_SELECTOR_AND_TRIGGER
+                INFORM_SELECTOR_AND_TRIGGER --> training
+                state train_and_store_model {
+                    [*] --> TRAIN
+                    TRAIN --> TRAINING_COMPLETED
+                    TRAINING_COMPLETED --> STORE_TRAINED_MODEL
+                    STORE_TRAINED_MODEL --> [*]
+                }
+                state evaluation {
+                    [*] --> EVALUATE
+                    EVALUATE --> single_evaluation
+                    state single_evaluation {
+                        [*] --> EVALUATE_SINGLE
+                        EVALUATE_SINGLE --> STORE_EVALUATION_RESULTS
+                        STORE_EVALUATION_RESULTS -->[*]
+                    }
+                    single_evaluation -->  [*]
+                }
+                train_and_store_model --> evaluation
+            }
+            EXECUTE_TRIGGERS --> execute_single_trigger
+            execute_single_trigger --> INFORM_SELECTOR_REMAINING_DATA
+
+            INFORM_SELECTOR_REMAINING_DATA --> [*]
+        }
+        [*] --> process_new_data_batch
+        process_new_data_batch --> [*]
+    }
+    FETCH_NEW_DATA --> process_new_data
+    process_new_data --> FETCH_NEW_DATA
+    DONE --> EXIT
+    EXIT --> [*]
+```

--- a/modyn/supervisor/internal/pipeline_executor/__init__.py
+++ b/modyn/supervisor/internal/pipeline_executor/__init__.py
@@ -4,7 +4,7 @@
 
 import os
 
-from .pipeline_executor import EVALUATION_RESULTS, PipelineExecutor, execute_pipeline  # noqa: F401
+from .pipeline_executor import PipelineExecutor, execute_pipeline  # noqa: F401
 
 files = os.listdir(os.path.dirname(__file__))
 files.remove("__init__.py")

--- a/modyn/supervisor/internal/pipeline_executor/models.py
+++ b/modyn/supervisor/internal/pipeline_executor/models.py
@@ -1,0 +1,406 @@
+# pylint: disable=E1133
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import logging
+import multiprocessing as mp
+import os
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+import pandas as pd
+from modyn.config.schema.config import ModynConfig
+from modyn.config.schema.pipeline import ModynPipelineConfig
+from modyn.supervisor.internal.grpc.enums import PipelineStage
+from modyn.supervisor.internal.utils.evaluation_status_reporter import EvaluationStatusReporter
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import override
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineOptions:
+    """
+    Wrapped cli argument bundle for the pipeline executor.
+    """
+
+    start_timestamp: int
+    pipeline_id: int
+    modyn_config: ModynConfig
+    pipeline_config: ModynPipelineConfig
+    eval_directory: Path
+    supervisor_supported_eval_result_writers: dict
+    exception_queue: mp.Queue
+    pipeline_status_queue: mp.Queue
+    training_status_queue: mp.Queue
+    eval_status_queue: mp.Queue
+    start_replay_at: int | None = None
+    stop_replay_at: int | None = None
+    maximum_triggers: int | None = None
+
+    @property
+    def dataset_id(self) -> str:
+        return self.pipeline_config.data.dataset_id
+
+    @property
+    def log_directory(self) -> Path:
+        return self.eval_directory
+
+    @property
+    def experiment_mode(self) -> bool:
+        return self.start_replay_at is not None
+
+    @cached_property
+    def selector_batch_size(self) -> int:
+        for dataset in self.modyn_config.storage.datasets:
+            if dataset.name == self.dataset_id:
+                return dataset.selector_batch_size
+
+        logger.info(
+            f"Dataset with id {self.dataset_id} not found in storage configuration. "
+            "Using default 128 for selector_batch_size."
+        )
+        return 128
+
+    @model_validator(mode="after")
+    def validate_replay(self) -> PipelineOptions:
+        if self.start_replay_at is None and self.stop_replay_at is not None:
+            raise ValueError("`stop_replay_at` can only be used in conjunction with `start_replay_at`.")
+        return self
+
+
+@dataclass
+class PipelineBatchState:
+    """Pipeline artifacts shared across stages during the processing of one batch."""
+
+    data: list[tuple[int, int, int]] = dataclasses.field(default_factory=list)
+    remaining_data: list[tuple[int, int, int]] = dataclasses.field(default_factory=list)
+
+    triggering_indexes: list[int] = dataclasses.field(default_factory=list)
+    previous_trigger_idx: int = 0
+
+    trigger_index: int = -1
+    """The index in the dataset where the trigger was initiated."""
+
+    trigger_id: int = -1
+    """The identifier of the trigger received from the selector."""
+
+    evaluations: dict[int, EvaluationStatusReporter] = dataclasses.field(default_factory=dict)
+
+
+@dataclass
+class ExecutionState(PipelineOptions):
+    """Represent the state of the pipeline executor including artifacts of pipeline stages."""
+
+    stage: PipelineStage = PipelineStage.INIT
+    """The current stage of the pipeline executor."""
+
+    current_sample_index: int = 0
+    current_sample_time: int = 0  # unix timestamp
+    """The unix timestamp of the last sample seen and processed by the pipeline executor."""
+
+    # this is to store the first and last timestamp of the remaining data after handling all triggers
+    remaining_data: list[tuple[int, int, int]] = dataclasses.field(default_factory=list)
+    remaining_data_range: Optional[tuple[int, int]] = None
+
+    triggers: list[int] = dataclasses.field(default_factory=list)
+    current_training_id: int | None = None
+    trained_models: list[int] = dataclasses.field(default_factory=list)
+
+    tracking: dict[str, pd.DataFrame] = dataclasses.field(default_factory=dict)
+    """Pipeline stage execution info keyed by stage id made available for pipeline orchestration (e.g. policies)"""
+
+    max_timestamp: int = -1
+
+    previous_model_id: Optional[int] = None
+
+    previous_largest_keys: set[int] = dataclasses.field(default_factory=set)
+
+    @property
+    def maximum_triggers_reached(self) -> bool:
+        return self.maximum_triggers is not None and len(self.triggers) >= self.maximum_triggers
+
+
+class ConfigLogs(BaseModel):
+    system: ModynConfig
+    pipeline: ModynPipelineConfig
+
+
+class StageInfo(BaseModel):
+    """Base class for stage log info. Has no members, intended to be subclassed"""
+
+    def online_df(self) -> pd.DataFrame | None:
+        """
+        Some stages might want to store data in the online DataFrame.
+
+        This data can be used by pipeline steps such as trigger policies.
+
+        Returns:
+            A DataFrame if the stage should collect data, else None.
+        """
+        return None
+
+
+class FetchDataInfo(StageInfo):
+    num_samples: int = Field(..., description="Number of samples processed in the new data.")
+    trigger_indexes: list[int] = Field(..., description="Indices of triggers in the new data.")
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame([(self.num_samples, str(self.trigger_indexes))], columns=["num_samples", "trigger_indexes"])
+
+
+class ProcessNewDataInfo(StageInfo):
+    fetch_time: int = Field(..., description="Time in milliseconds the fetch took")
+    num_samples: int = Field(..., description="Number of samples processed")
+    trigger_indexes: list[int] = Field(..., description="Indices of triggers in the new data.")
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame([(self.fetch_time, self.num_samples)], columns=["fetch_time", "num_samples"])
+
+
+class EvaluateTriggerInfo(StageInfo):
+    batch_size: int
+    trigger_indexes: list[int] = Field(default_factory=list)
+    trigger_eval_times: list[int] = Field(default_factory=list)
+    """Time in milliseconds that every next(...) call of the trigger.inform(...) generator took."""
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame([(self.batch_size, list(self.trigger_indexes))], columns=["batch_size", "trigger_indexes"])
+
+
+class _TriggerLogMixin(StageInfo):
+    trigger_i: int
+    """The index of the trigger in the list of all triggers of this batch."""
+
+    trigger_index: int
+    """The index in the dataset where the trigger was initiated."""
+
+    trigger_id: int
+    """The identifier of the trigger received from the selector."""
+
+
+class SelectorInformTriggerInfo(_TriggerLogMixin):
+    selector_log: dict[str, Any]
+    num_samples_in_trigger: int
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame(
+            [(self.trigger_i, self.trigger_index, self.trigger_i, self.num_samples_in_trigger)],
+            columns=["trigger_i", "trigger_index", "trigger_id", "num_samples_in_trigger"],
+        )
+
+
+class TriggerExecutionInfo(_TriggerLogMixin):
+    first_timestamp: int | None
+    last_timestamp: int | None
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame(
+            [(self.trigger_i, self.trigger_index, self.trigger_id, self.first_timestamp, self.last_timestamp)],
+            columns=["trigger_i", "trigger_index", "trigger_id", "first_timestamp", "last_timestamp"],
+        )
+
+
+class _TrainInfoMixin(StageInfo):
+    trigger_id: int
+    training_id: int
+
+
+class TrainingInfo(_TrainInfoMixin):
+    trainer_log: dict[str, Any]
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame([(self.trigger_id, self.training_id)], columns=["trigger_id", "training_id"])
+
+
+class StoreModelInfo(_TrainInfoMixin):
+    id_model: int  # model_ prefix not allowed in pydantic
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame(
+            [(self.trigger_id, self.training_id, self.id_model)],
+            columns=["trigger_id", "training_id", "id_model"],
+        )
+
+
+class _ModelEvalInfo(StageInfo):
+    trigger_id: int
+    id_model: int
+    dataset_id: str
+    interval_start: int | None
+    interval_end: int | None
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame(
+            [(self.trigger_id, self.id_model, self.dataset_id, self.interval_start, self.interval_end)],
+            columns=["trigger_id", "id_model", "dataset_id", "interval_start", "interval_end"],
+        )
+
+
+class SingleEvaluationInfo(_ModelEvalInfo):
+    failure_reason: str | None = None
+
+
+class StoreEvaluationInfo(_ModelEvalInfo):
+    results: dict[str, Any]
+
+
+class SelectorInformLog(StageInfo):
+    selector_log: dict[str, Any] | None
+    remaining_data: bool
+    trigger_indexes: list[int]
+
+    @override
+    def online_df(self) -> pd.DataFrame | None:
+        return pd.DataFrame(
+            [(self.remaining_data, self.trigger_indexes)], columns=["remaining_data", "trigger_indexes"]
+        )
+
+
+class StageLog(BaseModel):
+    id: str
+    """Identifier for the pipeline stage, PipelineStage.name in most cases"""
+
+    # experiment time
+    start: datetime.datetime
+    end: datetime.datetime | None = Field(None)
+    """Timestamp when the decorated function exits. If decorated functions yields a generator, this will be the time
+    when the generator is returned, not when the generator is exhausted."""
+
+    duration: datetime.timedelta | None = Field(None)
+    """As pipeline stages can be lazily evaluated generators where other computation steps are interleaved,
+    `end-start` is not always the actual duration this stage spent in computing."""
+
+    # dataset time of last seen sample
+    sample_idx: int
+    sample_time: int
+
+    # stage specific log info
+    info: StageInfo | None = Field(None)
+
+    def online_df(self, extended: bool = False) -> pd.DataFrame | None:
+        """Args:
+        extended: If True, include the columns of the info attribute. Requires all logs to have the same type.
+        """
+        df = pd.DataFrame(
+            [(self.id, self.start, self.end, self.duration, self.sample_idx, self.sample_time)],
+            columns=["id", "start", "end", "duration", "sample_idx", "sample_time"],
+        )
+        info_df = self.info.online_df() if self.info else None
+        if info_df is not None and extended:
+            # add additional columns
+            df = pd.concat([df, info_df], axis=1)
+
+        return df
+
+
+class SupervisorLogs(BaseModel):
+    stage_runs: list[StageLog] = Field(default_factory=list)
+
+    def clear(self) -> None:
+        self.stage_runs.clear()
+
+    def merge(self, logs: list[StageLog]) -> SupervisorLogs:
+        self.stage_runs = self.stage_runs + logs
+        return self
+
+    @property
+    def stage_runs_df(self) -> pd.DataFrame:
+        return pd.DataFrame([stage_run.df_row() for stage_run in self.stage_runs], columns=StageLog.df_columns())
+
+
+class PipelineLogs(BaseModel):
+    """
+    Wrapped logs for the pipeline executor.
+
+    This file maintains the log directory:
+    logs
+    ├── pipeline_1
+    │   ├── pipeline.log (final logfile being made available at the end of the pipeline execution)
+    │   ├── pipeline.part.log (initial logfile including static fields)
+    │   ├── supervisor.part_0.log (incremental log files)
+    │   ├── supervisor.part_1.log
+    │   └── supervisor.part_2.log
+    └── pipeline_2
+    """
+
+    # static logs
+
+    pipeline_id: int
+
+    config: ConfigLogs
+
+    experiment: bool
+    start_replay_at: int | None = Field(None, description="Epoch to start replaying at")
+    stop_replay_at: int | None = Field(None, description="Epoch to stop replaying at")
+
+    # incremental logs
+
+    supervisor: SupervisorLogs = Field(default_factory=SupervisorLogs)
+
+    # metadata
+    partial_idx: int = Field(0)
+
+    def materialize(self, log_dir_path: Path, mode: Literal["initial", "increment", "final"] = "increment") -> None:
+        """Materialize the logs to log files.
+
+        If run with pytest, log_file_path and mode will be ignored.
+
+        Args:
+            log_dir_path: The path to the logging directory.
+            mode: The mode to materialize the logs. Initial will output static fields, increment will output only
+                new items since the last materialization, and final will merge all logs.
+        """
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            self.model_dump_json()  # Enforce serialization to catch issues
+            return  # But don't actually store in tests
+
+        # ensure empty log directory
+        pipeline_logdir = log_dir_path / f"pipeline_{self.pipeline_id}"
+
+        if pipeline_logdir.exists():
+            # if not empty move the previous content to .backup_timetamp directory
+            backup_dir = log_dir_path / f"pipeline_{self.pipeline_id}.backup_{datetime.datetime.now().isoformat()}"
+            pipeline_logdir.rename(backup_dir)
+
+        pipeline_logdir.mkdir(parents=True, exist_ok=True)
+
+        # output logs
+
+        if mode == "initial":
+            with open(pipeline_logdir / "pipeline.part.log", "w", encoding="utf-8") as logfile:
+                logfile.write(self.model_dump_json(indent=2, exclude={"supervisor", "partial_idx"}, by_alias=True))
+            return
+
+        if mode == "increment":
+            with open(pipeline_logdir / f"supervisor_part_{self.partial_idx}.log", "w", encoding="utf-8") as logfile:
+                logfile.write(self.supervisor.model_dump_json(indent=2))
+
+            self.supervisor.clear()
+            self.partial_idx += 1
+            return
+
+        # final: merge increment logs
+        supervisor_files = sorted(pipeline_logdir.glob(f"pipeline_{self.pipeline_id}/supervisor.part_*.log"))
+        partial_supervisor_logs = [
+            SupervisorLogs.model_validate_json(file.read_text(encoding="utf-8")) for file in supervisor_files
+        ]
+        self.supervisor = self.supervisor.merge(partial_supervisor_logs)
+
+        with open(pipeline_logdir / "pipeline.log", "w", encoding="utf-8") as logfile:
+            logfile.write(self.model_dump_json(indent=2))
+
+        self.supervisor.clear()

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -1,554 +1,855 @@
-import json
+# pylint: disable=unused-argument
+from __future__ import annotations
+
 import logging
-import multiprocessing as mp
-import os
-import pathlib
 import sys
 import traceback
+import types
+from datetime import datetime, timedelta
 from time import sleep
-from typing import Any, Generator, Optional
+from typing import Callable, Generator, TypeVar, cast
 
-from modyn.common.benchmark import Stopwatch
+import pandas as pd
+from modyn.config.schema.pipeline import DatasetConfig
 
 # pylint: disable-next=no-name-in-module
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import EvaluateModelResponse, EvaluationAbortedReason
 from modyn.supervisor.internal.eval_strategies.abstract_eval_strategy import AbstractEvalStrategy
 from modyn.supervisor.internal.evaluation_result_writer import JsonResultWriter
-from modyn.supervisor.internal.grpc.enums import CounterAction, IdType, MsgType, PipelineStage
+from modyn.supervisor.internal.grpc.enums import CounterAction, IdType, MsgType, PipelineStage, PipelineType
 from modyn.supervisor.internal.grpc.template_msg import counter_submsg, dataset_submsg, id_submsg, pipeline_stage_msg
 from modyn.supervisor.internal.grpc_handler import GRPCHandler
 from modyn.supervisor.internal.triggers import Trigger
 from modyn.supervisor.internal.utils import EvaluationStatusReporter
 from modyn.utils import dynamic_module_import
+from modyn.utils.timer import timed_generator
+from typing_extensions import Concatenate, ParamSpec
+
+from .models import (
+    ConfigLogs,
+    EvaluateTriggerInfo,
+    ExecutionState,
+    FetchDataInfo,
+    PipelineLogs,
+    PipelineOptions,
+    ProcessNewDataInfo,
+    SelectorInformLog,
+    SelectorInformTriggerInfo,
+    SingleEvaluationInfo,
+    StageLog,
+    StoreEvaluationInfo,
+    StoreModelInfo,
+    TrainingInfo,
+    TriggerExecutionInfo,
+)
 
 logger = logging.getLogger(__name__)
 EXCEPTION_EXITCODE = 8
-EVALUATION_RESULTS = "evaluation_results"
+
+P = ParamSpec("P")  # parameters of pipeline stage
+R = TypeVar("R")  # result of pipeline stage
+
+G = TypeVar("G")  # generator type
+
+
+def pipeline_stage(  # type: ignore[no-untyped-def]
+    pipeline: PipelineType,
+    stage: PipelineStage,
+    *,
+    log: bool = True,
+    track: bool = False,
+):
+    """Decorator to register a pipeline stage handler function.
+
+    Args:
+        pipeline: The pipeline to register the stage in.
+        stage: The stage to register.
+        then: The next stage to execute after the current stage
+        log: Whether to log the stage execution.
+        track: Whether to track the stage execution and make results available in the pipeline (e.g. trigger policies).
+    """
+
+    def wrapper_outer(  # type: ignore[no-untyped-def]
+        func: Callable[Concatenate["PipelineExecutor", ExecutionState, StageLog, P], R]
+    ):
+        def wrapper(
+            self: "PipelineExecutor", state: ExecutionState, logs: PipelineLogs, *args: P.args, **kwargs: P.kwargs
+        ) -> R:
+            """Measures the time for each stage and logs the pipeline state."""
+
+            def patch_generator_timer(gen: R, stage_log: StageLog) -> R:  # type: ignore[misc]
+                """As generators will return immediate we have to add time for each yield after the decorator returned.
+                For doing so we wrap the generator with this function.
+                """
+                try:
+                    for item, time in timed_generator(gen):  # type: ignore
+                        stage_log.duration = (stage_log.duration or timedelta(0)) + timedelta(milliseconds=time)
+                        yield item
+                finally:
+                    report_results(stage_log)
+
+            def report_results(stage_log: StageLog) -> None:
+                """For generators we should only report logs and tracking info once the generator is finalized.
+                I.e. fully iterated or garbage collected. In the non-generator case we can report immediately.
+                """
+                # if stage reported additional logs, we make the log available to the pipeline in a dataframe
+                if track and stage_log.info:
+                    # ensure df exists
+                    old_df = state.tracking.get(stage_log.id, None)
+                    if (new_rows := stage_log.online_df(extended=True)) is not None:
+                        state.tracking[stage_log.id] = pd.concat([old_df, new_rows]) if old_df is not None else new_rows
+
+                # record logs
+                if log:
+                    logs.supervisor.stage_runs.append(stage_log)
+                    logger.info(f"[pipeline {state.pipeline_id}] Finished <{stage.name}>.")
+
+            state.stage = stage
+            if log:
+                logger.info(f"[pipeline {pipeline}: {state.pipeline_id}] Entering <{stage}>.")
+
+            # execute stage
+            stage_log = StageLog(
+                id=stage.name,
+                start=datetime.now(),
+                sample_idx=state.current_sample_index,
+                sample_time=state.current_sample_time,
+            )
+            result = func(self, state, stage_log, *args, **kwargs)  # type: ignore[call-arg]
+            stage_log.end = datetime.now()
+            stage_log.duration = stage_log.end - stage_log.start
+            state.stage = stage  # restore stage as child pipeline might have changed it
+
+            if isinstance(result, types.GeneratorType):
+                # If the result is a generator, wrap it with the timed_generator so that every yield will be timed
+                # and added to the log time. The adding happens post-return when the generator is actually iterated.
+                # The wrapped generator adjusts the duration of the stage log and tracking dataframe.
+                result = cast(R, patch_generator_timer(result, stage_log))  # type: ignore[arg-type]
+
+            else:
+                report_results(stage_log)
+
+            # result of stage function
+            return result
+
+        return wrapper
+
+    return wrapper_outer
 
 
 class PipelineExecutor:
-    def __init__(
-        self,
-        start_timestamp: int,
-        pipeline_id: int,
-        modyn_config: dict,
-        pipeline_config: dict,
-        eval_directory: str,
-        supervisor_supported_eval_result_writers: dict,
-        pipeline_status_queue: mp.Queue,
-        training_status_queue: mp.Queue,
-        eval_status_queue: mp.Queue,
-        start_replay_at: Optional[int] = None,
-        stop_replay_at: Optional[int] = None,
-        maximum_triggers: Optional[int] = None,
-    ) -> None:
+    def __init__(self, options: PipelineOptions) -> None:
         self.stage = PipelineStage.INIT
+        self.state = ExecutionState(**vars(options))
+        self.logs = PipelineLogs(
+            pipeline_id=options.pipeline_id,
+            config=ConfigLogs(system=options.modyn_config, pipeline=options.pipeline_config),
+            experiment=options.experiment_mode,
+            start_replay_at=options.start_replay_at,
+            stop_replay_at=options.stop_replay_at,
+        )
+        """Execution state of the pipeline executor."""
 
-        self.start_timestamp = start_timestamp
-        self.pipeline_id = pipeline_id
-        self.modyn_config = modyn_config
-        self.pipeline_config = pipeline_config
-        self.eval_directory = pathlib.Path(eval_directory)
-        self.supervisor_supported_eval_result_writers = supervisor_supported_eval_result_writers
-        self.pipeline_status_queue = pipeline_status_queue
-        self.training_status_queue = training_status_queue
-        self.eval_status_queue = eval_status_queue
-
-        self.previous_model_id: Optional[int] = None
-        if self.pipeline_config["training"]["initial_model"] == "pretrained":
-            self.previous_model_id = self.pipeline_config["training"]["initial_model_id"]
-
+        # pipeline controllers objects
+        self.trigger = self._setup_trigger()
         self.grpc = GRPCHandler(
-            self.modyn_config, self.pipeline_status_queue, self.training_status_queue, self.eval_status_queue
+            self.state.modyn_config.model_dump(by_alias=True),
+            self.state.pipeline_status_queue,
+            self.state.training_status_queue,
+            self.state.eval_status_queue,
         )
 
-        self.start_replay_at = start_replay_at
-        self.stop_replay_at = stop_replay_at
-        self.maximum_triggers = maximum_triggers
+    def run(self) -> None:
+        """Execute the main pipeline."""
+        logger.info(
+            f"[pipeline {self.state.pipeline_id}] Start executing, experiment mode {self.state.experiment_mode}."
+        )
 
-        self._sw = Stopwatch()
-        self._pipeline_log_file = self.eval_directory / f"pipeline_{self.pipeline_id}.json"
-        self.pipeline_log: dict[str, Any] = {
-            "configuration": {"pipeline_config": self.pipeline_config, "modyn_config": self.modyn_config},
-            "supervisor": {
-                "triggers": {},
-                "new_data_requests": [],
-                "num_triggers": 0,
-                "trigger_batch_times": [],
-                "selector_informs": [],
-            },
-        }
-        self._determine_pipeline_mode()
-        self._setup_trigger()
-        self._selector_batch_size = 128
+        self._init(self.state, self.logs)
+        self._init_cluster_connection(self.state, self.logs)
 
-        self.num_triggers = 0
-        self.current_training_id: Optional[int] = None
-        self.triggers: list[int] = []
-        # this is to store the first and last timestamp of the remaining data after handling all triggers in
-        # _handle_triggers_within_batch
-        self.remaining_data_range: Optional[tuple[int, int]] = None
+        if self.state.experiment_mode:
+            self._replay_data(self.state, self.logs)
+        else:
+            self._serve_online_data(self.state, self.logs)
 
-    def _update_pipeline_stage_and_enqueue_msg(
-        self, stage: PipelineStage, msg_type: MsgType, submsg: Optional[dict[str, Any]] = None, log: bool = False
-    ) -> None:
-        self.stage = stage
-        self.pipeline_status_queue.put(pipeline_stage_msg(self.stage, msg_type, submsg, log))
+        self._done(self.state, self.logs)
+        self._exit(self.state, self.logs)
 
-    def init_cluster_connection(self) -> None:
-        self._update_pipeline_stage_and_enqueue_msg(PipelineStage.INIT_CLUSTER_CONNECTION, MsgType.GENERAL)
+        logger.info(f"[pipeline {self.state.pipeline_id}] Execution done. Persist log.")
+
+    # ------------------------------------------------ Pipeline stages ----------------------------------------------- #
+
+    # Setup
+
+    @pipeline_stage(PipelineType.MAIN, PipelineStage.INIT, log=False)
+    def _init(self, s: ExecutionState, log: StageLog) -> None:
+        s.max_timestamp = s.start_timestamp
+        self.logs.materialize(s.log_directory, mode="initial")
+        if s.pipeline_config.training.initial_model == "pretrained":
+            s.previous_model_id = s.pipeline_config.training.initial_model_id
+
+    @pipeline_stage(PipelineType.MAIN, PipelineStage.INIT_CLUSTER_CONNECTION)
+    def _init_cluster_connection(self, s: ExecutionState, log: StageLog) -> None:
+        s.pipeline_status_queue.put(pipeline_stage_msg(PipelineStage.INIT_CLUSTER_CONNECTION, MsgType.GENERAL))
         self.grpc.init_cluster_connection()
 
-    def _determine_pipeline_mode(self) -> None:
-        if self.start_replay_at is None:
-            self.pipeline_log["experiment"] = False
-            self.experiment_mode = False
-            if self.stop_replay_at is not None:
-                raise ValueError("stop_replay_at can only be used in conjunction with start_replay_at.")
+    # Replay Data (experiment mode)
+
+    @pipeline_stage(PipelineType.REPLAY_DATA, PipelineStage.REPLAY_DATA)
+    def _replay_data(self, s: ExecutionState, log: StageLog) -> None:
+        assert s.start_replay_at is not None, "Cannot call replay_data when start_replay_at is None"
+
+        logger.info(f"Running pipeline {s.pipeline_id} in experiment mode.")
+        logger.info("Starting data replay.")
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(PipelineStage.REPLAY_DATA, MsgType.DATASET, dataset_submsg(s.dataset_id))
+        )
+
+        if s.stop_replay_at is None:
+            replay_data_generator = self.grpc.get_new_data_since(s.dataset_id, s.start_replay_at)
         else:
-            self.pipeline_log["experiment"] = True
-            self.pipeline_log["start_replay_at"] = self.start_replay_at
-            self.pipeline_log["stop_replay_at"] = self.stop_replay_at
-            self.experiment_mode = True
+            replay_data_generator = self.grpc.get_data_in_interval(s.dataset_id, s.start_replay_at, s.stop_replay_at)
 
-    def _setup_trigger(self) -> None:
-        trigger_id = self.pipeline_config["trigger"]["id"]
-        trigger_config = {}
-        if "trigger_config" in self.pipeline_config["trigger"].keys():
-            trigger_config = self.pipeline_config["trigger"]["trigger_config"]
-
-        trigger_module = dynamic_module_import("modyn.supervisor.internal.triggers")
-        self.trigger: Trigger = getattr(trigger_module, trigger_id)(trigger_config)
-        self.trigger.init_trigger(self.pipeline_id, self.pipeline_config, self.modyn_config, self.eval_directory)
-        if self.previous_model_id is not None:
-            self.trigger.inform_previous_model(self.previous_model_id)
-
-        assert self.trigger is not None, "Error during trigger initialization"
-
-    def _persist_pipeline_log(self) -> None:
-        if "PYTEST_CURRENT_TEST" in os.environ:
-            json.dumps(self.pipeline_log)  # Enforce serialization to catch issues
-            return  # But don't actually store in tests
-
-        with open(self._pipeline_log_file, "w", encoding="utf-8") as logfile:
-            json.dump(self.pipeline_log, logfile, indent=4)
-
-    def _start_single_evaluation(
-        self,
-        model_id: int,
-        trigger_id: int,
-        eval_dataset_config: dict,
-        interval_start: Optional[int],
-        interval_end: Optional[int],
-    ) -> None:
-        assert self.grpc.evaluator is not None, "Evaluator not initialized."
-        eval_dataset_id = eval_dataset_config["dataset_id"]
-        logger.info(
-            f"Evaluation Starts for model {model_id} on split {interval_start} to {interval_end}"
-            f" of dataset {eval_dataset_id}."
-        )
-        request = GRPCHandler.prepare_evaluation_request(
-            eval_dataset_config,
-            model_id,
-            self.pipeline_config["evaluation"]["device"],
-            interval_start,
-            interval_end,
-        )
-        self._sw.start("evaluate_model", overwrite=True)
-        response: EvaluateModelResponse = self.grpc.evaluator.evaluate_model(request)
-        interval_name = f"{interval_start}-{interval_end}"
-        if not response.evaluation_started:
-            reason = EvaluationAbortedReason.DESCRIPTOR.values_by_number[response.eval_aborted_reason].name
-            logger.error(
-                f"Evaluation for model {model_id} on split {interval_start} to {interval_end} not started with "
-                f"reason: {reason}."
+        for replay_data, request_time in replay_data_generator:
+            # setting sample here to have correct logs in process_new_data
+            s.current_sample_time = min(
+                (timestamp for (_, timestamp, _) in replay_data),
+                default=s.start_timestamp,
             )
-            self.pipeline_log[EVALUATION_RESULTS][trigger_id][interval_name] = {
-                "failure_reason": reason,
-            }
-            self._sw.stop("evaluate_model")
-        else:
-            logger.info(f"Evaluation started for model {model_id} on split {interval_start} to {interval_end}.")
-            reporter = EvaluationStatusReporter(
-                self.eval_status_queue, response.evaluation_id, eval_dataset_id, response.dataset_size
-            )
-            reporter.create_tracker()
-            evaluation = {response.evaluation_id: reporter}
-            assert self.current_training_id is not None, "Training ID not set."
-            self.grpc.wait_for_evaluation_completion(self.current_training_id, evaluation)
-            eval_result_writer: JsonResultWriter = self._init_evaluation_writer("json", 0)
-            self.grpc.store_evaluation_results([eval_result_writer], evaluation)
-            self.pipeline_log[EVALUATION_RESULTS][trigger_id][interval_name] = eval_result_writer.results
-            self.pipeline_log[EVALUATION_RESULTS][trigger_id][interval_name]["evaluation_time"] = self._sw.stop(
-                "evaluate_model"
-            )
+            s.current_sample_index = replay_data[0][0] if replay_data else 0
 
-    def _start_evaluations(
-        self, trigger_id: int, model_id: int, trigger_set_first_timestamp: int, trigger_set_last_timestamp: int
-    ) -> None:
-        assert self.grpc.evaluator is not None, "Evaluator not initialized."
-        eval_strategy_config = self.pipeline_config["evaluation"]["eval_strategy"]
-        eval_strategy_module = dynamic_module_import("modyn.supervisor.internal.eval_strategies")
-        eval_strategy: AbstractEvalStrategy = getattr(eval_strategy_module, eval_strategy_config["name"])(
-            eval_strategy_config["config"]
-        )
-        if EVALUATION_RESULTS not in self.pipeline_log:
-            self.pipeline_log[EVALUATION_RESULTS] = {}
+            self._process_new_data(s, self.logs, replay_data, request_time)
 
-        self.pipeline_log[EVALUATION_RESULTS][trigger_id] = {}
-
-        for eval_dataset_config in self.pipeline_config["evaluation"]["datasets"]:
-            for interval_start, interval_end in eval_strategy.get_eval_intervals(
-                first_timestamp=trigger_set_first_timestamp,
-                last_timestamp=trigger_set_last_timestamp,
-            ):
-                self._start_single_evaluation(model_id, trigger_id, eval_dataset_config, interval_start, interval_end)
-
-    def get_dataset_selector_batch_size(self) -> None:
-        # system configuration already validated, so the dataset_id will be present in the configuration file
-        dataset_id = self.pipeline_config["data"]["dataset_id"]
-        self._update_pipeline_stage_and_enqueue_msg(
-            PipelineStage.GET_SELECTOR_BATCH_SIZE, MsgType.DATASET, dataset_submsg(dataset_id)
-        )
-
-        for dataset in self.modyn_config["storage"]["datasets"]:
-            if dataset["name"] == dataset_id:
-                if "selector_batch_size" in dataset:
-                    self._selector_batch_size = dataset["selector_batch_size"]
+            if s.maximum_triggers is not None and len(s.triggers) >= s.maximum_triggers:
+                logger.info("Exiting replay loop due to trigger limit.")
                 break
 
-    def _handle_new_data(self, new_data: list[tuple[int, int, int]]) -> bool:
-        """This function handles new data during experiments or actual pipeline execution.
-        We partition `new_data` into batches of `selector_batch_size` to reduce selector latency in case of a trigger.
-        If a data point within a batch causes a trigger,
-        we inform the selector about all data points including that data point.
-        Otherwise, the selector is informed
+        logger.info(f"Experiment mode pipeline {s.pipeline_id} done.")
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(
+                PipelineStage.REPLAY_DATA_DONE,
+                MsgType.DATASET,
+                dataset_submsg(s.dataset_id),
+            )
+        )
+
+    # Online serving mode (non-experiment mode)
+
+    @pipeline_stage(PipelineType.SERVE_ONLINE, PipelineStage.SERVE_ONLINE_DATA)
+    def _serve_online_data(self, s: ExecutionState, log: StageLog) -> None:
+        """Run pipeline in production mode fetching new data until pipeline is stopped."""
+        logger.info(f"Running pipeline {s.pipeline_id} in online serving mode.")
+        logger.info("Press CTRL+C at any time to shutdown the pipeline.")
+
+        try:
+            while True:
+                num_new_triggers = self._fetch_new_data(s, self.logs)
+                if s.maximum_triggers_reached:
+                    break
+                if num_new_triggers == 0:
+                    self._wait_for_new_data(s, self.logs)
+
+        except KeyboardInterrupt:
+            logger.info("Initiating shutdown.")
+            self._shutdown_trainer()
+            logger.info("Shutdown successful.")
+
+        logger.info(f"New data mode pipeline {s.pipeline_id} done.")
+
+    @pipeline_stage(PipelineType.SERVE_ONLINE, PipelineStage.FETCH_NEW_DATA, track=True)
+    def _fetch_new_data(self, s: ExecutionState, log: StageLog) -> int:
+        """Try to fetch new data from the dataset and process it.
+
+        Returns:
+            The number of triggers that occurred during the processing of the new data.
         """
-        logger.info(f"Received {len(new_data)} new data points. Handling batches.")
-        new_data.sort(key=lambda tup: tup[1])
-        any_training_triggered = False
-        new_data_len = len(new_data)
-        self._update_pipeline_stage_and_enqueue_msg(
-            PipelineStage.HANDLE_NEW_DATA,
-            MsgType.COUNTER,
-            counter_submsg(CounterAction.CREATE, {"new_data_len": new_data_len}),
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(PipelineStage.FETCH_NEW_DATA, MsgType.DATASET, dataset_submsg(s.dataset_id))
         )
 
-        for i in range(0, new_data_len, self._selector_batch_size):
-            batch = new_data[i : i + self._selector_batch_size]
-            batch_size = self._selector_batch_size if i + self._selector_batch_size < new_data_len else new_data_len - i
-            self._update_pipeline_stage_and_enqueue_msg(
-                PipelineStage.HANDLE_NEW_DATA,
+        num_samples = 0
+        trigger_indexes: list[int] = []
+        largest_keys = set()
+        replay_data_generator = self.grpc.get_new_data_since(s.dataset_id, s.max_timestamp)
+
+        for fetched_data, fetch_time in replay_data_generator:
+            # Since get_new_data_since is inclusive, we have to expect more yet unprocessed samples
+            # with `max_timestamp` alongside already processed samples with `max_timestamp`.
+            # We memorize the already processed samples to avoid processing them again. Using set to get O(1) lookup.
+            fetched_data = [
+                (key, timestamp, label)
+                for (key, timestamp, label) in fetched_data
+                if key not in s.previous_largest_keys
+            ]
+            s.max_timestamp = (
+                max((timestamp for (_, timestamp, _) in fetched_data)) if len(fetched_data) > 0 else s.max_timestamp
+            )
+            largest_keys.update({key for (key, timestamp, _) in fetched_data if timestamp == s.max_timestamp})
+
+            # setting sample here to have correct logs in process_new_data
+            s.current_sample_time = min(
+                (timestamp for (_, timestamp, _) in fetched_data),
+                default=s.start_timestamp,
+            )
+            s.current_sample_index = fetched_data[0][0] if fetched_data else 0
+
+            # process new data and invoke triggers
+            trigger_indexes = trigger_indexes + self._process_new_data(s, self.logs, fetched_data, fetch_time)
+            num_samples += len(fetched_data)
+
+        s.previous_largest_keys = largest_keys
+
+        # log extra information
+        log.info = FetchDataInfo(num_samples=num_samples, trigger_indexes=trigger_indexes)
+
+        return len(trigger_indexes)
+
+    @pipeline_stage(PipelineType.SERVE_ONLINE, PipelineStage.WAIT_FOR_NEW_DATA)
+    def _wait_for_new_data(self, s: ExecutionState, log: StageLog) -> None:
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(
+                PipelineStage.WAIT_FOR_NEW_DATA,
+                MsgType.DATASET,
+                dataset_submsg(s.dataset_id),
+            )
+        )
+        sleep(2)
+
+    # Process new data
+
+    @pipeline_stage(PipelineType.NEW_DATA, PipelineStage.PROCESS_NEW_DATA, track=True)
+    def _process_new_data(
+        self, s: ExecutionState, log: StageLog, new_data: list[tuple[int, int, int]], fetch_time: int
+    ) -> list[int]:
+        """Handle new data during experiments or online pipeline serving.
+
+        We partition `new_data` into batches of `selector_batch_size` to reduce selector latency in case of a trigger.
+        If a data point within a batch causes a trigger, we inform the selector about all data points including
+        that data point. Otherwise, the selector is informed.
+
+        Args:
+            s: Execution state of the pipeline executor.
+            log: Log of the current stage.
+            new_data: List of tuples (key, timestamp, label) of new data points.
+            fetch_time: Number of milliseconds it took to fetch the data.
+
+        Returns:
+            List of indexes of data points that caused a trigger.
+        """
+        new_data.sort(key=lambda tup: tup[1])  # sort by timestamp
+        trigger_indexes: list[int] = []
+        new_data_len = len(new_data)
+
+        logger.info(f"Received {new_data_len} new data points. Handling batches.")
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(
+                PipelineStage.PROCESS_NEW_DATA,
                 MsgType.COUNTER,
-                counter_submsg(CounterAction.UPDATE, {"batch_size": batch_size}),
+                counter_submsg(CounterAction.CREATE, {"new_data_len": new_data_len}),
+            )
+        )
+
+        for i in range(0, new_data_len, s.selector_batch_size):
+            batch = new_data[i : i + s.selector_batch_size]
+            batch_size = s.selector_batch_size if i + s.selector_batch_size < new_data_len else new_data_len - i
+            if batch_size > 0:
+                s.current_sample_index = batch[0][0]  # update sample index
+                s.current_sample_time = batch[0][1]  # update sample time
+
+            s.pipeline_status_queue.put(
+                pipeline_stage_msg(
+                    PipelineStage.PROCESS_NEW_DATA,
+                    MsgType.COUNTER,
+                    counter_submsg(CounterAction.UPDATE, {"batch_size": batch_size}),
+                )
             )
 
-            triggered = self._handle_new_data_batch(batch)
-            any_training_triggered = any_training_triggered or triggered
-            if self.maximum_triggers is not None and self.num_triggers >= self.maximum_triggers:
-                logger.info(f"Reached trigger limit ({self.maximum_triggers}), exiting.")
+            trigger_indexes += self._process_new_data_batch(s, self.logs, batch)
+
+            if s.maximum_triggers is not None and len(s.triggers) >= s.maximum_triggers:
+                logger.info(f"Reached trigger limit ({s.maximum_triggers}), exiting.")
                 break
 
-        self._update_pipeline_stage_and_enqueue_msg(
-            PipelineStage.NEW_DATA_HANDLED, MsgType.COUNTER, counter_submsg(CounterAction.CLOSE)
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(PipelineStage.NEW_DATA_HANDLED, MsgType.COUNTER, counter_submsg(CounterAction.CLOSE))
         )
 
-        return any_training_triggered
+        # log extra information
+        log.info = ProcessNewDataInfo(fetch_time=fetch_time, num_samples=new_data_len, trigger_indexes=trigger_indexes)
+        self.logs.materialize(s.log_directory, mode="increment")
 
-    def _handle_new_data_batch(self, batch: list[tuple[int, int, int]]) -> bool:
-        self._sw.start("trigger_inform", overwrite=True)
-        triggering_indices: Generator[int, None, None] = self.trigger.inform(batch)
-        num_triggers = self._handle_triggers_within_batch(batch, triggering_indices)
+        return trigger_indexes
 
-        logger.info(f"There are {num_triggers} triggers in this batch.")
-        self.pipeline_log["supervisor"]["num_triggers"] += num_triggers
-        self.pipeline_log["supervisor"]["trigger_batch_times"].append(
-            {"batch_size": len(batch), "time": self._sw.stop("trigger_inform"), "num_triggers": num_triggers}
+    # Process new data BATCH
+
+    @pipeline_stage(PipelineType.NEW_BATCH, PipelineStage.PROCESS_NEW_DATA_BATCH, track=True)
+    def _process_new_data_batch(self, s: ExecutionState, log: StageLog, batch: list[tuple[int, int, int]]) -> list[int]:
+        """Process new data in batches and evaluate trigger policies in batches.
+
+        Args:
+            s: Execution state of the pipeline executor.
+            log: Log of the current stage.
+            batch: List of tuples (key, timestamp, label) of new data points.
+
+        Returns:
+            List of indexes of data points that caused a trigger.
+        """
+
+        # Evaluate trigger policy and inform selector
+        lazy_trigger_indexes = self._evaluate_trigger_policies(s, self.logs, batch)
+
+        # Execute triggers within batch (training & evaluation subpipelines)
+        executed_triggers = self._execute_triggers(s, self.logs, batch, lazy_trigger_indexes)
+
+        # Inform selector about remaining data
+        self._inform_selector_remaining_data(s, self.logs, batch, executed_triggers)
+
+        return executed_triggers
+
+    @pipeline_stage(PipelineType.NEW_BATCH, PipelineStage.EVALUATE_TRIGGER_POLICIES, track=True)
+    def _evaluate_trigger_policies(
+        self, s: ExecutionState, log: StageLog, batch: list[tuple[int, int, int]]
+    ) -> Generator[int, None, None]:
+        """Evaluate trigger policy and inform selector.
+
+        Returns:
+            List of indexes of data points that caused a trigger.
+        """
+        try:
+            # add log data
+            log.info = EvaluateTriggerInfo(batch_size=len(batch))
+
+            # Evaluate trigger policy
+            for trigger_index, t_micros in timed_generator(self.trigger.inform(batch)):
+                log.info.trigger_indexes.append(trigger_index)
+                log.info.trigger_eval_times.append(int(t_micros))
+                yield trigger_index
+
+        finally:
+            assert log.info
+            logger.info(f"There were {len(log.info.trigger_indexes)} triggers in this batch.")
+
+    @pipeline_stage(PipelineType.NEW_BATCH, PipelineStage.EXECUTE_TRIGGERS, track=True)
+    def _execute_triggers(
+        self,
+        s: ExecutionState,
+        log: StageLog,
+        batch: list[tuple[int, int, int]],
+        lazy_trigger_indexes: Generator[int, None, None],
+    ) -> list[int]:
+        """Evaluate trigger policy, start training after trigger and inform selector.
+
+        Args:
+            s: Execution state of the pipeline executor.
+
+        Returns:
+            The list of the actually processed triggers
+        """
+        logger.info(f"Processing {len(s.triggers)} triggers in this batch.")
+        s.pipeline_status_queue.put(pipeline_stage_msg(PipelineStage.EXECUTE_TRIGGERS, MsgType.GENERAL))
+
+        previous_trigger_index = 0
+        trigger_index = -1
+        trigger_indexes: list[int] = []
+        for i, trigger_index in enumerate(lazy_trigger_indexes):
+            # Run training and evaluation subpipelines
+            trigger_indexes.append(trigger_index)
+            trigger_data = batch[previous_trigger_index : trigger_index + 1]
+            previous_trigger_index = trigger_index + 1
+
+            self._execute_single_trigger(s, self.logs, trigger_data, i, trigger_index)
+            s.triggers.append(trigger_index)
+
+            if s.maximum_triggers is not None and len(s.triggers) >= s.maximum_triggers:
+                break
+
+        return trigger_indexes
+
+    @pipeline_stage(PipelineType.NEW_DATA, PipelineStage.INFORM_SELECTOR_REMAINING_DATA, track=True)
+    def _inform_selector_remaining_data(
+        self, s: ExecutionState, log: StageLog, batch: list[tuple[int, int, int]], trigger_indexes: list[int]
+    ) -> None:
+        """Inform selector about remaining data."""
+
+        # If no other trigger is coming in this batch, we  inform the Selector about the remaining data in this batch.
+        if len(trigger_indexes) > 0:
+            s.remaining_data = batch[trigger_indexes[-1] + 1 :]
+        else:
+            s.remaining_data = batch  # All data
+
+        logger.info(f"There are {len(s.remaining_data)} data points remaining after the triggers in this batch.")
+
+        if len(s.remaining_data) > 0:
+            # These data points will be included in the next trigger
+            # because we inform the Selector about them,
+            # just like other batches with no trigger at all are included.
+            selector_log = self.grpc.inform_selector(s.pipeline_id, s.remaining_data)
+            if s.remaining_data_range is not None:
+                # extend the range from last time
+                s.remaining_data_range = (s.remaining_data_range[0], s.remaining_data[-1][1])
+            else:
+                s.remaining_data_range = (s.remaining_data[0][1], s.remaining_data[-1][1])
+        else:
+            selector_log = None
+            s.remaining_data_range = None
+
+        # add log data
+        log.info = SelectorInformLog(
+            selector_log=selector_log, remaining_data=len(s.remaining_data) > 0, trigger_indexes=trigger_indexes
         )
 
-        return num_triggers > 0
+    # Execute trigger within batch
 
-    def _run_training(self, trigger_id: int) -> int:
+    @pipeline_stage(PipelineType.TRIGGER, PipelineStage.EXECUTE_SINGLE_TRIGGER, track=True)
+    def _execute_single_trigger(
+        self,
+        s: ExecutionState,
+        log: StageLog,
+        trigger_data: list[tuple[int, int, int]],
+        trigger_i: int,
+        trigger_index: int,
+    ) -> None:
+        """Execute trigger within batch.
+
+        Args:
+            s: Execution state of the pipeline executor.
+            trigger_data: Data points used for the training caused by the trigger.
+            trigger_i: Index of the trigger in the batch.
+            trigger_index: Index of the trigger in the data.
+        """
+        s.pipeline_status_queue.put(pipeline_stage_msg(PipelineStage.EXECUTE_SINGLE_TRIGGER, MsgType.GENERAL))
+
+        # trigger_id: identifier of the trigger received from the selector
+        trigger_id, num_samples_in_trigger = self._inform_selector_about_trigger(
+            s, self.logs, trigger_data, trigger_i, trigger_index
+        )
+
+        if num_samples_in_trigger > 0:
+            first_timestamp, last_timestamp = PipelineExecutor._get_trigger_timespan(s, trigger_i == 0, trigger_data)
+            s.remaining_data_range = None
+            training_id, model_id = self._train_and_store_model(s, self.logs, trigger_id)
+            self.trigger.inform_previous_model(model_id)
+
+            if s.pipeline_config.evaluation:
+                self._evaluate_and_store_results(
+                    s, self.logs, trigger_id, training_id, model_id, first_timestamp, last_timestamp
+                )
+
+        else:
+            first_timestamp, last_timestamp = None, None
+            logger.info(f"Skipping training on empty trigger {trigger_index}]")
+
+        log.info = TriggerExecutionInfo(
+            trigger_i=trigger_i,
+            trigger_index=trigger_index,
+            trigger_id=trigger_id,
+            first_timestamp=first_timestamp,
+            last_timestamp=last_timestamp,
+        )
+
+    @pipeline_stage(PipelineType.TRIGGER, PipelineStage.INFORM_SELECTOR_AND_TRIGGER, track=True)
+    def _inform_selector_about_trigger(
+        self,
+        s: ExecutionState,
+        log: StageLog,
+        trigger_data: list[tuple[int, int, int]],
+        trigger_i: int,
+        trigger_index: int,
+    ) -> tuple[int, int]:
+        """Inform selector about data until trigger and notify about trigger.
+
+        Returns:
+            trigger id from selector and number of samples in trigger.
+        """
+        s.pipeline_status_queue.put(pipeline_stage_msg(PipelineStage.INFORM_SELECTOR_AND_TRIGGER, MsgType.GENERAL))
+
+        # This call informs the selector about the data until (and including) the data point that caused the trigger
+        # and then also notifies it about the triggering. This means the next training call on trigger_id will
+        # guarantee that all data until that point has been processed by the selector.
+        trigger_id, selector_log = self.grpc.inform_selector_and_trigger(s.pipeline_id, trigger_data)
+        num_samples_in_trigger = self.grpc.get_number_of_samples(s.pipeline_id, trigger_id)
+
+        # add log data
+        log.info = SelectorInformTriggerInfo(
+            trigger_i=trigger_i,
+            trigger_index=trigger_index,
+            trigger_id=trigger_id,
+            selector_log=selector_log,
+            num_samples_in_trigger=num_samples_in_trigger,
+        )
+        return trigger_id, num_samples_in_trigger
+
+    # Training
+
+    @pipeline_stage(PipelineType.TRAINING, PipelineStage.TRAIN_AND_STORE_MODEL, track=True)
+    def _train_and_store_model(self, s: ExecutionState, log: StageLog, trigger_id: int) -> tuple[int, int]:
+        """Train a new model on batch data and store it."""
+
+        training_id = self._train(s, self.logs, trigger_id)
+        self._training_completed(s, self.logs, trigger_id)
+        model_id = self._store_trained_model(s, self.logs, trigger_id, training_id)
+
+        s.trained_models.append(model_id)
+
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(PipelineStage.EXECUTE_TRIGGERS, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id))
+        )
+        return training_id, model_id
+
+    @pipeline_stage(PipelineType.TRAINING, PipelineStage.TRAIN, track=True)
+    def _train(self, s: ExecutionState, log: StageLog, trigger_id: int) -> int:
         """Run training for trigger on GPU and block until done."""
-        assert self.pipeline_id is not None, "_run_training called without a registered pipeline."
-        self._update_pipeline_stage_and_enqueue_msg(
-            PipelineStage.RUN_TRAINING, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id)
-        )
-        logger.info(f"Running training for trigger {trigger_id}")
 
-        self._sw.start("train", overwrite=True)
-        num_samples_to_pass_per_trigger = self.pipeline_config["training"].get("num_samples_to_pass", [])
-        current_trigger_index = len(self.triggers)
+        logger.info(f"Running training for trigger {trigger_id}")
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(PipelineStage.TRAIN, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id))
+        )
+        num_samples_to_pass_per_trigger = s.pipeline_config.training.num_samples_to_pass or []
+        current_trigger_index = len(s.triggers)
         if current_trigger_index <= len(num_samples_to_pass_per_trigger) - 1:
             num_samples_to_pass = num_samples_to_pass_per_trigger[current_trigger_index]
         else:
             num_samples_to_pass = None
 
-        self.current_training_id = self.grpc.start_training(
-            self.pipeline_id, trigger_id, self.pipeline_config, self.previous_model_id, num_samples_to_pass
+        s.current_training_id = self.grpc.start_training(
+            s.pipeline_id,
+            trigger_id,
+            s.pipeline_config.model_dump(by_alias=True),
+            s.previous_model_id,
+            num_samples_to_pass,
+        )
+        trainer_log = self.grpc.wait_for_training_completion(s.current_training_id, s.pipeline_id, trigger_id)
+
+        # add log data
+        log.info = TrainingInfo(
+            trigger_id=trigger_id,
+            training_id=s.current_training_id,
+            trainer_log=trainer_log,
         )
 
-        self.stage = PipelineStage.WAIT_FOR_TRAINING_COMPLETION
-        trainer_log = self.grpc.wait_for_training_completion(self.current_training_id, self.pipeline_id, trigger_id)
+        return s.current_training_id
 
-        if trigger_id not in self.pipeline_log["supervisor"]["triggers"]:
-            self.pipeline_log["supervisor"]["triggers"][trigger_id] = {}  # can happen in tests
-
-        self.pipeline_log["supervisor"]["triggers"][trigger_id]["total_trainer_time"] = self._sw.stop()
-        self.pipeline_log["supervisor"]["triggers"][trigger_id]["trainer_log"] = trainer_log
-
-        self._update_pipeline_stage_and_enqueue_msg(
-            PipelineStage.STORE_TRAINED_MODEL, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id)
+    @pipeline_stage(PipelineType.TRAINING, PipelineStage.TRAINING_COMPLETED, track=False)
+    def _training_completed(self, s: ExecutionState, log: StageLog, training_id: int) -> None:
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(
+                PipelineStage.TRAINING_COMPLETED, MsgType.ID, id_submsg(IdType.TRAINING, training_id), True
+            )
         )
-        # We store the trained model for evaluation in any case.
-        self._sw.start("store_trained_model", overwrite=True)
-        model_id = self.grpc.store_trained_model(self.current_training_id)
-        self.trigger.inform_previous_model(model_id)
-        self.pipeline_log["supervisor"]["triggers"][trigger_id]["store_trained_model_time"] = self._sw.stop()
+        logger.info(f"Training {training_id} completed")
+
+    @pipeline_stage(PipelineType.TRAINING, PipelineStage.STORE_TRAINED_MODEL, track=True)
+    def _store_trained_model(self, s: ExecutionState, log: StageLog, trigger_id: int, training_id: int) -> int:
+        """Stores a trained model and returns the model id."""
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(PipelineStage.STORE_TRAINED_MODEL, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id))
+        )
+
+        model_id = self.grpc.store_trained_model(training_id)
 
         # Only if the pipeline actually wants to continue the training on it, we set previous model.
-        if self.pipeline_config["training"]["use_previous_model"]:
-            self.previous_model_id = model_id
+        if s.pipeline_config.training.use_previous_model:
+            s.previous_model_id = model_id
 
-        self.triggers.append(trigger_id)
+        # add log data
+        log.info = StoreModelInfo(trigger_id=trigger_id, training_id=training_id, id_model=model_id)
+
         return model_id
 
+    # Evaluation
+
+    @pipeline_stage(PipelineType.EVALUATION, PipelineStage.EVALUATE, track=True)
+    def _evaluate_and_store_results(
+        self,
+        s: ExecutionState,
+        log: StageLog,
+        trigger_id: int,
+        training_id: int,
+        model_id: int,
+        first_timestamp: int,
+        last_timestamp: int,
+    ) -> None:
+        """Evaluate the trained model and store the results."""
+        assert self.grpc.evaluator is not None, "Evaluator not initialized."
+        assert self.state.pipeline_config.evaluation is not None, "Evaluation config not set."
+        s.pipeline_status_queue.put(
+            pipeline_stage_msg(PipelineStage.EVALUATE, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id))
+        )
+
+        eval_strategy_config = self.state.pipeline_config.evaluation.eval_strategy
+        eval_strategy_module = dynamic_module_import("modyn.supervisor.internal.eval_strategies")
+        eval_strategy: AbstractEvalStrategy = getattr(eval_strategy_module, eval_strategy_config.name)(
+            eval_strategy_config.config.model_dump(by_alias=True)
+        )
+
+        for eval_dataset_config in self.state.pipeline_config.evaluation.datasets:
+            for interval_start, interval_end in eval_strategy.get_eval_intervals(first_timestamp, last_timestamp):
+                results = self._single_evaluation(
+                    s, self.logs, trigger_id, training_id, model_id, eval_dataset_config, interval_start, interval_end
+                )
+                if results:
+                    self._store_evaluation_results(
+                        s,
+                        self.logs,
+                        trigger_id,
+                        model_id,
+                        eval_dataset_config.dataset_id,
+                        results,
+                        interval_start,
+                        interval_end,
+                    )
+
+    @pipeline_stage(PipelineType.EVALUATION, PipelineStage.EVALUATE_SINGLE, track=True)
+    def _single_evaluation(
+        self,
+        s: ExecutionState,
+        log: StageLog,
+        trigger_id: int,
+        training_id: int,
+        model_id: int,
+        eval_dataset_config: DatasetConfig,
+        interval_start: int | None,
+        interval_end: int | None,
+    ) -> dict[int, EvaluationStatusReporter] | None:
+        assert self.grpc.evaluator is not None, "Evaluator not initialized."
+        assert self.state.pipeline_config.evaluation
+        logger.info(
+            f"Evaluation Starts for model {model_id} on split {interval_start} to {interval_end}"
+            f" of dataset {eval_dataset_config.dataset_id}."
+        )
+        request = GRPCHandler.prepare_evaluation_request(
+            eval_dataset_config.model_dump(by_alias=True),
+            model_id,
+            self.state.pipeline_config.evaluation.device,
+            interval_start,
+            interval_end,
+        )
+        response: EvaluateModelResponse = self.grpc.evaluator.evaluate_model(request)
+        log.info = SingleEvaluationInfo(
+            trigger_id=trigger_id,
+            id_model=model_id,
+            dataset_id=eval_dataset_config.dataset_id,
+            interval_start=interval_start,
+            interval_end=interval_end,
+        )
+        if not response.evaluation_started:
+            log.info.failure_reason = EvaluationAbortedReason.DESCRIPTOR.values_by_number[
+                response.eval_aborted_reason
+            ].name
+            logger.error(
+                f"Evaluation for model {model_id} on split {interval_start} to {interval_end} not started with "
+                f"reason: {log.info.failure_reason}."
+            )
+            return None
+
+        logger.info(f"Evaluation started for model {model_id} on split {interval_start} to {interval_end}.")
+        reporter = EvaluationStatusReporter(
+            self.state.eval_status_queue,
+            response.evaluation_id,
+            eval_dataset_config.dataset_id,
+            response.dataset_size,
+        )
+        evaluation = {response.evaluation_id: reporter}
+        reporter.create_tracker()
+        self.grpc.wait_for_evaluation_completion(training_id, evaluation)
+        return evaluation
+
+    @pipeline_stage(PipelineType.EVALUATION, PipelineStage.STORE_EVALUATION_RESULTS, track=True)
+    def _store_evaluation_results(
+        self,
+        s: ExecutionState,
+        log: StageLog,
+        trigger_id: int,
+        model_id: int,
+        dataset_id: int,
+        evaluation: dict[int, EvaluationStatusReporter],
+        interval_start: int | None,
+        interval_end: int | None,
+    ) -> None:
+        eval_result_writer: JsonResultWriter = self._init_evaluation_writer(s, "json", trigger_id)
+        self.grpc.store_evaluation_results([eval_result_writer], evaluation)
+
+        log.info = StoreEvaluationInfo(
+            trigger_id=trigger_id,
+            id_model=model_id,
+            dataset_id=dataset_id,
+            interval_start=interval_start,
+            interval_end=interval_end,
+            results=eval_result_writer.results,
+        )
+
+    # Teardown
+
+    @pipeline_stage(PipelineType.MAIN, PipelineStage.DONE)
+    def _done(self, s: ExecutionState, log: StageLog) -> None:
+        s.pipeline_status_queue.put(pipeline_stage_msg(PipelineStage.DONE, MsgType.GENERAL))
+        self.logs.materialize(s.log_directory, mode="final")
+
+    @pipeline_stage(PipelineType.MAIN, PipelineStage.EXIT)
+    def _exit(self, s: ExecutionState, log: StageLog) -> None:
+        return None  # end of pipeline
+
+    # ---------------------------------------------------- Helpers --------------------------------------------------- #
+
+    # setup
+
+    def _setup_trigger(self) -> Trigger:
+        trigger_id = self.state.pipeline_config.trigger.id
+        trigger_config = self.state.pipeline_config.trigger.trigger_config
+
+        trigger_module = dynamic_module_import("modyn.supervisor.internal.triggers")
+        trigger: Trigger = getattr(trigger_module, trigger_id)(trigger_config)
+        assert trigger is not None, "Error during trigger initialization"
+
+        trigger.init_trigger(
+            self.state.pipeline_id, self.state.pipeline_config, self.state.modyn_config, self.state.eval_directory
+        )
+        if self.state.previous_model_id is not None:
+            trigger.inform_previous_model(self.state.previous_model_id)
+
+        return trigger
+
+    # pipeline run
+
+    @staticmethod
     def _get_trigger_timespan(
-        self, is_first_triggering_data: bool, triggering_data: list[tuple[int, int, int]]
+        s: ExecutionState, is_first_trigger_data: bool, trigger_data: list[tuple[int, int, int]]
     ) -> tuple[int, int]:
-        if is_first_triggering_data:
+        if is_first_trigger_data:
             # now it is the first trigger in this batch. Triggering_data can be empty.
             # when it is indeed empty, then there is remaining data in the last batch
             # because num_samples_in_trigger is not 0.
-            assert len(triggering_data) > 0 or self.remaining_data_range is not None
+            assert len(trigger_data) > 0 or s.remaining_data_range is not None
 
-            if self.remaining_data_range is not None:
-                first_timestamp = self.remaining_data_range[0]
-                last_timestamp = self.remaining_data_range[1] if len(triggering_data) == 0 else triggering_data[-1][1]
+            if s.remaining_data_range is not None:
+                first_timestamp = s.remaining_data_range[0]
+                last_timestamp = s.remaining_data_range[1] if len(trigger_data) == 0 else trigger_data[-1][1]
             else:
-                first_timestamp = triggering_data[0][1]
-                last_timestamp = triggering_data[-1][1]
+                first_timestamp = trigger_data[0][1]
+                last_timestamp = trigger_data[-1][1]
         else:
-            assert len(triggering_data) > 0
-            # since num_samples_in_trigger is not 0, we are sure that triggering_data is not empty
-            first_timestamp = triggering_data[0][1]
-            last_timestamp = triggering_data[-1][1]
+            assert len(trigger_data) > 0
+            # since num_samples_in_trigger is not 0, we are sure that trigger_data is not empty
+            first_timestamp = trigger_data[0][1]
+            last_timestamp = trigger_data[-1][1]
 
         return first_timestamp, last_timestamp
 
-    def _handle_triggers_within_batch(
-        self, batch: list[tuple[int, int, int]], triggering_indices: Generator[int, None, None]
-    ) -> int:
-        previous_trigger_idx = 0
-        logger.info("Handling triggers within batch.")
-        self._update_pipeline_stage_and_enqueue_msg(PipelineStage.HANDLE_TRIGGERS_WITHIN_BATCH, MsgType.GENERAL)
+    def _init_evaluation_writer(self, s: ExecutionState, name: str, trigger_id: int) -> JsonResultWriter:
+        return s.supervisor_supported_eval_result_writers[name](s.pipeline_id, trigger_id, self.state.eval_directory)
 
-        triggering_idx_list = []
-
-        for i, triggering_idx in enumerate(triggering_indices):
-            triggering_idx_list.append(triggering_idx)
-            self._update_pipeline_stage_and_enqueue_msg(PipelineStage.INFORM_SELECTOR_AND_TRIGGER, MsgType.GENERAL)
-            triggering_data = batch[previous_trigger_idx : triggering_idx + 1]
-            previous_trigger_idx = triggering_idx + 1
-
-            # This call informs the selector about the data until (and including)
-            # the data point that caused the trigger and then also notifies it about the triggering.
-            # This means the next training call on trigger_id will guarantee
-            # that all data until that point has been processed by the selector.
-            self._sw.start("selector_inform", overwrite=True)
-            trigger_id, selector_log = self.grpc.inform_selector_and_trigger(self.pipeline_id, triggering_data)
-            self.pipeline_log["supervisor"]["triggers"][trigger_id] = {
-                "total_selector_time": self._sw.stop(),
-                "selector_log": selector_log,
-            }
-            self._persist_pipeline_log()
-
-            num_samples_in_trigger = self.grpc.get_number_of_samples(self.pipeline_id, trigger_id)
-            if num_samples_in_trigger > 0:
-                self._update_pipeline_stage_and_enqueue_msg(
-                    PipelineStage.HANDLE_TRIGGERS_WITHIN_BATCH, MsgType.ID, id_submsg(IdType.TRIGGER, trigger_id)
-                )
-                self.trigger.inform_previous_trigger_and_data_points(trigger_id, num_samples_in_trigger)
-                first_timestamp, last_timestamp = self._get_trigger_timespan(i == 0, triggering_data)
-                self.pipeline_log["supervisor"]["triggers"][trigger_id]["first_timestamp"] = first_timestamp
-                self.pipeline_log["supervisor"]["triggers"][trigger_id]["last_timestamp"] = last_timestamp
-                # reset the remaining data range since we have processed it now
-                self.remaining_data_range = None
-                model_id = self._run_training(trigger_id)  # Blocks until training is done.
-                # Start evaluation
-                if "evaluation" in self.pipeline_config:
-                    self._start_evaluations(trigger_id, model_id, first_timestamp, last_timestamp)
-            else:
-                logger.info(f"Skipping training on empty trigger {trigger_id}]")
-            self._persist_pipeline_log()
-
-            self.num_triggers = self.num_triggers + 1
-            if self.maximum_triggers is not None and self.num_triggers >= self.maximum_triggers:
-                return len(triggering_idx_list)
-
-        # we have to inform the Selector about the remaining data in this batch.
-        if len(triggering_idx_list) == 0:
-            remaining_data = batch
-        else:
-            remaining_data = batch[triggering_idx_list[-1] + 1 :]
-
-        logger.info(f"There are {len(remaining_data)} data points remaining after the trigger.")
-        if len(remaining_data) > 0:
-            # These data points will be included in the next trigger
-            # because we inform the Selector about them,
-            # just like other batches with no trigger at all are included.
-            self._sw.start("selector_inform", overwrite=True)
-            selector_log = self.grpc.inform_selector(self.pipeline_id, remaining_data)
-            self.pipeline_log["supervisor"]["selector_informs"].append(
-                {"total_selector_time": self._sw.stop(), "selector_log": selector_log}
-            )
-            if self.remaining_data_range is not None:
-                # extend the range from last time
-                self.remaining_data_range = (self.remaining_data_range[0], remaining_data[-1][1])
-            else:
-                self.remaining_data_range = (remaining_data[0][1], remaining_data[-1][1])
-        else:
-            self.remaining_data_range = None
-        return len(triggering_idx_list)
-
-    def _init_evaluation_writer(self, name: str, trigger_id: int) -> JsonResultWriter:
-        return self.supervisor_supported_eval_result_writers[name](self.pipeline_id, trigger_id, self.eval_directory)
-
-    def replay_data(self) -> None:
-        assert self.start_replay_at is not None, "Cannot call replay_data when start_replay_at is None"
-        dataset_id = self.pipeline_config["data"]["dataset_id"]
-        self._update_pipeline_stage_and_enqueue_msg(
-            PipelineStage.REPLAY_DATA, MsgType.DATASET, dataset_submsg(dataset_id)
-        )
-        logger.info("Starting data replay.")
-
-        if self.stop_replay_at is None:
-            generator = self.grpc.get_new_data_since(dataset_id, self.start_replay_at)
-        else:
-            generator = self.grpc.get_data_in_interval(dataset_id, self.start_replay_at, self.stop_replay_at)
-
-        for replay_data, request_time in generator:
-            assert isinstance(replay_data, list)
-            assert isinstance(request_time, int)
-            self.pipeline_log["supervisor"]["new_data_requests"].append(
-                {"time": request_time, "num_items": len(replay_data)}
-            )
-            self._handle_new_data(replay_data)
-            self._persist_pipeline_log()
-            if self.maximum_triggers is not None and self.num_triggers >= self.maximum_triggers:
-                logger.info("Exiting replay loop due to trigger limit.")
-                break
-
-        self._update_pipeline_stage_and_enqueue_msg(
-            PipelineStage.REPLAY_DATA_DONE, MsgType.DATASET, dataset_submsg(dataset_id)
-        )
-
-    def shutdown_trainer(self) -> None:
-        if self.current_training_id is not None:
-            self.grpc.stop_training_at_trainer_server(self.current_training_id)
-
-    def wait_for_new_data(self, start_timestamp: int) -> None:
-        last_timestamp = start_timestamp
-        dataset_id = self.pipeline_config["data"]["dataset_id"]
-
-        previous_largest_keys = set()
-
-        logger.info("Press CTRL+C at any time to shutdown the pipeline.")
-
-        continue_running = True
-
-        try:
-            while continue_running:
-                self._update_pipeline_stage_and_enqueue_msg(
-                    PipelineStage.FETCH_NEW_DATA, MsgType.DATASET, dataset_submsg(dataset_id)
-                )
-
-                trigger_occured = False
-                largest_keys = set()
-                for new_data, _ in self.grpc.get_new_data_since(dataset_id, last_timestamp):
-                    # Since get_new_data_since is inclusive, we need to filter out the keys
-                    # we have already processed in the previous get_new_data_since request
-                    new_data = [
-                        (key, timestamp, label)
-                        for (key, timestamp, label) in new_data
-                        if key not in previous_largest_keys
-                    ]
-                    last_timestamp = (
-                        max((timestamp for (_, timestamp, _) in new_data)) if len(new_data) > 0 else last_timestamp
-                    )
-
-                    # Remember all data points with last_timestamp so we do not process them again in the next iteration
-                    # We use a set to have a O(1) check in the line above.
-                    largest_keys.update({key for (key, timestamp, _) in new_data if timestamp == last_timestamp})
-
-                    if self._handle_new_data(new_data):
-                        trigger_occured = True
-
-                    if self.maximum_triggers is not None and self.num_triggers >= self.maximum_triggers:
-                        continue_running = False
-
-                previous_largest_keys = largest_keys
-                if not trigger_occured:
-                    self._update_pipeline_stage_and_enqueue_msg(
-                        PipelineStage.WAIT_FOR_NEW_DATA, MsgType.DATASET, dataset_submsg(dataset_id)
-                    )
-                    sleep(2)
-
-        except KeyboardInterrupt:
-            logger.info("Initiating shutdown.")
-            self.shutdown_trainer()
-            logger.info("Shutdown successful.")
-
-    def execute(self) -> None:
-        logger.info(f"[pipeline {self.pipeline_id}] Get dataset selector batch size.")
-        self.get_dataset_selector_batch_size()
-
-        logger.info(f"[pipeline {self.pipeline_id}] Start executing, experiment mode {self.experiment_mode}.")
-        if self.experiment_mode:
-            self.replay_data()
-        else:
-            self.wait_for_new_data(self.start_timestamp)
-
-        logger.info(f"[pipeline {self.pipeline_id}] Execution done. Persist log.")
-        self._update_pipeline_stage_and_enqueue_msg(PipelineStage.DONE, MsgType.GENERAL)
-        self._persist_pipeline_log()
+    def _shutdown_trainer(self) -> None:
+        if self.state.current_training_id is not None:
+            self.grpc.stop_training_at_trainer_server(self.state.current_training_id)
 
 
-# pylint: disable=too-many-locals
-def execute_pipeline(
-    start_timestamp: int,
-    pipeline_id: int,
-    modyn_config: dict,
-    pipeline_config: dict,
-    eval_directory: str,
-    supervisor_supported_eval_result_writers: dict,
-    exception_queue: mp.Queue,
-    pipeline_status_queue: mp.Queue,
-    training_status_queue: mp.Queue,
-    eval_status_queue: mp.Queue,
-    start_replay_at: Optional[int] = None,
-    stop_replay_at: Optional[int] = None,
-    maximum_triggers: Optional[int] = None,
-) -> None:
+def execute_pipeline(options: PipelineOptions) -> None:
     try:
-        pipeline = PipelineExecutor(
-            start_timestamp,
-            pipeline_id,
-            modyn_config,
-            pipeline_config,
-            eval_directory,
-            supervisor_supported_eval_result_writers,
-            pipeline_status_queue,
-            training_status_queue,
-            eval_status_queue,
-            start_replay_at,
-            stop_replay_at,
-            maximum_triggers,
-        )
-        pipeline.init_cluster_connection()
-        pipeline.execute()
+        PipelineExecutor(options).run()
+
     except Exception:  # pylint: disable=broad-except
         exception_msg = traceback.format_exc()
         logger.error(exception_msg)
-        exception_queue.put(exception_msg)
+        options.exception_queue.put(exception_msg)
         sys.exit(EXCEPTION_EXITCODE)

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -10,7 +10,7 @@ from time import sleep
 from typing import Callable, Generator, TypeVar, cast
 
 import pandas as pd
-from modyn.config.schema.pipeline import DatasetConfig, ResultWriterType
+from modyn.config.schema.pipeline import EvalDataConfig, ResultWriterType
 
 # pylint: disable-next=no-name-in-module
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import EvaluateModelResponse, EvaluationAbortedReason
@@ -743,7 +743,7 @@ class PipelineExecutor:
         trigger_id: int,
         training_id: int,
         model_id: int,
-        eval_dataset_config: DatasetConfig,
+        eval_dataset_config: EvalDataConfig,
         interval_start: int | None,
         interval_end: int | None,
     ) -> dict[int, EvaluationStatusReporter] | None:

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -118,12 +118,12 @@ def pipeline_stage(  # type: ignore[no-untyped-def]
                 if track and stage_log.info:
                     # ensure df exists
                     old_df = state.tracking.get(stage_log.id, None)
-                    if (new_rows := stage_log.online_df(extended=True)) is not None:
+                    if (new_rows := stage_log.df(extended=True)) is not None:
                         state.tracking[stage_log.id] = pd.concat([old_df, new_rows]) if old_df is not None else new_rows
 
                 # record logs
                 if log:
-                    logs.supervisor.stage_runs.append(stage_log)
+                    logs.supervisor_logs.stage_runs.append(stage_log)
                     logger.info(f"[pipeline {state.pipeline_id}] Finished <{stage.name}>.")
 
             state.stage = stage
@@ -245,7 +245,7 @@ class PipelineExecutor:
             replay_data_generator = self.grpc.get_data_in_interval(s.dataset_id, s.start_replay_at, s.stop_replay_at)
 
         for replay_data, request_time in replay_data_generator:
-            # setting sample here to have correct logs in process_new_data
+            # setting sample info here to have correct logs in process_new_data
             s.current_sample_time = replay_data[0][1] if replay_data else s.start_timestamp
             s.current_sample_index = replay_data[0][0] if replay_data else 0
 
@@ -317,7 +317,7 @@ class PipelineExecutor:
             )
             largest_keys.update({key for (key, timestamp, _) in fetched_data if timestamp == s.max_timestamp})
 
-            # setting sample here to have correct logs in process_new_data
+            # setting sample info here to have correct logs in process_new_data
             s.current_sample_time = fetched_data[0][1] if fetched_data else s.start_timestamp
             s.current_sample_index = fetched_data[0][0] if fetched_data else 0
 

--- a/modyn/supervisor/internal/supervisor.py
+++ b/modyn/supervisor/internal/supervisor.py
@@ -23,6 +23,7 @@ from modyn.supervisor.internal.grpc.enums import MsgType, PipelineStage, Pipelin
 from modyn.supervisor.internal.grpc.template_msg import exit_submsg, pipeline_res_msg, pipeline_stage_msg
 from modyn.supervisor.internal.grpc_handler import GRPCHandler
 from modyn.supervisor.internal.pipeline_executor import execute_pipeline
+from modyn.supervisor.internal.pipeline_executor.models import PipelineOptions
 from modyn.supervisor.internal.utils import PipelineInfo
 from modyn.utils import is_directory_writable, model_available, trigger_available
 from pydantic import ValidationError
@@ -191,6 +192,7 @@ class Supervisor:
         stop_replay_at: Optional[int] = None,
         maximum_triggers: Optional[int] = None,
     ) -> dict:
+        # pylint: disable-msg=too-many-locals
         pipeline_config_model = self.validate_pipeline_config(pipeline_config)
         if not pipeline_config_model:
             return pipeline_res_msg(exception="Invalid pipeline configuration")
@@ -214,24 +216,22 @@ class Supervisor:
             return pipeline_res_msg(exception="Failed to register pipeline")
 
         try:
-            process = Process(
-                target=execute_pipeline,
-                args=(
-                    start_timestamp,
-                    pipeline_id,
-                    self.modyn_config.model_dump(by_alias=True),
-                    pipeline_config,
-                    eval_directory,
-                    self.supported_evaluation_result_writers,
-                    exception_queue,
-                    pipeline_status_queue,
-                    training_status_queue,
-                    eval_status_queue,
-                    start_replay_at,
-                    stop_replay_at,
-                    maximum_triggers,
-                ),
+            pipeline_options = PipelineOptions(
+                start_timestamp=start_timestamp,
+                pipeline_id=pipeline_id,
+                modyn_config=self.modyn_config,
+                pipeline_config=pipeline_config_model,
+                eval_directory=pathlib.Path(eval_directory),
+                supervisor_supported_eval_result_writers=self.supported_evaluation_result_writers,
+                exception_queue=exception_queue,
+                pipeline_status_queue=pipeline_status_queue,
+                training_status_queue=training_status_queue,
+                eval_status_queue=eval_status_queue,
+                start_replay_at=start_replay_at,
+                stop_replay_at=stop_replay_at,
+                maximum_triggers=maximum_triggers,
             )
+            process = Process(target=execute_pipeline, args=(pipeline_options,))
             process.start()
             self._pipeline_process_dict[pipeline_id] = PipelineInfo(
                 process,
@@ -241,8 +241,9 @@ class Supervisor:
                 eval_status_queue,
             )
             return pipeline_res_msg(pipeline_id=pipeline_id)
-        except Exception:  # pylint: disable=broad-except
-            return pipeline_res_msg(pipeline_id=pipeline_id, exception="Failed to execute pipeline")
+        except Exception as ex:  # pylint: disable=broad-except
+            raise ex
+            # return pipeline_res_msg(pipeline_id=pipeline_id, exception="Failed to execute pipeline")
 
     # ---------------------------------------------------- Helpers --------------------------------------------------- #
 

--- a/modyn/tests/conftest.py
+++ b/modyn/tests/conftest.py
@@ -3,6 +3,8 @@
 import pytest
 from modyn.config.schema.config import (
     DatabaseConfig,
+    DatasetBinaryFileWrapperConfig,
+    DatasetsConfig,
     EvaluatorConfig,
     MetadataDatabaseConfig,
     ModelStorageConfig,
@@ -17,6 +19,8 @@ from modyn.config.schema.pipeline import (
     DatasetConfig,
     EvaluationConfig,
     FullModelStrategy,
+    MatrixEvalStrategyConfig,
+    MatrixEvalStrategyModel,
     Metric,
     ModelConfig,
     ModynPipelineConfig,
@@ -128,6 +132,25 @@ def dummy_system_config(
     )
 
 
+@pytest.fixture
+def dummy_dataset_config() -> DatasetConfig:
+    return DatasetsConfig(
+        name="test",
+        description="",
+        version="",
+        base_path="",
+        filesystem_wrapper_type="BinaryFilesystemWrapper",
+        file_wrapper_type="BinaryFileWrapper",
+        file_wrapper_config=DatasetBinaryFileWrapperConfig(
+            file_extension=".bin",
+            byteorder="little",
+            record_size=8,
+            label_size=4,
+        ),
+        selector_batch_size=128,
+    )
+
+
 # ----------------------------------------------------- Pipeline ----------------------------------------------------- #
 
 
@@ -152,8 +175,17 @@ def pipeline_training_config() -> TrainingConfig:
 
 
 @pytest.fixture
-def pipeline_evaluation_config() -> EvaluationConfig:
+def eval_strategies_config() -> MatrixEvalStrategyModel:
+    return MatrixEvalStrategyModel(
+        name="MatrixEvalStrategy",
+        config=MatrixEvalStrategyConfig(eval_every="100s", eval_start_from=0, eval_end_at=300),
+    )
+
+
+@pytest.fixture
+def pipeline_evaluation_config(eval_strategies_config: MatrixEvalStrategyModel) -> EvaluationConfig:
     return EvaluationConfig(
+        eval_strategy=eval_strategies_config,
         device="cpu",
         datasets=[
             DatasetConfig(

--- a/modyn/tests/conftest.py
+++ b/modyn/tests/conftest.py
@@ -133,7 +133,7 @@ def dummy_system_config(
 
 
 @pytest.fixture
-def dummy_dataset_config() -> DatasetConfig:
+def dummy_dataset_config() -> DatasetsConfig:
     return DatasetsConfig(
         name="test",
         description="",

--- a/modyn/tests/supervisor/internal/evaluation_result_writer/test_json_result_writer.py
+++ b/modyn/tests/supervisor/internal/evaluation_result_writer/test_json_result_writer.py
@@ -4,13 +4,13 @@ import tempfile
 
 # pylint: disable=no-name-in-module
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import EvaluationData
-from modyn.supervisor.internal.evaluation_result_writer import JsonResultWriter
+from modyn.supervisor.internal.evaluation_result_writer import DedicatedJsonResultWriter
 
 
 def test_json_writer():
     with tempfile.TemporaryDirectory() as path:
         eval_dir = pathlib.Path(path)
-        writer = JsonResultWriter(10, 15, eval_dir)
+        writer = DedicatedJsonResultWriter(10, 15, eval_dir)
         writer.add_evaluation_data("mnist", 1000, [EvaluationData(metric="Accuracy", result=0.5)])
         writer.store_results()
 

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -1,18 +1,36 @@
 # pylint: disable=unused-argument,redefined-outer-name
+import datetime
 import multiprocessing as mp
 import os
 import pathlib
 import shutil
-from typing import Optional
+import time
+from dataclasses import dataclass
+from typing import Generator, overload
 from unittest import mock
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
+
+import pytest
+from modyn.config.schema.config import DatasetsConfig, ModynConfig, SupervisorConfig
+from modyn.config.schema.pipeline import EvaluationConfig, ModynPipelineConfig
 
 # pylint: disable=no-name-in-module
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import EvaluateModelResponse, EvaluationAbortedReason
 from modyn.supervisor.internal.eval_strategies.matrix_eval_strategy import MatrixEvalStrategy
 from modyn.supervisor.internal.evaluation_result_writer import JsonResultWriter, TensorboardResultWriter
+from modyn.supervisor.internal.grpc.enums import PipelineStage, PipelineType
 from modyn.supervisor.internal.grpc_handler import GRPCHandler
-from modyn.supervisor.internal.pipeline_executor import EVALUATION_RESULTS, PipelineExecutor, execute_pipeline
+from modyn.supervisor.internal.pipeline_executor import PipelineExecutor, execute_pipeline
+from modyn.supervisor.internal.pipeline_executor.models import (
+    ConfigLogs,
+    ExecutionState,
+    PipelineLogs,
+    PipelineOptions,
+    SingleEvaluationInfo,
+    StageInfo,
+    StageLog,
+)
+from modyn.supervisor.internal.pipeline_executor.pipeline_executor import pipeline_stage
 
 EVALUATION_DIRECTORY: pathlib.Path = pathlib.Path(os.path.realpath(__file__)).parent / "test_eval_dir"
 SUPPORTED_EVAL_RESULT_WRITERS: dict = {"json": JsonResultWriter, "tensorboard": TensorboardResultWriter}
@@ -25,81 +43,86 @@ TRAINING_STATUS_QUEUE = mp.Queue()
 EVAL_STATUS_QUEUE = mp.Queue()
 
 
-def get_minimal_training_config() -> dict:
-    return {
-        "gpus": 1,
-        "device": "cpu",
-        "dataloader_workers": 1,
-        "use_previous_model": True,
-        "initial_model": "random",
-        "batch_size": 42,
-        "optimizers": [
-            {"name": "default1", "algorithm": "SGD", "source": "PyTorch", "param_groups": [{"module": "model"}]},
-        ],
-        "optimization_criterion": {"name": "CrossEntropyLoss"},
-        "checkpointing": {"activated": False},
-        "selection_strategy": {"name": "NewDataStrategy", "maximum_keys_in_memory": 10},
-    }
+@pytest.fixture
+def minimal_system_config(dummy_system_config: ModynConfig) -> ModynConfig:
+    config = dummy_system_config.model_copy()
+    config.supervisor = SupervisorConfig(hostname="localhost", port=50051, eval_directory=EVALUATION_DIRECTORY)
+    return config
 
 
-def get_minimal_evaluation_config() -> dict:
-    return {
-        "eval_strategy": get_minimal_eval_strategies_config(),
-        "device": "cpu",
-        "datasets": [
-            {
-                "dataset_id": "MNIST_eval",
-                "bytes_parser_function": "def bytes_parser_function(data: bytes) -> bytes:\n\treturn data",
-                "dataloader_workers": 2,
-                "batch_size": 64,
-                "metrics": [{"name": "Accuracy"}],
-            }
-        ],
-    }
+@pytest.fixture
+def minimal_pipeline_config(dummy_pipeline_config: ModynPipelineConfig) -> ModynPipelineConfig:
+    config = dummy_pipeline_config.model_copy()
+    return config
 
 
-def get_minimal_pipeline_config() -> dict:
-    return {
-        "pipeline": {"name": "Test"},
-        "model": {"id": "ResNet18"},
-        "model_storage": {"full_model_strategy": {"name": "PyTorchFullModel"}},
-        "training": get_minimal_training_config(),
-        "data": {"dataset_id": "test", "bytes_parser_function": "def bytes_parser_function(x):\n\treturn x"},
-        "trigger": {"id": "DataAmountTrigger", "trigger_config": {"data_points_for_trigger": 1}},
-    }
+def get_dummy_pipeline_options(system_config: ModynConfig, pipeline_config: ModynPipelineConfig) -> PipelineOptions:
+    return PipelineOptions(
+        start_timestamp=START_TIMESTAMP,
+        pipeline_id=PIPELINE_ID,
+        modyn_config=system_config,
+        pipeline_config=pipeline_config,
+        eval_directory=str(EVALUATION_DIRECTORY),
+        supervisor_supported_eval_result_writers=SUPPORTED_EVAL_RESULT_WRITERS,
+        exception_queue=EXCEPTION_QUEUE,
+        pipeline_status_queue=PIPELINE_STATUS_QUEUE,
+        training_status_queue=TRAINING_STATUS_QUEUE,
+        eval_status_queue=EVAL_STATUS_QUEUE,
+    )
 
 
-def get_minimal_eval_strategies_config() -> dict:
-    return {
-        "name": "MatrixEvalStrategy",
-        "config": {
-            "eval_every": "100s",
-            "eval_start_from": 0,
-            "eval_end_at": 300,
-        },
-    }
+@pytest.fixture
+def dummy_pipeline_options(
+    minimal_system_config: ModynConfig, minimal_pipeline_config: ModynPipelineConfig
+) -> PipelineOptions:
+    return get_dummy_pipeline_options(minimal_system_config, minimal_pipeline_config)
 
 
-def get_minimal_system_config() -> dict:
-    return {}
+@pytest.fixture
+def dummy_execution_state(dummy_pipeline_options: PipelineOptions) -> ExecutionState:
+    return ExecutionState(**vars(dummy_pipeline_options))
 
 
-def noop_constructor_mock(
-    self,
-    start_timestamp: int,
-    pipeline_id: int,
-    modyn_config: dict,
-    pipeline_config: dict,
-    eval_directory: str,
-    supervisor_supported_eval_result_writers: dict,
-    pipeline_status_queue: mp.Queue,
-    training_status_queue: mp.Queue,
-    eval_status_queue: mp.Queue,
-    start_replay_at: Optional[int] = None,
-    stop_replay_at: Optional[int] = None,
-    maximum_triggers: Optional[int] = None,
-) -> None:
-    pass
+@pytest.fixture
+def dummy_logs(dummy_pipeline_options: PipelineOptions) -> PipelineLogs:
+    options = dummy_pipeline_options
+    return PipelineLogs(
+        pipeline_id=PIPELINE_ID,
+        config=ConfigLogs(system=options.modyn_config, pipeline=options.pipeline_config),
+        experiment=options.experiment_mode,
+        start_replay_at=options.start_replay_at,
+        stop_replay_at=options.stop_replay_at,
+    )
+
+
+@pytest.fixture
+def dummy_stage_log() -> StageLog:
+    return StageLog(id="dummy", start=0, sample_idx=1, sample_time=1000)
+
+
+@overload
+def get_non_connecting_pipeline_executor(
+    system_config: ModynConfig, pipeline_config: ModynPipelineConfig
+) -> PipelineExecutor: ...
+
+
+@overload
+def get_non_connecting_pipeline_executor(pipeline_options: PipelineOptions) -> PipelineExecutor: ...
+
+
+def get_non_connecting_pipeline_executor(
+    pipeline_options: PipelineOptions | None = None,
+    system_config: ModynConfig | None = None,
+    pipeline_config: ModynPipelineConfig | None = None,
+) -> PipelineExecutor:
+    if pipeline_options:
+        return PipelineExecutor(pipeline_options)
+    return PipelineExecutor(get_dummy_pipeline_options(system_config, pipeline_config))
+
+
+@pytest.fixture
+def non_connecting_pipeline_executor(dummy_pipeline_options: PipelineOptions) -> PipelineExecutor:
+    return PipelineExecutor(dummy_pipeline_options)
 
 
 def sleep_mock(duration: int):
@@ -116,199 +139,222 @@ def teardown():
     shutil.rmtree(EVALUATION_DIRECTORY)
 
 
-def get_non_connecting_pipeline_executor(pipeline_config=None) -> PipelineExecutor:
-    if pipeline_config is None:
-        pipeline_config = get_minimal_pipeline_config()
-    pipeline_executor = PipelineExecutor(
-        START_TIMESTAMP,
-        PIPELINE_ID,
-        get_minimal_system_config(),
-        pipeline_config,
-        str(EVALUATION_DIRECTORY),
-        SUPPORTED_EVAL_RESULT_WRITERS,
-        PIPELINE_STATUS_QUEUE,
-        TRAINING_STATUS_QUEUE,
-        EVAL_STATUS_QUEUE,
+def test_initialization(non_connecting_pipeline_executor: PipelineExecutor) -> None:
+    assert non_connecting_pipeline_executor.state.stage == PipelineStage.INIT
+
+
+def test_pipeline_stage_decorator(dummy_pipeline_options: PipelineOptions) -> None:
+
+    class TestStageLogInfo(StageInfo):
+        name: str
+
+    class TestPipelineExecutor(PipelineExecutor):
+
+        @pipeline_stage(PipelineType.MAIN, PipelineStage.INIT, log=True, track=True)
+        def _stage_func(self, s: ExecutionState, log: StageLog) -> int:
+            time.sleep(0.1)
+            log.info = TestStageLogInfo(name="test")
+
+            return 1
+
+    pe = TestPipelineExecutor(dummy_pipeline_options)
+    t0 = datetime.datetime.now()
+    assert pe._stage_func(pe.state, pe.logs) == 1
+    t1 = datetime.datetime.now()
+
+    assert len(pe.logs.supervisor.stage_runs) == 1
+    assert pe.logs.supervisor.stage_runs[0].info.name == "test"
+    assert (pe.logs.supervisor.stage_runs[0].start - t0).total_seconds() < 8e-3
+    assert (pe.logs.supervisor.stage_runs[0].end - t1).total_seconds() < 8e-3
+    assert abs((pe.logs.supervisor.stage_runs[0].duration - (t1 - t0)).total_seconds()) < 8e-3
+
+
+def test_pipeline_stage_decorator_generator(dummy_pipeline_options: PipelineOptions) -> None:
+
+    class TestStageLogInfo(StageInfo):
+        elements: list[int]
+        finalized: bool = False
+
+    def create_generator(x: int = 3) -> Generator[int, None, None]:
+        time.sleep(0.1)
+        for i in range(x):
+            time.sleep(0.02)
+            yield i
+
+    class TestPipelineExecutor(PipelineExecutor):
+
+        @pipeline_stage(PipelineType.MAIN, PipelineStage.INIT, log=True, track=True)
+        def _stage_func(self, s: ExecutionState, log: StageLog) -> Generator[int, None, None]:
+            try:
+                time.sleep(0.1)
+                log.info = TestStageLogInfo(elements=[])
+                for i in create_generator():
+                    time.sleep(0.02)
+                    log.info.elements.append(i)
+                    yield i
+            finally:
+                log.info.finalized = True
+
+    times: list[datetime.timedelta] = []
+    gen_values: list[int] = []
+
+    last_time = datetime.datetime.now()
+    pe = TestPipelineExecutor(dummy_pipeline_options)
+    gen = pe._stage_func(pe.state, pe.logs)
+    times.append(datetime.datetime.now() - last_time)
+    last_time = datetime.datetime.now()
+    for x in gen:
+        gen_values.append(x)
+        times.append(datetime.datetime.now() - last_time)
+        time.sleep(0.2)  # this should not be counted in the time of the generator
+        last_time = datetime.datetime.now()
+
+        if x == 2:
+            break  # stop the generator early
+
+    gen = None  # make sure the generator is closed
+
+    assert gen_values == [0, 1, 2]
+    assert len(times) == 4
+
+    assert pe.logs.supervisor.stage_runs[0].info.elements == [0, 1, 2]
+    assert pe.logs.supervisor.stage_runs[0].info.finalized
+
+    assert abs(times[0].total_seconds()) < 0.005
+    assert abs(times[1].total_seconds() - 0.1 * 2 - 0.02 * 2) < 0.035  # higher tolerance due to pipeline_stage overhead
+    assert abs(times[2].total_seconds() - 0.02 * 2) < 0.025
+    assert abs(times[3].total_seconds() - 0.02 * 2) < 0.025
+
+
+def test_get_dataset_selector_batch_size_given(
+    minimal_system_config: ModynConfig,
+    minimal_pipeline_config: ModynPipelineConfig,
+    dummy_dataset_config: DatasetsConfig,
+) -> None:
+    dataset1 = dummy_dataset_config.model_copy()
+    dataset1.selector_batch_size = 2048
+    minimal_system_config.storage.datasets = [dataset1]
+    pe = get_non_connecting_pipeline_executor(
+        system_config=minimal_system_config, pipeline_config=minimal_pipeline_config
     )
-    return pipeline_executor
+    pe.state.selector_batch_size == 2048
 
 
-def test_initialization() -> None:
-    get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-
-
-def test_get_dataset_selector_batch_size_given():
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-
-    pe.pipeline_config = get_minimal_pipeline_config()
-    pe.modyn_config = {
-        "storage": {
-            "datasets": [{"name": "test", "selector_batch_size": 2048}, {"name": "test1", "selector_batch_size": 128}]
-        }
-    }
-    pe.get_dataset_selector_batch_size()
-    assert pe._selector_batch_size == 2048
-
-
-def test_get_dataset_selector_batch_size_not_given():
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-
-    pe.pipeline_config = get_minimal_pipeline_config()
-    pe.modyn_config = {"storage": {"datasets": [{"name": "test"}]}}
-    pe.get_dataset_selector_batch_size()
-    assert pe._selector_batch_size == 128
-
-
-def test_shutdown_trainer():
+def test_shutdown_trainer() -> None:
     # TODO(MaxiBoether): implement
     pass
 
 
-@patch.object(GRPCHandler, "get_new_data_since", return_value=[([(10, 42, 0), (11, 43, 1)], {})])
-@patch.object(PipelineExecutor, "_handle_new_data", return_value=False, side_effect=KeyboardInterrupt)
-def test_wait_for_new_data(test__handle_new_data: MagicMock, test_get_new_data_since: MagicMock):
-    # This is a simple test and does not the inclusivity filtering!
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
+@patch.object(GRPCHandler, "get_new_data_since", return_value=[([(10, 42, 0), (11, 43, 1)], 99)])
+@patch.object(PipelineExecutor, "_process_new_data", side_effect=[[10, 11]])
+def test_fetch_new_data(
+    test__process_new_data: MagicMock,
+    test_get_new_data_since: MagicMock,
+    non_connecting_pipeline_executor: PipelineExecutor,
+    dummy_execution_state: ExecutionState,
+    dummy_logs: PipelineLogs,
+):
+    dummy_execution_state.max_timestamp = 21
+    triggers = non_connecting_pipeline_executor._fetch_new_data(dummy_execution_state, dummy_logs)
 
-    pe.wait_for_new_data(21)
     test_get_new_data_since.assert_called_once_with("test", 21)
-    test__handle_new_data.assert_called_once_with([(10, 42, 0), (11, 43, 1)])
+    test__process_new_data.assert_called_once_with(ANY, ANY, [(10, 42, 0), (11, 43, 1)], 99)
+    assert triggers == 2
 
 
-@patch.object(GRPCHandler, "get_new_data_since", return_value=[([(10, 42, 0)], {}), ([(11, 43, 1)], {})])
-@patch.object(PipelineExecutor, "_handle_new_data", return_value=False, side_effect=[None, KeyboardInterrupt])
-def test_wait_for_new_data_batched(test__handle_new_data: MagicMock, test_get_new_data_since: MagicMock):
-    # This is a simple test and does not the inclusivity filtering!
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-
-    pe.wait_for_new_data(21)
+@patch.object(GRPCHandler, "get_new_data_since", return_value=[([(10, 42, 0)], 98), ([(11, 43, 1)], 99)])
+@patch.object(PipelineExecutor, "_process_new_data", side_effect=[[10], [11]])
+def test_fetch_new_data_batched(
+    test__process_new_data: MagicMock,
+    test_get_new_data_since: MagicMock,
+    non_connecting_pipeline_executor: PipelineExecutor,
+    dummy_execution_state: ExecutionState,
+    dummy_logs: PipelineLogs,
+) -> None:
+    dummy_execution_state.max_timestamp = 21
+    triggers = non_connecting_pipeline_executor._fetch_new_data(dummy_execution_state, dummy_logs)
     test_get_new_data_since.assert_called_once_with("test", 21)
 
-    expected_calls = [
-        call([(10, 42, 0)]),
-        call([(11, 43, 1)]),
-    ]
-
-    assert test__handle_new_data.call_args_list == expected_calls
+    expected_calls = [call(ANY, ANY, [(10, 42, 0)], 98), call(ANY, ANY, [(11, 43, 1)], 99)]
+    assert test__process_new_data.call_args_list == expected_calls
+    assert triggers == 2
 
 
-def test_wait_for_new_data_filtering():
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
+def test_serve_online_data(
+    non_connecting_pipeline_executor: PipelineExecutor, dummy_execution_state: ExecutionState, dummy_logs: PipelineLogs
+) -> None:
+    pe = non_connecting_pipeline_executor
 
-    mocked__handle_new_data_return_vals = [True, True, KeyboardInterrupt]
+    mocked__process_new_data_return_vals = [[10], [], []]
     mocked_get_new_data_since = [
-        [([(10, 42, 0), (11, 43, 0), (12, 43, 1)], {})],
-        [([(11, 43, 0), (12, 43, 1), (13, 43, 2), (14, 45, 3)], {})],
-        [([], {})],
-        ValueError,
+        [([(10, 42, 0), (11, 43, 0), (12, 43, 1)], 97)],
+        [([(11, 43, 0), (12, 43, 1), (13, 43, 2), (14, 45, 3)], 98)],
+        [([], 99)],
+        KeyboardInterrupt,
     ]
 
     handle_mock: MagicMock
-    with patch.object(pe, "_handle_new_data", side_effect=mocked__handle_new_data_return_vals) as handle_mock:
+    with patch.object(pe, "_process_new_data", side_effect=mocked__process_new_data_return_vals) as handle_mock:
         get_new_data_mock: MagicMock
         with patch.object(pe.grpc, "get_new_data_since", side_effect=mocked_get_new_data_since) as get_new_data_mock:
-            pe.wait_for_new_data(21)
+            dummy_execution_state.max_timestamp = 21
+            pe._serve_online_data(dummy_execution_state, dummy_logs)
 
             assert handle_mock.call_count == 3
-            assert get_new_data_mock.call_count == 3
+            assert get_new_data_mock.call_count == 3 + 1
 
             expected_handle_mock_arg_list = [
-                call([(10, 42, 0), (11, 43, 0), (12, 43, 1)]),
-                call([(13, 43, 2), (14, 45, 3)]),
-                call([]),
+                call(ANY, ANY, [(10, 42, 0), (11, 43, 0), (12, 43, 1)], 97),
+                call(ANY, ANY, [(13, 43, 2), (14, 45, 3)], 98),
+                call(ANY, ANY, [], 99),
             ]
             assert handle_mock.call_args_list == expected_handle_mock_arg_list
 
-            expected_get_new_data_arg_list = [call("test", 21), call("test", 43), call("test", 45)]
+            expected_get_new_data_arg_list = [call("test", 21), call("test", 43), call("test", 45), call("test", 45)]
             assert get_new_data_mock.call_args_list == expected_get_new_data_arg_list
 
 
-def test_wait_for_new_data_filtering_batched():
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-
-    mocked__handle_new_data_return_vals = [True, True, True, True, True, KeyboardInterrupt]
-    mocked_get_new_data_since = [
-        [([(10, 42, 0), (11, 43, 0)], {}), ([(12, 43, 1)], {})],
-        [([(11, 43, 0)], {}), ([(12, 43, 1), (13, 43, 2)], {}), ([(14, 45, 3)], {})],
-        [([], {})],
-        ValueError,
-    ]
-
-    handle_mock: MagicMock
-    with patch.object(pe, "_handle_new_data", side_effect=mocked__handle_new_data_return_vals) as handle_mock:
-        get_new_data_mock: MagicMock
-        with patch.object(pe.grpc, "get_new_data_since", side_effect=mocked_get_new_data_since) as get_new_data_mock:
-            pe.wait_for_new_data(21)
-
-            assert handle_mock.call_count == 6
-            assert get_new_data_mock.call_count == 3
-
-            expected_handle_mock_arg_list = [
-                call([(10, 42, 0), (11, 43, 0)]),
-                call([(12, 43, 1)]),
-                call([]),
-                call([(13, 43, 2)]),
-                call([(14, 45, 3)]),
-                call([]),
-            ]
-            assert handle_mock.call_args_list == expected_handle_mock_arg_list
-
-            expected_get_new_data_arg_list = [call("test", 21), call("test", 43), call("test", 45)]
-            assert get_new_data_mock.call_args_list == expected_get_new_data_arg_list
-
-
-def test__handle_new_data_with_batch():
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe._selector_batch_size = 3
+@pytest.mark.parametrize(
+    "selector_batch_size, batching_return_vals, expected_process_new_data_batch_args",
+    [
+        (
+            3,
+            [[10], [14, 15], []],
+            [
+                call(ANY, ANY, [(10, 1), (11, 2), (12, 3)]),
+                call(ANY, ANY, [(13, 4), (14, 5), (15, 6)]),
+                call(ANY, ANY, [(16, 7), (17, 8)]),
+            ],
+        ),
+        (200, [[10, 14, 15]], None),  # large batch  # use new_data
+        (200, [[]], None),  # no triggers  # use new_data
+    ],
+)
+def test__process_new_data(
+    selector_batch_size: int,
+    batching_return_vals: list[list[int]],
+    expected_process_new_data_batch_args: list,
+    non_connecting_pipeline_executor: PipelineExecutor,
+    dummy_execution_state: ExecutionState,
+) -> None:
+    pe = non_connecting_pipeline_executor
     new_data = [(10, 1), (11, 2), (12, 3), (13, 4), (14, 5), (15, 6), (16, 7), (17, 8)]
 
     batch_mock: MagicMock
-    with patch.object(pe, "_handle_new_data_batch") as batch_mock:
-        pe._handle_new_data(new_data)
-        expected_handle_new_data_batch_arg_list = [
-            call([(10, 1), (11, 2), (12, 3)]),
-            call([(13, 4), (14, 5), (15, 6)]),
-            call([(16, 7), (17, 8)]),
-        ]
-        assert batch_mock.call_args_list == expected_handle_new_data_batch_arg_list
+    with patch.object(ExecutionState, "selector_batch_size", new_callable=PropertyMock) as selector_batch_size_mock:
+        selector_batch_size_mock.return_value = selector_batch_size
+        with patch.object(PipelineExecutor, "_process_new_data_batch", side_effect=batching_return_vals) as batch_mock:
+            trigger_indexes = pe._process_new_data(dummy_execution_state, pe.logs, new_data, 0)
+            assert trigger_indexes == [x for sub in batching_return_vals for x in sub]
+            assert batch_mock.call_args_list == (expected_process_new_data_batch_args or [call(ANY, ANY, new_data)])
 
 
-def test__handle_new_data_with_large_batch():
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    new_data = [(10, 1), (11, 2), (12, 3), (13, 4), (14, 5), (15, 6), (16, 7), (17, 8)]
-
-    batch_mock: MagicMock
-    with patch.object(pe, "_handle_new_data_batch") as batch_mock:
-        pe._handle_new_data(new_data)
-        expected_handle_new_data_batch_arg_list = [call(new_data)]
-        assert batch_mock.call_args_list == expected_handle_new_data_batch_arg_list
-
-
-def test__handle_new_data():
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-
-    pe._selector_batch_size = 2
-    batching_return_vals = [False, True, False]
-    new_data = [(10, 1), (11, 2), (12, 3), (13, 4), (14, 5)]
-
-    batch_mock: MagicMock
-    with patch.object(pe, "_handle_new_data_batch", side_effect=batching_return_vals) as batch_mock:
-        result = pe._handle_new_data(new_data)
-        assert result
-
-        expected_handle_new_data_batch_arg_list = [
-            call([(10, 1), (11, 2)]),
-            call([(12, 3), (13, 4)]),
-            call([(14, 5)]),
-        ]
-        assert batch_mock.call_count == 3
-        assert batch_mock.call_args_list == expected_handle_new_data_batch_arg_list
-
-
-@patch.object(GRPCHandler, "inform_selector")
-def test__handle_new_data_batch_no_triggers(test_inform_selector: MagicMock):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.pipeline_id = 42
+@patch.object(GRPCHandler, "inform_selector", return_value={})
+def test__process_new_data_batch_no_triggers(
+    test_inform_selector: MagicMock, dummy_pipeline_options: PipelineOptions
+) -> None:
+    dummy_pipeline_options.pipeline_id = 42
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
     batch = [(10, 1), (11, 2)]
 
     with patch.object(pe.trigger, "inform") as inform_mock:
@@ -317,496 +363,483 @@ def test__handle_new_data_batch_no_triggers(test_inform_selector: MagicMock):
             yield from []
 
         inform_mock.side_effect = fake
-        assert not pe._handle_new_data_batch(batch)
+        assert len(pe._process_new_data_batch(pe.state, pe.logs, batch)) == 0
 
         inform_mock.assert_called_once_with(batch)
         test_inform_selector.assert_called_once_with(42, batch)
 
 
-@patch.object(PipelineExecutor, "_run_training")
+@pytest.mark.parametrize(
+    (
+        "batch,trigger_indexes,trigger_ids,inform_selector_and_trigger_expected_args,"
+        "train_and_store_model_expected_args,inform_selector_expected_args"
+    ),
+    [
+        (
+            [(10, 1, 0), (11, 2, 0), (12, 3, 0), (13, 4, 0), (14, 5, 0), (15, 6, 0), (16, 7, 0)],  # batch
+            [1, 3, 5],  # trigger_indexes
+            [(0, {}), (1, {}), (2, {})],  # trigger_id, selector_log
+            [  # inform_selector_and_trigger_expected_args
+                [(10, 1, 0), (11, 2, 0)],
+                [(12, 3, 0), (13, 4, 0)],
+                [(14, 5, 0), (15, 6, 0)],
+            ],
+            # train_and_store_model_expected_args
+            [call(ANY, ANY, 0), call(ANY, ANY, 1), call(ANY, ANY, 2)],
+            # inform_selector_expected_args
+            [call(42, [(16, 7, 0)])],
+        ),
+        (  # test empty triggers
+            [(10, 1, 5), (11, 2, 5), (12, 3, 5), (13, 4, 5), (14, 5, 5), (15, 6, 5), (16, 7, 5)],  # batch
+            [0, 0, 3],  # trigger_indexes
+            [(0, {}), (1, {}), (2, {})],  # (trigger_id, selector_log)
+            # inform_selector_and_trigger_expected_args
+            [[(10, 1, 5)], [], [(11, 2, 5), (12, 3, 5), (13, 4, 5)]],
+            # train_and_store_model_expected_args
+            [call(ANY, ANY, 0), call(ANY, ANY, 2)],
+            # inform_selector_expected_args
+            [call(42, [(14, 5, 5), (15, 6, 5), (16, 7, 5)])],
+        ),
+    ],
+)
+@patch.object(PipelineExecutor, "_train_and_store_model", return_value=(-1, -1))
 @patch.object(GRPCHandler, "inform_selector_and_trigger")
 @patch.object(GRPCHandler, "inform_selector")
 @patch.object(GRPCHandler, "get_number_of_samples")
-def test__handle_triggers_within_batch(
+def test__execute_triggers(
     test_get_number_of_samples: MagicMock,
     test_inform_selector: MagicMock,
     test_inform_selector_and_trigger: MagicMock,
-    test__run_training: MagicMock,
-):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.pipeline_id = 42
-    batch = [(10, 1), (11, 2), (12, 3), (13, 4), (14, 5), (15, 6), (16, 7)]
-    triggering_indices = [1, 3, 5]
-    trigger_ids = [(0, {}), (1, {}), (2, {})]
+    test__train_and_store_model: MagicMock,
+    batch: list[tuple[int, int]],
+    trigger_indexes: list[int],
+    trigger_ids: list[tuple[int, dict]],
+    inform_selector_and_trigger_expected_args: list,
+    train_and_store_model_expected_args: list,
+    inform_selector_expected_args: list,
+    dummy_pipeline_options: PipelineOptions,
+) -> None:
+    dummy_pipeline_options.pipeline_id = 42
+    dummy_pipeline_options.pipeline_config.evaluation = None
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+
     test_inform_selector_and_trigger.side_effect = trigger_ids
     test_inform_selector.return_value = {}
-    test_get_number_of_samples.return_value = len(batch)
+    test_get_number_of_samples.side_effect = [len(params) for params in inform_selector_and_trigger_expected_args]
 
-    pe._handle_triggers_within_batch(batch, triggering_indices)
+    pe._execute_triggers(pe.state, pe.logs, batch, trigger_indexes)
+    pe._inform_selector_remaining_data(pe.state, pe.logs, batch, trigger_indexes)
 
-    inform_selector_and_trigger_expected_args = [
-        call(42, [(10, 1), (11, 2)]),
-        call(42, [(12, 3), (13, 4)]),
-        call(42, [(14, 5), (15, 6)]),
-    ]
-    assert test_inform_selector_and_trigger.call_count == 3
-    assert test_inform_selector_and_trigger.call_args_list == inform_selector_and_trigger_expected_args
+    assert test_inform_selector_and_trigger.call_count == len(inform_selector_and_trigger_expected_args)
+    assert test_inform_selector_and_trigger.call_args_list == (
+        [call(42, params) for params in inform_selector_and_trigger_expected_args]
+    )
 
-    run_training_expected_args = [call(0), call(1), call(2)]
-    assert test__run_training.call_count == 3
-    assert test__run_training.call_args_list == run_training_expected_args
+    assert test__train_and_store_model.call_count == len(train_and_store_model_expected_args)
+    assert test__train_and_store_model.call_args_list == train_and_store_model_expected_args
 
-    assert test_inform_selector.call_count == 1
-    test_inform_selector.assert_called_once_with(42, [(16, 7)])
+    assert test_inform_selector.call_count == len(inform_selector_expected_args)
+    assert test_inform_selector.call_args_list == inform_selector_expected_args
 
 
-@patch.object(PipelineExecutor, "_run_training")
+@dataclass
+class _BatchConfig:
+    data: list[tuple[int, int, int]]  # (key, timestamp, label)
+    trigger_indexes: list[int]
+    get_num_samples: list[int]  # sequence of return values of get_number_of_samples
+    remaining_data_range: tuple[int, int] | None = None
+    expected_tracking: dict[str, list[int | None]] | None = None
+
+
+@pytest.mark.parametrize(
+    "batches,inform_selector_and_trigger_retval",
+    [
+        (  # TEST 1
+            [
+                _BatchConfig(  # first batch
+                    data=[
+                        # trigger 0
+                        (10, 1, 5),
+                        (11, 2, 5),
+                        # trigger 1 is empty
+                        # trigger 2
+                        (12, 3, 5),
+                        (13, 4, 5),
+                        # remaining data
+                        (14, 5, 5),
+                        (15, 6, 5),
+                        (16, 7, 5),
+                    ],
+                    trigger_indexes=[1, 1, 3],
+                    get_num_samples=[2, 0, 2],
+                    remaining_data_range=(5, 7),
+                    expected_tracking={
+                        "trigger_i": [0, 1, 2],
+                        "trigger_id": [0, 1, 2],
+                        "trigger_index": [1, 1, 3],
+                        "first_timestamp": [1, None, 3],
+                        "last_timestamp": [2, None, 4],
+                    },
+                ),
+                _BatchConfig(  # second batch
+                    data=[
+                        # trigger 3 covers remaining data from last batch
+                        # trigger 4
+                        (17, 8, 5),
+                        (18, 9, 5),
+                        # remaining data
+                        (19, 10, 5),
+                    ],
+                    trigger_indexes=[-1, 1],
+                    get_num_samples=[3, 2],
+                    remaining_data_range=(10, 10),
+                    expected_tracking={
+                        "trigger_i": [0, 1, 2, 0, 1],
+                        "trigger_id": [0, 1, 2, 3, 4],
+                        "trigger_index": [1, 1, 3, -1, 1],
+                        "first_timestamp": [1, None, 3, 5, 8],
+                        "last_timestamp": [2, None, 4, 7, 9],
+                    },
+                ),
+                _BatchConfig(  # third batch
+                    data=[(20, 11, 5), (21, 12, 5), (22, 13, 5)],
+                    trigger_indexes=[2],
+                    get_num_samples=[4],
+                    remaining_data_range=None,
+                    expected_tracking={
+                        "trigger_i": [0, 1, 2, 0, 1, 0],
+                        "trigger_id": [0, 1, 2, 3, 4, 5],
+                        "trigger_index": [1, 1, 3, -1, 1, 2],
+                        "first_timestamp": [1, None, 3, 5, 8, 10],
+                        "last_timestamp": [2, None, 4, 7, 9, 13],
+                    },
+                ),
+            ],
+            # inform_selector_and_trigger_retval
+            [(0, {}), (1, {}), (2, {}), (3, {}), (4, {}), (5, {})],
+        ),
+        (  # TEST 2
+            [
+                _BatchConfig(  # first batch
+                    data=[
+                        # trigger 0
+                        (10, 1, 5),
+                        (11, 2, 5),
+                    ],
+                    trigger_indexes=[],
+                    get_num_samples=[0, 0],
+                    remaining_data_range=(1, 2),
+                    expected_tracking=None,  # no trigger index
+                ),
+                _BatchConfig(  # second batch
+                    data=[
+                        # trigger 1
+                        (12, 3, 5),
+                        (13, 4, 5),
+                    ],
+                    trigger_indexes=[-1],
+                    get_num_samples=[2],
+                    remaining_data_range=(3, 4),
+                    expected_tracking={
+                        "trigger_i": [0],
+                        "trigger_id": [0],
+                        "trigger_index": [-1],
+                        "first_timestamp": [1],
+                        "last_timestamp": [2],
+                    },
+                ),
+                _BatchConfig(  # third batch
+                    data=[
+                        # still trigger 1's data
+                        (14, 5, 5),
+                        (15, 6, 5),
+                        (16, 7, 5),
+                    ],
+                    trigger_indexes=[],
+                    get_num_samples=[],
+                    remaining_data_range=(3, 7),
+                    expected_tracking={  # nothing new as empty trigger
+                        "trigger_i": [0],
+                        "trigger_id": [0],
+                        "trigger_index": [-1],
+                        "first_timestamp": [1],
+                        "last_timestamp": [2],
+                    },
+                ),
+                _BatchConfig(  # fourth batch
+                    data=[
+                        # still trigger 1's data
+                        (17, 8, 5),
+                        (18, 9, 5),
+                        # trigger 2
+                        (19, 10, 5),
+                        (20, 11, 5),
+                    ],
+                    trigger_indexes=[1, 3],
+                    get_num_samples=[7, 2],
+                    remaining_data_range=None,
+                    expected_tracking={
+                        "trigger_i": [0, 0, 1],
+                        "trigger_id": [0, 1, 2],
+                        "trigger_index": [-1, 1, 3],
+                        "first_timestamp": [1, 3, 10],
+                        "last_timestamp": [2, 9, 11],
+                    },
+                ),
+            ],
+            # inform_selector_and_trigger_retval
+            [(0, {}), (1, {}), (2, {})],
+        ),
+    ],
+)
+@patch.object(PipelineExecutor, "_train_and_store_model", return_value=(-1, -1))
 @patch.object(GRPCHandler, "inform_selector_and_trigger")
 @patch.object(GRPCHandler, "inform_selector")
 @patch.object(GRPCHandler, "get_number_of_samples")
-def test__handle_triggers_within_batch_empty_triggers(
+def test__execute_triggers_within_batch_trigger_timespan(
     test_get_number_of_samples: MagicMock,
     test_inform_selector: MagicMock,
     test_inform_selector_and_trigger: MagicMock,
     test__run_training: MagicMock,
-):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    # each tuple is (key, timestamp, label)
-    batch = [(10, 1, 5), (11, 2, 5), (12, 3, 5), (13, 4, 5), (14, 5, 5), (15, 6, 5), (16, 7, 5)]
-    triggering_indices = [-1, -1, 3]
-    trigger_ids = [(0, {}), (1, {}), (2, {})]
-    test_inform_selector_and_trigger.side_effect = trigger_ids
+    batches: list[_BatchConfig],
+    inform_selector_and_trigger_retval: list[tuple[int, dict]],
+    dummy_pipeline_options: PipelineOptions,
+) -> None:
+    tracking_columns = ["trigger_i", "trigger_id", "trigger_index", "first_timestamp", "last_timestamp"]
+    test_inform_selector_and_trigger.side_effect = inform_selector_and_trigger_retval
     test_inform_selector.return_value = {}
-    test_get_number_of_samples.side_effect = [0, 0, 4]
-    pe._handle_triggers_within_batch(batch, triggering_indices)
-    inform_selector_and_trigger_expected_args = [
-        call(42, []),
-        call(42, []),
-        call(42, [(10, 1, 5), (11, 2, 5), (12, 3, 5), (13, 4, 5)]),
-    ]
-    assert test_inform_selector_and_trigger.call_count == 3
-    assert test_inform_selector_and_trigger.call_args_list == inform_selector_and_trigger_expected_args
 
-    run_training_expected_args = [call(2)]
-    assert test__run_training.call_count == 1
-    assert test__run_training.call_args_list == run_training_expected_args
-
-    assert test_inform_selector.call_count == 1
-    test_inform_selector.assert_called_once_with(42, [(14, 5, 5), (15, 6, 5), (16, 7, 5)])
-
-
-@patch.object(PipelineExecutor, "_run_training")
-@patch.object(GRPCHandler, "inform_selector_and_trigger")
-@patch.object(GRPCHandler, "inform_selector")
-@patch.object(GRPCHandler, "get_number_of_samples")
-def test__handle_triggers_within_batch_trigger_timespan(
-    test_get_number_of_samples: MagicMock,
-    test_inform_selector: MagicMock,
-    test_inform_selector_and_trigger: MagicMock,
-    test__run_training: MagicMock,
-):
-    def reset_state():
+    def run_batch_triggers_and_validate(pe: PipelineExecutor, batch: _BatchConfig) -> None:
         test_get_number_of_samples.reset_mock()
         test_inform_selector_and_trigger.reset_mock()
         test__run_training.reset_mock()
         test_inform_selector.reset_mock()
 
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    test_inform_selector.return_value = {}
-    test_inform_selector_and_trigger.side_effect = [(0, {}), (1, {}), (2, {}), (3, {}), (4, {}), (5, {})]
+        test_get_number_of_samples.side_effect = batch.get_num_samples
 
-    # each tuple is (key, timestamp, label)
-    first_batch = [
-        # trigger 0
-        (10, 1, 5),
-        (11, 2, 5),
-        # trigger 1 is empty
-        # trigger 2
-        (12, 3, 5),
-        (13, 4, 5),
-        # remaining data
-        (14, 5, 5),
-        (15, 6, 5),
-        (16, 7, 5),
-    ]
-    triggering_indices = [1, 1, 3]
-    test_get_number_of_samples.side_effect = [2, 0, 2]  # the size of trigger 0, 1, 2
+        pe._execute_triggers(pe.state, pe.logs, batch.data, batch.trigger_indexes)
+        pe._inform_selector_remaining_data(pe.state, pe.logs, batch.data, batch.trigger_indexes)
 
-    pe._handle_triggers_within_batch(first_batch, triggering_indices)
-    assert pe.pipeline_log["supervisor"]["triggers"][0]["first_timestamp"] == 1
-    assert pe.pipeline_log["supervisor"]["triggers"][0]["last_timestamp"] == 2
+        assert pe.state.remaining_data_range == batch.remaining_data_range
+        if batch.expected_tracking:
+            assert pe.state.tracking[PipelineStage.EXECUTE_SINGLE_TRIGGER.name][tracking_columns].to_dict("list") == (
+                batch.expected_tracking
+            )
 
-    assert "first_timestamp" not in pe.pipeline_log["supervisor"]["triggers"][1]
-    assert "last_timestamp" not in pe.pipeline_log["supervisor"]["triggers"][1]
-
-    assert pe.pipeline_log["supervisor"]["triggers"][2]["first_timestamp"] == 3
-    assert pe.pipeline_log["supervisor"]["triggers"][2]["last_timestamp"] == 4
-    assert pe.remaining_data_range == (5, 7)
-    reset_state()
-
-    second_batch = [
-        # trigger 3 covers remaining data from last batch
-        # trigger 4
-        (17, 8, 5),
-        (18, 9, 5),
-        # remaining data
-        (19, 10, 5),
-    ]
-    triggering_indices = [-1, 1]
-    test_get_number_of_samples.side_effect = [3, 2]  # the size of trigger 3, 4
-    pe._handle_triggers_within_batch(second_batch, triggering_indices)
-    assert pe.pipeline_log["supervisor"]["triggers"][3]["first_timestamp"] == 5
-    assert pe.pipeline_log["supervisor"]["triggers"][3]["last_timestamp"] == 7
-    assert pe.pipeline_log["supervisor"]["triggers"][4]["first_timestamp"] == 8
-    assert pe.pipeline_log["supervisor"]["triggers"][4]["last_timestamp"] == 9
-    assert pe.remaining_data_range == (10, 10)
-    reset_state()
-
-    third_batch = [(20, 11, 5), (21, 12, 5), (22, 13, 5)]  # trigger 5, also includes remaining data from last batch
-    triggering_indices = [2]
-    test_get_number_of_samples.side_effect = [4]  # the size of trigger 5
-    pe._handle_triggers_within_batch(third_batch, triggering_indices)
-    assert pe.pipeline_log["supervisor"]["triggers"][5]["first_timestamp"] == 10
-    assert pe.pipeline_log["supervisor"]["triggers"][5]["last_timestamp"] == 13
-    assert pe.remaining_data_range is None
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    for batch in batches:
+        run_batch_triggers_and_validate(pe, batch)
 
 
-@patch.object(PipelineExecutor, "_run_training")
-@patch.object(GRPCHandler, "inform_selector_and_trigger")
-@patch.object(GRPCHandler, "inform_selector")
-@patch.object(GRPCHandler, "get_number_of_samples")
-def test__handle_triggers_within_batch_trigger_timespan_across_batch(
-    test_get_number_of_samples: MagicMock,
-    test_inform_selector: MagicMock,
-    test_inform_selector_and_trigger: MagicMock,
-    test__run_training: MagicMock,
-):
-    def reset_state():
-        test_get_number_of_samples.reset_mock()
-        test_inform_selector_and_trigger.reset_mock()
-        test__run_training.reset_mock()
-        test_inform_selector.reset_mock()
+@pytest.mark.parametrize(
+    "trigger_id, training_id, model_id",
+    [
+        (21, 1337, 101),
+    ],
+)
+@patch.object(GRPCHandler, "store_trained_model")
+@patch.object(GRPCHandler, "wait_for_training_completion")
+@patch.object(GRPCHandler, "start_training")
+def test_train_and_store_model(
+    test_start_training: MagicMock,
+    test_wait_for_training_completion: MagicMock,
+    test_store_trained_model: MagicMock,
+    trigger_id: int,
+    training_id: int,
+    model_id: int,
+    dummy_pipeline_options: PipelineOptions,
+) -> None:
+    dummy_pipeline_options.pipeline_id = 42
+    dummy_pipeline_options.pipeline_config.evaluation = None
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
 
-    pe = get_non_connecting_pipeline_executor()
-    test_inform_selector.return_value = {}
-    test_inform_selector_and_trigger.side_effect = [(0, {}), (1, {}), (2, {})]
+    test_start_training.return_value = training_id
+    test_store_trained_model.return_value = model_id
+    test_wait_for_training_completion.return_value = {}
 
-    # each tuple is (key, timestamp, label)
-    first_batch = [
-        # trigger 0
-        (10, 1, 5),
-        (11, 2, 5),
-    ]
-    triggering_indices = []
-    pe._handle_triggers_within_batch(first_batch, triggering_indices)
-    assert pe.remaining_data_range == (1, 2)
-    test_get_number_of_samples.assert_not_called()
-    test_inform_selector_and_trigger.assert_not_called()
-    test__run_training.assert_not_called()
-    test_inform_selector.assert_called_once_with(PIPELINE_ID, first_batch)
+    ret_training_id, ret_model_id = pe._train_and_store_model(pe.state, pe.logs, trigger_id)
+    assert (ret_training_id, ret_model_id) == (training_id, model_id)
+    assert pe.state.previous_model_id == model_id
+    assert pe.state.current_training_id == training_id
 
-    reset_state()
-    second_batch = [
-        # trigger 1
-        (12, 3, 5),
-        (13, 4, 5),
-    ]
-    triggering_indices = [-1]
-    test_get_number_of_samples.side_effect = [2]  # the size of trigger 0
-    pe._handle_triggers_within_batch(second_batch, triggering_indices)
-    assert pe.pipeline_log["supervisor"]["triggers"][0]["first_timestamp"] == 1
-    assert pe.pipeline_log["supervisor"]["triggers"][0]["last_timestamp"] == 2
-    assert pe.remaining_data_range == (3, 4)
-    test_get_number_of_samples.assert_called_once_with(PIPELINE_ID, 0)
-    test_inform_selector_and_trigger.assert_called_once_with(42, [])
-    test__run_training.assert_called_once_with(0)
-    test_inform_selector.assert_called_once_with(PIPELINE_ID, second_batch)
-
-    reset_state()
-    third_batch = [
-        # still trigger 1's data
-        (14, 5, 5),
-        (15, 6, 5),
-        (16, 7, 5),
-    ]
-    triggering_indices = []
-    pe._handle_triggers_within_batch(third_batch, triggering_indices)
-    assert pe.remaining_data_range == (3, 7)
-    reset_state()
-
-    fourth_batch = [
-        # still trigger 1's data
-        (17, 8, 5),
-        (18, 9, 5),
-        # trigger 2
-        (19, 10, 5),
-        (20, 11, 5),
-    ]
-
-    triggering_indices = [1, 3]
-    test_get_number_of_samples.side_effect = [7, 2]
-    pe._handle_triggers_within_batch(fourth_batch, triggering_indices)
-    assert pe.remaining_data_range is None
-    assert pe.pipeline_log["supervisor"]["triggers"][1]["first_timestamp"] == 3
-    assert pe.pipeline_log["supervisor"]["triggers"][1]["last_timestamp"] == 9
-    assert pe.pipeline_log["supervisor"]["triggers"][2]["first_timestamp"] == 10
-    assert pe.pipeline_log["supervisor"]["triggers"][2]["last_timestamp"] == 11
+    test_wait_for_training_completion.assert_called_once_with(training_id, 42, trigger_id)
+    test_start_training.assert_called_once_with(42, trigger_id, ANY, None, None)
+    test_wait_for_training_completion.assert_called_once_with(training_id, 42, trigger_id)
+    test_store_trained_model.assert_called_once_with(training_id)
 
 
 @patch.object(GRPCHandler, "store_trained_model", return_value=101)
 @patch.object(GRPCHandler, "start_training", return_value=1337)
-@patch.object(GRPCHandler, "wait_for_training_completion")
-def test__run_training(
+@patch.object(GRPCHandler, "wait_for_training_completion", return_value={})
+def test_run_training_set_num_samples_to_pass(
     test_wait_for_training_completion: MagicMock,
     test_start_training: MagicMock,
     test_store_trained_model: MagicMock,
-):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.pipeline_id = 42
-    pe._run_training(21)
-    assert pe.previous_model_id == 101
-    assert pe.current_training_id == 1337
+    dummy_pipeline_options: PipelineOptions,
+) -> None:
+    dummy_pipeline_options.pipeline_id = 42
+    dummy_pipeline_options.pipeline_config.training.num_samples_to_pass = [73]
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
 
-    test_wait_for_training_completion.assert_called_once_with(1337, 42, 21)
-    test_start_training.assert_called_once_with(42, 21, get_minimal_pipeline_config(), None, None)
-    test_store_trained_model.assert_called_once()
-
-
-@patch.object(GRPCHandler, "store_trained_model", return_value=101)
-@patch.object(GRPCHandler, "start_training", return_value=1337)
-@patch.object(GRPCHandler, "wait_for_training_completion")
-def test__run_training_set_num_samples_to_pass(
-    test_wait_for_training_completion: MagicMock,
-    test_start_training: MagicMock,
-    test_store_trained_model: MagicMock,
-):
-    pipeline_config = get_minimal_pipeline_config()
-    pipeline_config["training"]["num_samples_to_pass"] = [73]
-    pe = get_non_connecting_pipeline_executor(pipeline_config)
-    pe.pipeline_id = 42
-    pe._run_training(trigger_id=21)
-    test_start_training.assert_called_once_with(42, 21, pipeline_config, None, 73)
+    pe._train_and_store_model(pe.state, pe.logs, trigger_id=21)
+    test_start_training.assert_called_once_with(42, 21, ANY, None, 73)
     test_start_training.reset_mock()
+
+    # trigger is added to trigger list _execute_triggers, as we are not calling it here, we fake the it
+    pe.state.triggers.append(21)
 
     # the next time _run_training is called, the num_samples_to_pass should be set to 0
     # because the next trigger is out of the range of `num_samples_to_pass`
-    pe._run_training(trigger_id=22)
-    test_start_training.assert_called_once_with(42, 22, pipeline_config, 101, None)
+    pe._train_and_store_model(pe.state, pe.logs, trigger_id=22)
+    test_start_training.assert_called_once_with(42, 22, ANY, 101, None)
 
 
-@patch.object(GRPCHandler, "get_data_in_interval", return_value=[([(10, 1), (11, 2)], 0)])
-@patch.object(PipelineExecutor, "_handle_new_data")
-def test_replay_data_closed_interval(test__handle_new_data: MagicMock, test_get_data_in_interval: MagicMock):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.start_replay_at = 0
-    pe.stop_replay_at = 42
-    pe.replay_data()
-
-    test_get_data_in_interval.assert_called_once_with("test", 0, 42)
-    test__handle_new_data.assert_called_once_with([(10, 1), (11, 2)])
-
-
-@patch.object(GRPCHandler, "get_data_in_interval", return_value=[([(10, 1)], 0), ([(11, 2)], 0)])
-@patch.object(PipelineExecutor, "_handle_new_data")
-def test_replay_data_closed_interval_batched(test__handle_new_data: MagicMock, test_get_data_in_interval: MagicMock):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.start_replay_at = 0
-    pe.stop_replay_at = 42
-    pe.replay_data()
-
-    test_get_data_in_interval.assert_called_once_with("test", 0, 42)
-    assert test__handle_new_data.call_count == 2
-    assert test__handle_new_data.call_args_list == [call([(10, 1)]), call([(11, 2)])]
-
-
-@patch.object(GRPCHandler, "get_new_data_since", return_value=[([(10, 1), (11, 2)], 0)])
-@patch.object(PipelineExecutor, "_handle_new_data")
-def test_replay_data_open_interval(test__handle_new_data: MagicMock, test_get_new_data_since: MagicMock):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.start_replay_at = 0
-    pe.stop_replay_at = None
-    pe.replay_data()
-
-    test_get_new_data_since.assert_called_once_with("test", 0)
-    test__handle_new_data.assert_called_once_with([(10, 1), (11, 2)])
-
-
-@patch.object(GRPCHandler, "get_new_data_since", return_value=[([(10, 1)], 0), ([(11, 2)], 0)])
-@patch.object(PipelineExecutor, "_handle_new_data")
-def test_replay_data_open_interval_batched(test__handle_new_data: MagicMock, test_get_new_data_since: MagicMock):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.start_replay_at = 0
-    pe.stop_replay_at = None
-    pe.replay_data()
-
-    test_get_new_data_since.assert_called_once_with("test", 0)
-    assert test__handle_new_data.call_count == 2
-    assert test__handle_new_data.call_args_list == [call([(10, 1)]), call([(11, 2)])]
-
-
-@patch.object(PipelineExecutor, "init_cluster_connection", return_value=None)
-@patch("modyn.utils.grpc_connection_established", return_value=True)
-@patch.object(PipelineExecutor, "get_dataset_selector_batch_size")
-@patch.object(PipelineExecutor, "replay_data")
-@patch.object(PipelineExecutor, "wait_for_new_data")
-def test_non_experiment_pipeline(
-    test_wait_for_new_data: MagicMock,
-    test_replay_data: MagicMock,
-    test_get_dataset_selector_batch_size: MagicMock,
-    test_grpc_connection_established,
-    test_init_cluster_connection,
-):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.experiment_mode = False
-    pe.init_cluster_connection()
-    pe.execute()
-
-    test_get_dataset_selector_batch_size.assert_called_once()
-    test_wait_for_new_data.assert_called_once_with(21)
-    test_replay_data.assert_not_called()
-
-
-@patch.object(PipelineExecutor, "init_cluster_connection", return_value=None)
-@patch("modyn.utils.grpc_connection_established", return_value=True)
-@patch.object(PipelineExecutor, "get_dataset_selector_batch_size")
-@patch.object(PipelineExecutor, "replay_data")
-@patch.object(PipelineExecutor, "wait_for_new_data")
-def test_experiment_pipeline(
-    test_wait_for_new_data: MagicMock,
-    test_replay_data: MagicMock,
-    test_get_dataset_selector_batch_size: MagicMock,
-    test_grpc_connection_established,
-    test_init_cluster_connection,
-):
-    pe = get_non_connecting_pipeline_executor()  # pylint: disable=no-value-for-parameter
-    pe.experiment_mode = True
-    pe.init_cluster_connection()
-    pe.execute()
-
-    test_get_dataset_selector_batch_size.assert_called_once()
-    test_wait_for_new_data.assert_not_called()
-    test_replay_data.assert_called_once()
-
-
-@patch.object(PipelineExecutor, "init_cluster_connection", return_value=None)
-@patch("modyn.utils.grpc_connection_established", return_value=True)
-@patch.object(PipelineExecutor, "execute", return_value=None)
-def test_execute_pipeline(
-    test_execute: MagicMock,
-    test_grpc_connection_established: MagicMock,
-    test_init_cluster_connection: MagicMock,
-):
-    execute_pipeline(
-        START_TIMESTAMP,
-        PIPELINE_ID,
-        get_minimal_system_config(),
-        get_minimal_pipeline_config(),
-        EVALUATION_DIRECTORY,
-        SUPPORTED_EVAL_RESULT_WRITERS,
-        EXCEPTION_QUEUE,
-        PIPELINE_STATUS_QUEUE,
-        TRAINING_STATUS_QUEUE,
-        EVAL_STATUS_QUEUE,
-    )
-
-    test_init_cluster_connection.assert_called_once()
-    test_execute.assert_called_once()
-
-
+@pytest.mark.parametrize("test_failure", [True])  # TODO add true
 @patch.object(GRPCHandler, "wait_for_evaluation_completion")
 @patch.object(GRPCHandler, "store_evaluation_results")
-def test__start_evaluations_success(
-    test_store_evaluation_results,
-    test_wait_for_evaluation_completion,
-):
-    pipeline_config = get_minimal_pipeline_config()
-    evaluation_config = get_minimal_evaluation_config()
-    eval_dataset_config = evaluation_config["datasets"][0]
-    pipeline_config["evaluation"] = evaluation_config
-    evaluator_stub_mock = mock.Mock(spec=["evaluate_model"])
-    evaluator_stub_mock.evaluate_model.return_value = EvaluateModelResponse(
-        evaluation_started=True, evaluation_id=42, dataset_size=10
-    )
+def test__start_evaluations(
+    test_store_evaluation_results: MagicMock,
+    test_wait_for_evaluation_completion: MagicMock,
+    test_failure: bool,
+    dummy_pipeline_options: PipelineOptions,
+    pipeline_evaluation_config: EvaluationConfig,
+) -> None:
+    eval_dataset_config = pipeline_evaluation_config.datasets[0]
+    dummy_pipeline_options.pipeline_config.evaluation = pipeline_evaluation_config
 
-    pipeline_executor = PipelineExecutor(
-        START_TIMESTAMP,
-        PIPELINE_ID,
-        get_minimal_system_config(),
-        pipeline_config,
-        str(EVALUATION_DIRECTORY),
-        SUPPORTED_EVAL_RESULT_WRITERS,
-        PIPELINE_STATUS_QUEUE,
-        TRAINING_STATUS_QUEUE,
-        EVAL_STATUS_QUEUE,
-    )
-    pipeline_executor.grpc.evaluator = evaluator_stub_mock
-    pipeline_executor.current_training_id = 0
-
-    intervals = [(0, 100), (100, 200), (None, None), (None, 200), (None, 0), (200, None), (0, None), (0, 0)]
-
-    def fake(first_timestamp: int, last_timestamp: int):
-        yield from intervals
-
-    with patch.object(MatrixEvalStrategy, "get_eval_intervals", side_effect=fake):
-        model_id = 1
-        pipeline_executor._start_evaluations(
-            trigger_id=0, model_id=model_id, trigger_set_first_timestamp=20, trigger_set_last_timestamp=70
-        )
-        device = evaluation_config["device"]
-        assert evaluator_stub_mock.evaluate_model.call_count == len(intervals)
-
-        expected_calls = [
-            call(GRPCHandler.prepare_evaluation_request(eval_dataset_config, model_id, device, start_ts, end_ts))
-            for start_ts, end_ts in intervals
-        ]
-
-        assert evaluator_stub_mock.evaluate_model.call_args_list == expected_calls
-
-
-@patch.object(GRPCHandler, "wait_for_evaluation_completion")
-@patch.object(GRPCHandler, "store_evaluation_results")
-def test__start_evaluations_failure(
-    test_store_evaluation_results,
-    test_wait_for_evaluation_completion,
-):
-    pipeline_config = get_minimal_pipeline_config()
-    evaluation_config = get_minimal_evaluation_config()
-    pipeline_config["evaluation"] = evaluation_config
     evaluator_stub_mock = mock.Mock(spec=["evaluate_model"])
     success_response = EvaluateModelResponse(evaluation_started=True, evaluation_id=42, dataset_size=10)
     failure_response = EvaluateModelResponse(
         evaluation_started=False, eval_aborted_reason=EvaluationAbortedReason.EMPTY_DATASET
     )
     # we let the second evaluation fail; it shouldn't affect the third evaluation
-    evaluator_stub_mock.evaluate_model.side_effect = [success_response, failure_response, success_response]
-
-    pipeline_executor = PipelineExecutor(
-        START_TIMESTAMP,
-        PIPELINE_ID,
-        get_minimal_system_config(),
-        pipeline_config,
-        str(EVALUATION_DIRECTORY),
-        SUPPORTED_EVAL_RESULT_WRITERS,
-        PIPELINE_STATUS_QUEUE,
-        TRAINING_STATUS_QUEUE,
-        EVAL_STATUS_QUEUE,
-    )
-    pipeline_executor.grpc.evaluator = evaluator_stub_mock
-    pipeline_executor.current_training_id = 0
-
-    def fake_get_eval_intervals(first_timestamp: int, last_timestamp: int):
-        yield from [(0, 100), (100, 200), (200, 300)]
-
-    with patch.object(MatrixEvalStrategy, "get_eval_intervals", side_effect=fake_get_eval_intervals):
-        pipeline_executor._start_evaluations(
-            trigger_id=0, model_id=0, trigger_set_first_timestamp=70, trigger_set_last_timestamp=100
+    if test_failure:
+        evaluator_stub_mock.evaluate_model.side_effect = [success_response, failure_response, success_response]
+    else:
+        evaluator_stub_mock.evaluate_model.return_value = EvaluateModelResponse(
+            evaluation_started=True, evaluation_id=42, dataset_size=10
         )
-        assert evaluator_stub_mock.evaluate_model.call_count == 3
-        assert test_store_evaluation_results.call_count == 2
-        assert test_wait_for_evaluation_completion.call_count == 2
 
-        assert pipeline_executor.pipeline_log[EVALUATION_RESULTS][0][f"{0}-{100}"] != {}
-        assert pipeline_executor.pipeline_log[EVALUATION_RESULTS][0][f"{100}-{200}"] == {
-            "failure_reason": "EMPTY_DATASET"
-        }
-        assert pipeline_executor.pipeline_log[EVALUATION_RESULTS][0][f"{200}-{300}"] != {}
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    pe.grpc.evaluator = evaluator_stub_mock
+
+    if test_failure:
+
+        def get_eval_intervals(
+            first_timestamp: int, last_timestamp: int
+        ) -> Generator[tuple[int | None, int | None], None, None]:
+            yield from [(0, 100), (100, 200), (200, 300)]
+
+    else:
+        intervals = [(0, 100), (100, 200), (None, None), (None, 200), (None, 0), (200, None), (0, None), (0, 0)]
+
+        def get_eval_intervals(
+            first_timestamp: int, last_timestamp: int
+        ) -> Generator[tuple[int | None, int | None], None, None]:
+            yield from intervals
+
+    with patch.object(MatrixEvalStrategy, "get_eval_intervals", side_effect=get_eval_intervals):
+        model_id = 1
+        pe._evaluate_and_store_results(
+            pe.state, pe.logs, trigger_id=0, training_id=0, model_id=model_id, first_timestamp=20, last_timestamp=70
+        )
+
+        if test_failure:
+            assert evaluator_stub_mock.evaluate_model.call_count == 3
+            assert test_store_evaluation_results.call_count == 2
+            assert test_wait_for_evaluation_completion.call_count == 2
+
+            stage_info = [
+                run.info for run in pe.logs.supervisor.stage_runs if isinstance(run.info, SingleEvaluationInfo)
+            ]
+            assert len(stage_info) == 3
+            assert (stage_info[0].interval_start, stage_info[0].interval_end) == (0, 100)
+            assert (stage_info[1].interval_start, stage_info[1].interval_end) == (100, 200)
+            assert (stage_info[2].interval_start, stage_info[2].interval_end) == (200, 300)
+            assert stage_info[0].failure_reason is None
+            assert stage_info[1].failure_reason == "EMPTY_DATASET"
+            assert stage_info[2].failure_reason is None
+        else:
+            assert evaluator_stub_mock.evaluate_model.call_count == len(intervals)
+            expected_calls = [
+                call(
+                    GRPCHandler.prepare_evaluation_request(
+                        eval_dataset_config.model_dump(by_alias=True),
+                        model_id,
+                        pipeline_evaluation_config.device,
+                        start_ts,
+                        end_ts,
+                    )
+                )
+                for start_ts, end_ts in intervals
+            ]
+
+            assert evaluator_stub_mock.evaluate_model.call_args_list == expected_calls
+
+
+@pytest.mark.parametrize("stop_replay_at", [None, 2, 43])
+@pytest.mark.parametrize(
+    "grpc_fetch_retval",
+    [
+        [([(10, 1, 0), (11, 2, 0)], 0)],  # open_interval
+        [([(10, 1, 0)], 0), ([(11, 2, 0)], 0)],  # open_interval_batched
+        [([(10, 1, 0)], 0), ([(11, 2, 0)], 0), ([], 0)],
+    ],
+)
+@patch.object(PipelineExecutor, "_process_new_data")
+@patch.object(GRPCHandler, "get_new_data_since")
+@patch.object(GRPCHandler, "get_data_in_interval")
+def test_replay_data(
+    test_get_data_in_interval: MagicMock,
+    test_get_new_data_since: MagicMock,
+    test__process_new_data: MagicMock,
+    grpc_fetch_retval: list[tuple[list[tuple[int, int]], int]],
+    stop_replay_at: int | None,
+    dummy_pipeline_options: PipelineOptions,
+) -> None:
+    dummy_pipeline_options.pipeline_id = 42
+    dummy_pipeline_options.start_replay_at = 0
+    dummy_pipeline_options.stop_replay_at = stop_replay_at
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+
+    if stop_replay_at:
+        test_get_data_in_interval.side_effect = [grpc_fetch_retval]
+    else:
+        test_get_new_data_since.side_effect = [grpc_fetch_retval]
+
+    pe._replay_data(pe.state, pe.logs)
+
+    if stop_replay_at:
+        test_get_data_in_interval.assert_called_once_with("test", 0, stop_replay_at)
+    else:
+        test_get_new_data_since.assert_called_once_with("test", 0)
+
+    assert test__process_new_data.call_count == len(grpc_fetch_retval)
+    assert test__process_new_data.call_args_list == [call(ANY, ANY, r[0], r[1]) for r in grpc_fetch_retval]
+
+
+@pytest.mark.parametrize("experiment", [True, False])
+@patch.object(PipelineExecutor, "_replay_data", return_value=None)
+@patch.object(PipelineExecutor, "_serve_online_data", return_value=None)
+@patch.object(GRPCHandler, "init_cluster_connection", return_value=None)
+@patch("modyn.utils.grpc_connection_established", return_value=True)
+def test_execute_pipeline(
+    test_grpc_connection_established: MagicMock,
+    test_init_cluster_connection: MagicMock,
+    test_serve_online_data: MagicMock,
+    test_replay_data: MagicMock,
+    experiment: bool,
+    dummy_pipeline_options: PipelineOptions,
+) -> None:
+    dummy_pipeline_options.start_replay_at = 0 if experiment else None
+
+    execute_pipeline(dummy_pipeline_options)
+
+    test_init_cluster_connection.assert_called_once()
+
+    if experiment:
+        test_serve_online_data.assert_not_called()
+        test_replay_data.assert_called_once()
+    else:
+        test_serve_online_data.assert_called_once()
+        test_replay_data.assert_not_called()

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -162,11 +162,11 @@ def test_pipeline_stage_decorator(dummy_pipeline_args: PipelineExecutionParams) 
     assert pe._stage_func(pe.state, pe.logs) == 1
     t1 = datetime.datetime.now()
 
-    assert len(pe.logs.supervisor.stage_runs) == 1
-    assert pe.logs.supervisor.stage_runs[0].info.name == "test"
-    assert (pe.logs.supervisor.stage_runs[0].start - t0).total_seconds() < 8e-3
-    assert (pe.logs.supervisor.stage_runs[0].end - t1).total_seconds() < 8e-3
-    assert abs((pe.logs.supervisor.stage_runs[0].duration - (t1 - t0)).total_seconds()) < 8e-3
+    assert len(pe.logs.supervisor_logs.stage_runs) == 1
+    assert pe.logs.supervisor_logs.stage_runs[0].info.name == "test"
+    assert (pe.logs.supervisor_logs.stage_runs[0].start - t0).total_seconds() < 8e-3
+    assert (pe.logs.supervisor_logs.stage_runs[0].end - t1).total_seconds() < 8e-3
+    assert abs((pe.logs.supervisor_logs.stage_runs[0].duration - (t1 - t0)).total_seconds()) < 8e-3
 
 
 def test_pipeline_stage_decorator_generator(dummy_pipeline_args: PipelineExecutionParams) -> None:
@@ -217,8 +217,8 @@ def test_pipeline_stage_decorator_generator(dummy_pipeline_args: PipelineExecuti
     assert gen_values == [0, 1, 2]
     assert len(times) == 4
 
-    assert pe.logs.supervisor.stage_runs[0].info.elements == [0, 1, 2]
-    assert pe.logs.supervisor.stage_runs[0].info.finalized
+    assert pe.logs.supervisor_logs.stage_runs[0].info.elements == [0, 1, 2]
+    assert pe.logs.supervisor_logs.stage_runs[0].info.finalized
 
     assert abs(times[0].total_seconds()) < 0.005
     assert abs(times[1].total_seconds() - 0.1 * 2 - 0.02 * 2) < 0.035  # higher tolerance due to pipeline_stage overhead
@@ -749,7 +749,7 @@ def test__start_evaluations(
             assert test_wait_for_evaluation_completion.call_count == 2
 
             stage_info = [
-                run.info for run in pe.logs.supervisor.stage_runs if isinstance(run.info, SingleEvaluationInfo)
+                run.info for run in pe.logs.supervisor_logs.stage_runs if isinstance(run.info, SingleEvaluationInfo)
             ]
             assert len(stage_info) == 3
             assert (stage_info[0].interval_start, stage_info[0].interval_end) == (0, 100)

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -17,23 +17,21 @@ from modyn.config.schema.pipeline import EvaluationConfig, ModynPipelineConfig
 # pylint: disable=no-name-in-module
 from modyn.evaluator.internal.grpc.generated.evaluator_pb2 import EvaluateModelResponse, EvaluationAbortedReason
 from modyn.supervisor.internal.eval_strategies.matrix_eval_strategy import MatrixEvalStrategy
-from modyn.supervisor.internal.evaluation_result_writer import JsonResultWriter, TensorboardResultWriter
-from modyn.supervisor.internal.grpc.enums import PipelineStage, PipelineType
+from modyn.supervisor.internal.grpc.enums import PipelineStage
 from modyn.supervisor.internal.grpc_handler import GRPCHandler
 from modyn.supervisor.internal.pipeline_executor import PipelineExecutor, execute_pipeline
 from modyn.supervisor.internal.pipeline_executor.models import (
     ConfigLogs,
     ExecutionState,
+    PipelineExecutionParams,
     PipelineLogs,
-    PipelineOptions,
     SingleEvaluationInfo,
     StageInfo,
     StageLog,
 )
-from modyn.supervisor.internal.pipeline_executor.pipeline_executor import pipeline_stage
+from modyn.supervisor.internal.pipeline_executor.pipeline_executor import _pipeline_stage_parents, pipeline_stage
 
 EVALUATION_DIRECTORY: pathlib.Path = pathlib.Path(os.path.realpath(__file__)).parent / "test_eval_dir"
-SUPPORTED_EVAL_RESULT_WRITERS: dict = {"json": JsonResultWriter, "tensorboard": TensorboardResultWriter}
 START_TIMESTAMP = 21
 PIPELINE_ID = 42
 EVAL_ID = 42
@@ -56,14 +54,15 @@ def minimal_pipeline_config(dummy_pipeline_config: ModynPipelineConfig) -> Modyn
     return config
 
 
-def get_dummy_pipeline_options(system_config: ModynConfig, pipeline_config: ModynPipelineConfig) -> PipelineOptions:
-    return PipelineOptions(
+def get_dummy_pipeline_args(
+    system_config: ModynConfig, pipeline_config: ModynPipelineConfig
+) -> PipelineExecutionParams:
+    return PipelineExecutionParams(
         start_timestamp=START_TIMESTAMP,
         pipeline_id=PIPELINE_ID,
         modyn_config=system_config,
         pipeline_config=pipeline_config,
         eval_directory=str(EVALUATION_DIRECTORY),
-        supervisor_supported_eval_result_writers=SUPPORTED_EVAL_RESULT_WRITERS,
         exception_queue=EXCEPTION_QUEUE,
         pipeline_status_queue=PIPELINE_STATUS_QUEUE,
         training_status_queue=TRAINING_STATUS_QUEUE,
@@ -72,22 +71,23 @@ def get_dummy_pipeline_options(system_config: ModynConfig, pipeline_config: Mody
 
 
 @pytest.fixture
-def dummy_pipeline_options(
+def dummy_pipeline_args(
     minimal_system_config: ModynConfig, minimal_pipeline_config: ModynPipelineConfig
-) -> PipelineOptions:
-    return get_dummy_pipeline_options(minimal_system_config, minimal_pipeline_config)
+) -> PipelineExecutionParams:
+    return get_dummy_pipeline_args(minimal_system_config, minimal_pipeline_config)
 
 
 @pytest.fixture
-def dummy_execution_state(dummy_pipeline_options: PipelineOptions) -> ExecutionState:
-    return ExecutionState(**vars(dummy_pipeline_options))
+def dummy_execution_state(dummy_pipeline_args: PipelineExecutionParams) -> ExecutionState:
+    return ExecutionState(**vars(dummy_pipeline_args))
 
 
 @pytest.fixture
-def dummy_logs(dummy_pipeline_options: PipelineOptions) -> PipelineLogs:
-    options = dummy_pipeline_options
+def dummy_logs(dummy_pipeline_args: PipelineExecutionParams) -> PipelineLogs:
+    options = dummy_pipeline_args
     return PipelineLogs(
         pipeline_id=PIPELINE_ID,
+        pipeline_stages=_pipeline_stage_parents,
         config=ConfigLogs(system=options.modyn_config, pipeline=options.pipeline_config),
         experiment=options.experiment_mode,
         start_replay_at=options.start_replay_at,
@@ -97,7 +97,7 @@ def dummy_logs(dummy_pipeline_options: PipelineOptions) -> PipelineLogs:
 
 @pytest.fixture
 def dummy_stage_log() -> StageLog:
-    return StageLog(id="dummy", start=0, sample_idx=1, sample_time=1000)
+    return StageLog(id="dummy", start=0, sample_idx=1, sample_time=1000, trigger_idx=0)
 
 
 @overload
@@ -107,22 +107,22 @@ def get_non_connecting_pipeline_executor(
 
 
 @overload
-def get_non_connecting_pipeline_executor(pipeline_options: PipelineOptions) -> PipelineExecutor: ...
+def get_non_connecting_pipeline_executor(pipeline_args: PipelineExecutionParams) -> PipelineExecutor: ...
 
 
 def get_non_connecting_pipeline_executor(
-    pipeline_options: PipelineOptions | None = None,
+    pipeline_args: PipelineExecutionParams | None = None,
     system_config: ModynConfig | None = None,
     pipeline_config: ModynPipelineConfig | None = None,
 ) -> PipelineExecutor:
-    if pipeline_options:
-        return PipelineExecutor(pipeline_options)
-    return PipelineExecutor(get_dummy_pipeline_options(system_config, pipeline_config))
+    if pipeline_args:
+        return PipelineExecutor(pipeline_args)
+    return PipelineExecutor(get_dummy_pipeline_args(system_config, pipeline_config))
 
 
 @pytest.fixture
-def non_connecting_pipeline_executor(dummy_pipeline_options: PipelineOptions) -> PipelineExecutor:
-    return PipelineExecutor(dummy_pipeline_options)
+def non_connecting_pipeline_executor(dummy_pipeline_args: PipelineExecutionParams) -> PipelineExecutor:
+    return PipelineExecutor(dummy_pipeline_args)
 
 
 def sleep_mock(duration: int):
@@ -143,21 +143,21 @@ def test_initialization(non_connecting_pipeline_executor: PipelineExecutor) -> N
     assert non_connecting_pipeline_executor.state.stage == PipelineStage.INIT
 
 
-def test_pipeline_stage_decorator(dummy_pipeline_options: PipelineOptions) -> None:
+def test_pipeline_stage_decorator(dummy_pipeline_args: PipelineExecutionParams) -> None:
 
     class TestStageLogInfo(StageInfo):
         name: str
 
     class TestPipelineExecutor(PipelineExecutor):
 
-        @pipeline_stage(PipelineType.MAIN, PipelineStage.INIT, log=True, track=True)
+        @pipeline_stage(PipelineStage.INIT, log=True, track=True)
         def _stage_func(self, s: ExecutionState, log: StageLog) -> int:
             time.sleep(0.1)
             log.info = TestStageLogInfo(name="test")
 
             return 1
 
-    pe = TestPipelineExecutor(dummy_pipeline_options)
+    pe = TestPipelineExecutor(dummy_pipeline_args)
     t0 = datetime.datetime.now()
     assert pe._stage_func(pe.state, pe.logs) == 1
     t1 = datetime.datetime.now()
@@ -169,7 +169,7 @@ def test_pipeline_stage_decorator(dummy_pipeline_options: PipelineOptions) -> No
     assert abs((pe.logs.supervisor.stage_runs[0].duration - (t1 - t0)).total_seconds()) < 8e-3
 
 
-def test_pipeline_stage_decorator_generator(dummy_pipeline_options: PipelineOptions) -> None:
+def test_pipeline_stage_decorator_generator(dummy_pipeline_args: PipelineExecutionParams) -> None:
 
     class TestStageLogInfo(StageInfo):
         elements: list[int]
@@ -183,7 +183,7 @@ def test_pipeline_stage_decorator_generator(dummy_pipeline_options: PipelineOpti
 
     class TestPipelineExecutor(PipelineExecutor):
 
-        @pipeline_stage(PipelineType.MAIN, PipelineStage.INIT, log=True, track=True)
+        @pipeline_stage(PipelineStage.INIT, log=True, track=True)
         def _stage_func(self, s: ExecutionState, log: StageLog) -> Generator[int, None, None]:
             try:
                 time.sleep(0.1)
@@ -199,7 +199,7 @@ def test_pipeline_stage_decorator_generator(dummy_pipeline_options: PipelineOpti
     gen_values: list[int] = []
 
     last_time = datetime.datetime.now()
-    pe = TestPipelineExecutor(dummy_pipeline_options)
+    pe = TestPipelineExecutor(dummy_pipeline_args)
     gen = pe._stage_func(pe.state, pe.logs)
     times.append(datetime.datetime.now() - last_time)
     last_time = datetime.datetime.now()
@@ -295,7 +295,6 @@ def test_serve_online_data(
 
     handle_mock: MagicMock
     with patch.object(pe, "_process_new_data", side_effect=mocked__process_new_data_return_vals) as handle_mock:
-        get_new_data_mock: MagicMock
         with patch.object(pe.grpc, "get_new_data_since", side_effect=mocked_get_new_data_since) as get_new_data_mock:
             dummy_execution_state.max_timestamp = 21
             pe._serve_online_data(dummy_execution_state, dummy_logs)
@@ -351,10 +350,10 @@ def test__process_new_data(
 
 @patch.object(GRPCHandler, "inform_selector", return_value={})
 def test__process_new_data_batch_no_triggers(
-    test_inform_selector: MagicMock, dummy_pipeline_options: PipelineOptions
+    test_inform_selector: MagicMock, dummy_pipeline_args: PipelineExecutionParams
 ) -> None:
-    dummy_pipeline_options.pipeline_id = 42
-    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    dummy_pipeline_args.pipeline_id = 42
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_args)
     batch = [(10, 1), (11, 2)]
 
     with patch.object(pe.trigger, "inform") as inform_mock:
@@ -417,17 +416,17 @@ def test__execute_triggers(
     inform_selector_and_trigger_expected_args: list,
     train_and_store_model_expected_args: list,
     inform_selector_expected_args: list,
-    dummy_pipeline_options: PipelineOptions,
+    dummy_pipeline_args: PipelineExecutionParams,
 ) -> None:
-    dummy_pipeline_options.pipeline_id = 42
-    dummy_pipeline_options.pipeline_config.evaluation = None
-    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    dummy_pipeline_args.pipeline_id = 42
+    dummy_pipeline_args.pipeline_config.evaluation = None
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_args)
 
     test_inform_selector_and_trigger.side_effect = trigger_ids
     test_inform_selector.return_value = {}
     test_get_number_of_samples.side_effect = [len(params) for params in inform_selector_and_trigger_expected_args]
 
-    pe._execute_triggers(pe.state, pe.logs, batch, trigger_indexes)
+    pe._handle_triggers(pe.state, pe.logs, batch, trigger_indexes)
     pe._inform_selector_remaining_data(pe.state, pe.logs, batch, trigger_indexes)
 
     assert test_inform_selector_and_trigger.call_count == len(inform_selector_and_trigger_expected_args)
@@ -603,7 +602,7 @@ def test__execute_triggers_within_batch_trigger_timespan(
     test__run_training: MagicMock,
     batches: list[_BatchConfig],
     inform_selector_and_trigger_retval: list[tuple[int, dict]],
-    dummy_pipeline_options: PipelineOptions,
+    dummy_pipeline_args: PipelineExecutionParams,
 ) -> None:
     tracking_columns = ["trigger_i", "trigger_id", "trigger_index", "first_timestamp", "last_timestamp"]
     test_inform_selector_and_trigger.side_effect = inform_selector_and_trigger_retval
@@ -617,16 +616,16 @@ def test__execute_triggers_within_batch_trigger_timespan(
 
         test_get_number_of_samples.side_effect = batch.get_num_samples
 
-        pe._execute_triggers(pe.state, pe.logs, batch.data, batch.trigger_indexes)
+        pe._handle_triggers(pe.state, pe.logs, batch.data, batch.trigger_indexes)
         pe._inform_selector_remaining_data(pe.state, pe.logs, batch.data, batch.trigger_indexes)
 
         assert pe.state.remaining_data_range == batch.remaining_data_range
         if batch.expected_tracking:
-            assert pe.state.tracking[PipelineStage.EXECUTE_SINGLE_TRIGGER.name][tracking_columns].to_dict("list") == (
+            assert pe.state.tracking[PipelineStage.HANDLE_SINGLE_TRIGGER.name][tracking_columns].to_dict("list") == (
                 batch.expected_tracking
             )
 
-    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_args)
     for batch in batches:
         run_batch_triggers_and_validate(pe, batch)
 
@@ -647,11 +646,11 @@ def test_train_and_store_model(
     trigger_id: int,
     training_id: int,
     model_id: int,
-    dummy_pipeline_options: PipelineOptions,
+    dummy_pipeline_args: PipelineExecutionParams,
 ) -> None:
-    dummy_pipeline_options.pipeline_id = 42
-    dummy_pipeline_options.pipeline_config.evaluation = None
-    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    dummy_pipeline_args.pipeline_id = 42
+    dummy_pipeline_args.pipeline_config.evaluation = None
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_args)
 
     test_start_training.return_value = training_id
     test_store_trained_model.return_value = model_id
@@ -675,11 +674,11 @@ def test_run_training_set_num_samples_to_pass(
     test_wait_for_training_completion: MagicMock,
     test_start_training: MagicMock,
     test_store_trained_model: MagicMock,
-    dummy_pipeline_options: PipelineOptions,
+    dummy_pipeline_args: PipelineExecutionParams,
 ) -> None:
-    dummy_pipeline_options.pipeline_id = 42
-    dummy_pipeline_options.pipeline_config.training.num_samples_to_pass = [73]
-    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    dummy_pipeline_args.pipeline_id = 42
+    dummy_pipeline_args.pipeline_config.training.num_samples_to_pass = [73]
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_args)
 
     pe._train_and_store_model(pe.state, pe.logs, trigger_id=21)
     test_start_training.assert_called_once_with(42, 21, ANY, None, 73)
@@ -694,18 +693,18 @@ def test_run_training_set_num_samples_to_pass(
     test_start_training.assert_called_once_with(42, 22, ANY, 101, None)
 
 
-@pytest.mark.parametrize("test_failure", [True])  # TODO add true
+@pytest.mark.parametrize("test_failure", [False, True])
 @patch.object(GRPCHandler, "wait_for_evaluation_completion")
 @patch.object(GRPCHandler, "store_evaluation_results")
 def test__start_evaluations(
     test_store_evaluation_results: MagicMock,
     test_wait_for_evaluation_completion: MagicMock,
     test_failure: bool,
-    dummy_pipeline_options: PipelineOptions,
+    dummy_pipeline_args: PipelineExecutionParams,
     pipeline_evaluation_config: EvaluationConfig,
 ) -> None:
     eval_dataset_config = pipeline_evaluation_config.datasets[0]
-    dummy_pipeline_options.pipeline_config.evaluation = pipeline_evaluation_config
+    dummy_pipeline_args.pipeline_config.evaluation = pipeline_evaluation_config
 
     evaluator_stub_mock = mock.Mock(spec=["evaluate_model"])
     success_response = EvaluateModelResponse(evaluation_started=True, evaluation_id=42, dataset_size=10)
@@ -720,7 +719,7 @@ def test__start_evaluations(
             evaluation_started=True, evaluation_id=42, dataset_size=10
         )
 
-    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_args)
     pe.grpc.evaluator = evaluator_stub_mock
 
     if test_failure:
@@ -795,12 +794,12 @@ def test_replay_data(
     test__process_new_data: MagicMock,
     grpc_fetch_retval: list[tuple[list[tuple[int, int]], int]],
     stop_replay_at: int | None,
-    dummy_pipeline_options: PipelineOptions,
+    dummy_pipeline_args: PipelineExecutionParams,
 ) -> None:
-    dummy_pipeline_options.pipeline_id = 42
-    dummy_pipeline_options.start_replay_at = 0
-    dummy_pipeline_options.stop_replay_at = stop_replay_at
-    pe = get_non_connecting_pipeline_executor(dummy_pipeline_options)
+    dummy_pipeline_args.pipeline_id = 42
+    dummy_pipeline_args.start_replay_at = 0
+    dummy_pipeline_args.stop_replay_at = stop_replay_at
+    pe = get_non_connecting_pipeline_executor(dummy_pipeline_args)
 
     if stop_replay_at:
         test_get_data_in_interval.side_effect = [grpc_fetch_retval]
@@ -829,11 +828,11 @@ def test_execute_pipeline(
     test_serve_online_data: MagicMock,
     test_replay_data: MagicMock,
     experiment: bool,
-    dummy_pipeline_options: PipelineOptions,
+    dummy_pipeline_args: PipelineExecutionParams,
 ) -> None:
-    dummy_pipeline_options.start_replay_at = 0 if experiment else None
+    dummy_pipeline_args.start_replay_at = 0 if experiment else None
 
-    execute_pipeline(dummy_pipeline_options)
+    execute_pipeline(dummy_pipeline_args)
 
     test_init_cluster_connection.assert_called_once()
 

--- a/modyn/tests/supervisor/internal/test_grpc_handler.py
+++ b/modyn/tests/supervisor/internal/test_grpc_handler.py
@@ -31,7 +31,7 @@ from modyn.storage.internal.grpc.generated.storage_pb2 import (
     GetNewDataSinceResponse,
 )
 from modyn.storage.internal.grpc.generated.storage_pb2_grpc import StorageStub
-from modyn.supervisor.internal.evaluation_result_writer import JsonResultWriter
+from modyn.supervisor.internal.evaluation_result_writer import DedicatedJsonResultWriter
 from modyn.supervisor.internal.grpc_handler import GRPCHandler
 from modyn.supervisor.internal.utils import EvaluationStatusReporter
 from modyn.trainer_server.internal.grpc.generated.trainer_server_pb2 import JsonString as TrainerJsonString
@@ -500,7 +500,7 @@ def test_store_evaluation_results(test_connection_established):
     with tempfile.TemporaryDirectory() as path:
         with patch.object(handler.evaluator, "get_evaluation_result", return_value=res) as get_method:
             eval_dir = pathlib.Path(path)
-            handler.store_evaluation_results([JsonResultWriter(5, 3, eval_dir)], evaluations)
+            handler.store_evaluation_results([DedicatedJsonResultWriter(5, 3, eval_dir)], evaluations)
             assert get_method.call_count == 2
 
             called_ids = [call[0][0].evaluation_id for call in get_method.call_args_list]
@@ -567,7 +567,7 @@ def test_store_evaluation_results_invalid(test_connection_established):
         with patch.object(handler.evaluator, "get_evaluation_result", return_value=res) as get_method:
             eval_dir = pathlib.Path(path)
 
-            handler.store_evaluation_results([JsonResultWriter(5, 3, eval_dir)], evaluations)
+            handler.store_evaluation_results([DedicatedJsonResultWriter(5, 3, eval_dir)], evaluations)
             get_method.assert_called_with(EvaluationResultRequest(evaluation_id=10))
 
             file_path = eval_dir / f"{5}_{3}.eval"

--- a/modyn/tests/supervisor/internal/test_supervisor.py
+++ b/modyn/tests/supervisor/internal/test_supervisor.py
@@ -45,7 +45,6 @@ def noop_pipeline_executor_constructor_mock(
     modyn_config: dict,
     pipeline_config: dict,
     eval_directory: str,
-    supervisor_supported_eval_result_writers: dict,
     pipeline_status_queue: mp.Queue,
     training_status_queue: mp.Queue,
     eval_status_queue: mp.Queue,

--- a/modyn/tests/utils/test_timer.py
+++ b/modyn/tests/utils/test_timer.py
@@ -1,0 +1,33 @@
+import time
+from typing import Generator
+
+from modyn.utils.timer import timed_generator
+
+
+def test_timed_generator() -> None:
+
+    def gen(r: int) -> Generator[int, None, None]:
+        time.sleep(0.01)
+        for i in range(r):
+            time.sleep(0.05)
+            yield i
+
+    s0 = time.time()
+    g = timed_generator(gen(3))
+    s1 = time.time()
+    assert s1 - s0 < 1e-3
+
+    n = next(g)
+    s2 = time.time()
+    # should take ~60ms
+    assert n[0] == 0 and abs((s2 - s1) * 1000 - 10 - 50) < 10 and abs(n[1] - 60) < 10
+
+    n = next(g)
+    s3 = time.time()
+    # should take ~50ms
+    assert n[0] == 1 and abs((s3 - s2) * 1000 - 50) < 10 and abs(n[1] - 50) < 10
+
+    n = next(g)
+    s4 = time.time()
+    # should take ~50ms
+    assert n[0] == 2 and abs((s4 - s3) * 1000 - 50) < 10 and abs(n[1] - 50) < 10

--- a/modyn/tests/utils/test_utils.py
+++ b/modyn/tests/utils/test_utils.py
@@ -72,7 +72,7 @@ def test_validate_yaml():
     read_pipeline(pipeline_path)
 
 
-@patch("time.time", lambda: 0.4)
+@patch("time.monotonic_ns", lambda: 400_000_000)
 def test_current_time_millis():
     assert current_time_millis() == 400
 

--- a/modyn/trainer_server/internal/dataset/key_sources/local_key_source.py
+++ b/modyn/trainer_server/internal/dataset/key_sources/local_key_source.py
@@ -17,7 +17,7 @@ class LocalKeySource(AbstractKeySource):
 
         if len(tuples_list) == 0:
             return [], []
-        keys, weights = zip(*tuples_list)
+        keys, weights = zip(*tuples_list)  # type: ignore
 
         return list(keys), list(weights)
 

--- a/modyn/utils/timer.py
+++ b/modyn/utils/timer.py
@@ -1,0 +1,20 @@
+import time
+from typing import Generator, TypeVar
+
+X = TypeVar("X")
+
+
+def timed_generator(generator: Generator[X, None, None]) -> Generator[tuple[X, float], None, None]:
+    """
+    Wrap a lazy generator and yields tuples of (item, elapsed_time).
+
+    Args:
+        generator: The lazy generator to wrap.
+
+    Returns:
+        A generator that yields (item, elapsed_time_millis) for each item in the original generator.
+    """
+    start_time = time.time()  # first evaluation starts when loop is entered
+    for item in generator:
+        yield item, (time.time() - start_time) * 1000  # yield item and compute elapsed time
+        start_time = time.time()  # next item requested: start timer again

--- a/modyn/utils/utils.py
+++ b/modyn/utils/utils.py
@@ -25,7 +25,7 @@ import torch
 
 logger = logging.getLogger(__name__)
 UNAVAILABLE_PKGS = []
-SECONDS_PER_UNIT = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+SECONDS_PER_UNIT = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800, "mth": 86400 * 30, "y": 365 * 86400}
 MAX_MESSAGE_SIZE = 1024 * 1024 * 128  # 128 MB
 EMIT_MESSAGE_PERCENTAGES = [0.25, 0.5, 0.75]
 
@@ -65,8 +65,17 @@ def trigger_available(trigger_type: str) -> bool:
 
 
 def current_time_millis() -> int:
-    timestamp = time.time() * 1000
+    timestamp = time.monotonic_ns() / 1_000_000
     return int(round(timestamp))
+
+
+def current_time_micros() -> int:
+    timestamp = time.monotonic_ns() / 1_000
+    return int(round(timestamp))
+
+
+def current_time_nanos() -> int:
+    return time.monotonic_ns()
 
 
 def grpc_connection_established(channel: grpc.Channel, timeout_sec: int = 5) -> bool:


### PR DESCRIPTION
# Motivation

The current state of `pipeline_executor.py` doesn't follow clear sequential or logical order. Also, the setup doesn't allow to automatically profile and log pipeline stage execution. Restructuring the orchestration of a pipeline in a PipelineExecutor here.

# Changes

- Split all logical pipeline stages into separate `PipelineExecutor` member functions and merge unused PipelineStages (like `RUN_TRAINING` and `TRAINING_DONE`). This allows to have a 1:1 mapping between logical pipeline stages and member functions.
- Sort the pipeline stage functions sequentially according to their position in the pipeline
- Add `@pipeline_stage(...)` decorator which wraps every pipeline stage function. When calling the decorated function we record meta information for `logging` (post-experiment analysis) and `tracking` (for online feedback) purposes. This includes `start` & `end` timestamps as well as the current "dataset/sample time". This is especially useful in experiments to be able to sort/plot different measurements by the time of the processed samples. 
- Move all state (that is not enclosed in controller objects like `grpc`) into a central `ExecutionState` dataclass.
- Adjusted tests accordingly, removing code duplication in tests by parameterizing tests with `pytest.mark.parameterize(...)`
- Some renaming and other minor adjustments