### PR TITLE
refactor: Use more explicit trigger configurations

### DIFF
--- a/benchmark/mnist/mnist.yaml
+++ b/benchmark/mnist/mnist.yaml
@@ -46,5 +46,4 @@ data:
       return Image.open(io.BytesIO(data)).convert("RGB")
 trigger:
   id: DataAmountTrigger
-  trigger_config:
-    data_points_for_trigger: 2000
+  num_samples: 2000

--- a/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
@@ -45,5 +45,4 @@ data:
 
 trigger:
   id: TimeTrigger
-  every: 1
-  unit: d
+  every: 1d

--- a/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/arxiv.yaml
@@ -45,5 +45,5 @@ data:
 
 trigger:
   id: TimeTrigger
-  trigger_config:
-    trigger_every: "1d"
+  every: 1
+  unit: d

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/arxiv_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/arxiv_datadrift.yaml
@@ -47,9 +47,8 @@ data:
 
 trigger:
   id: DataDriftTrigger
-  trigger_config:
-    data_points_for_detection: 100000
-    sample_size: 5000
+  data_points: 100000
+  sample_size: 5000
   
 evaluation:
   eval_strategy:

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/arxiv_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/arxiv_datadrift.yaml
@@ -47,7 +47,7 @@ data:
 
 trigger:
   id: DataDriftTrigger
-  data_points: 100000
+  detection_interval_data_points: 100000
   sample_size: 5000
   
 evaluation:

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
@@ -47,11 +47,10 @@ data:
 
 trigger:
   id: DataDriftTrigger
-  trigger_config:
-    data_points_for_detection: 5000
-    metric_name: mmd
-    metric_config:
-      bootstrap: False
+  data_points: 5000
+  metric: mmd
+  metric_config:
+    bootstrap: False
   
 evaluation:
   eval_strategy:

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
@@ -47,7 +47,7 @@ data:
 
 trigger:
   id: DataDriftTrigger
-  data_points: 5000
+  detection_interval_data_points: 5000
   metric: mmd
   metric_config:
     bootstrap: False

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/yearbook_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/yearbook_datadrift.yaml
@@ -49,11 +49,10 @@ data:
 
 trigger:
   id: DataDriftTrigger
-  trigger_config:
-    data_points_for_detection: 1000
-    metric_name: model
-    metric_config:
-      threshold: 0.7
+  data_points: 1000
+  metric: model
+  metric_config:
+    threshold: 0.7
   
 evaluation:
   eval_strategy:

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/yearbook_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/yearbook_datadrift.yaml
@@ -49,7 +49,7 @@ data:
 
 trigger:
   id: DataDriftTrigger
-  data_points: 1000
+  detection_interval_data_points: 1000
   metric: model
   metric_config:
     threshold: 0.7

--- a/benchmark/wildtime_benchmarks/example_pipelines/fmow.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/fmow.yaml
@@ -49,5 +49,4 @@ data:
 #change and configure it if you want day/week/month granularity
 trigger:
   id: DataAmountTrigger
-  trigger_config:
-    data_points_for_trigger: 2000
+  num_samples: 2000

--- a/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
@@ -45,5 +45,4 @@ data:
 
 trigger:
   id: TimeTrigger
-  every: 1
-  unit: d
+  every: 1d

--- a/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/huffpost.yaml
@@ -45,5 +45,5 @@ data:
 
 trigger:
   id: TimeTrigger
-  trigger_config:
-    trigger_every: "1d"
+  every: 1
+  unit: d

--- a/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
@@ -49,5 +49,4 @@ data:
 
 trigger:
   id: TimeTrigger
-  every: 1
-  unit: d
+  every: 1d

--- a/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/yearbook.yaml
@@ -49,5 +49,5 @@ data:
 
 trigger:
   id: TimeTrigger
-  trigger_config:
-    trigger_every: "1d"
+  every: 1
+  unit: d

--- a/experiments/cloc_online_dataset/gen_pipelines.py
+++ b/experiments/cloc_online_dataset/gen_pipelines.py
@@ -59,7 +59,7 @@ data:
 trigger:
   id: DataAmountTrigger
   trigger_config:
-    data_points_for_trigger: 500000
+    num_samples: 500000
 """
 
 def main():

--- a/modyn/config/examples/example-pipeline.yaml
+++ b/modyn/config/examples/example-pipeline.yaml
@@ -64,8 +64,7 @@ data:
       return Image.open(io.BytesIO(data)).convert("RGB")
 trigger:
   id: DataAmountTrigger
-  trigger_config:
-    data_points_for_trigger: 100
+  num_samples: 100
 evaluation:
   eval_strategy:
     name: "MatrixEvalStrategy"

--- a/modyn/config/schema/pipeline.py
+++ b/modyn/config/schema/pipeline.py
@@ -431,14 +431,17 @@ class DataAmountTriggerConfig(BaseModel):
 
 class DataDriftTriggerConfig(BaseModel):
     id: Literal["DataDriftTrigger"] = Field("DataDriftTrigger")
-    data_points: int = Field(description="The number of data points for one drift detection.", ge=1)
+    detection_interval_data_points: int = Field(
+        1000, description="The number of samples in the interval after which drift detection is performed.", ge=1
+    )
     sample_size: int | None = Field(None, description="The number of samples used for the metric calculation.", ge=1)
-    detection_interval: int = Field(1000, description="The interval in which drift detection is performed.", ge=1)
     metric: str = Field("model", description="The metric used for drift detection.")
     metric_config: dict[str, Any] = Field(default_factory=dict, description="Configuration for the evidently metric.")
 
 
-TriggerConfig = Annotated[Union[TimeTriggerConfig, DataAmountTriggerConfig, DataDriftTriggerConfig], Field(discriminator="id")]
+TriggerConfig = Annotated[
+    Union[TimeTriggerConfig, DataAmountTriggerConfig, DataDriftTriggerConfig], Field(discriminator="id")
+]
 
 
 # ---------------------------------------------------- EVALUATION ---------------------------------------------------- #

--- a/modyn/config/schema/pipeline.py
+++ b/modyn/config/schema/pipeline.py
@@ -418,16 +418,32 @@ class DataConfig(BaseModel):
 # ------------------------------------------------------ TRIGGER ----------------------------------------------------- #
 
 
-class TriggerConfig(BaseModel):
-    id: str = Field(description="Type of trigger to be used.")
+class TimeTriggerConfig(BaseModel):
+    id: Literal["TimeTrigger"] = Field("TimeTrigger")
+    every: int = Field(description="The interval length for the trigger specified by an integer", ge=1)
+    unit: Literal["s", "m", "h", "d", "w", "mth", "y"] = Field(description="The unit of the interval length.")
 
-    trigger_config: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Configuration dictionary that will be passed to the trigger on initialization.",
-    )
+
+class DataAmountTriggerConfig(BaseModel):
+    id: Literal["DataAmountTrigger"] = Field("DataAmountTrigger")
+    num_samples: int = Field(description="The number of samples that should trigger the pipeline.", ge=1)
+
+
+class DataDriftTriggerConfig(BaseModel):
+    id: Literal["DataDriftTrigger"] = Field("DataDriftTrigger")
+    data_points: int = Field(description="The number of data points for one drift detection.", ge=1)
+    sample_size: int | None = Field(None, description="The number of samples used for the metric calculation.", ge=1)
+    detection_interval: int = Field(1000, description="The interval in which drift detection is performed.", ge=1)
+    metric: str = Field("model", description="The metric used for drift detection.")
+    metric_config: dict[str, Any] = Field(default_factory=dict, description="Configuration for the evidently metric.")
+
+
+TriggerConfig = Annotated[Union[TimeTriggerConfig, DataAmountTriggerConfig, DataDriftTriggerConfig], Field(discriminator="id")]
 
 
 # ---------------------------------------------------- EVALUATION ---------------------------------------------------- #
+
+
 class Metric(BaseModel):
     name: str = Field(description="The name of the evaluation metric.")
     config: Optional[Dict[str, Any]] = Field(None, description="Configuration for the evaluation metric.")

--- a/modyn/supervisor/internal/triggers/amounttrigger.py
+++ b/modyn/supervisor/internal/triggers/amounttrigger.py
@@ -1,20 +1,19 @@
 from typing import Generator
 
+from modyn.config.schema.pipeline import DataAmountTriggerConfig
 from modyn.supervisor.internal.triggers.trigger import Trigger
 
 
 class DataAmountTrigger(Trigger):
     """Triggers when a certain number of data points have been used."""
 
-    def __init__(self, trigger_config: dict):
-        if "data_points_for_trigger" not in trigger_config.keys():
-            raise ValueError("Trigger config is missing `data_points_for_trigger` field")
-
-        self.data_points_for_trigger: int = trigger_config["data_points_for_trigger"]
-        assert self.data_points_for_trigger > 0, "data_points_for_trigger needs to be at least 1"
+    def __init__(self, config: DataAmountTriggerConfig):
+        self.data_points_for_trigger: int = config.num_samples
         self.remaining_data_points = 0
 
-        super().__init__(trigger_config)
+        assert self.data_points_for_trigger > 0, "data_points_for_trigger needs to be at least 1"
+
+        super().__init__()
 
     def inform(self, new_data: list[tuple[int, int, int]]) -> Generator[int, None, None]:
         assert self.remaining_data_points < self.data_points_for_trigger, "Inconsistent remaining datapoints"

--- a/modyn/supervisor/internal/triggers/timetrigger.py
+++ b/modyn/supervisor/internal/triggers/timetrigger.py
@@ -4,7 +4,6 @@ from typing import Generator
 
 from modyn.config.schema.pipeline import TimeTriggerConfig
 from modyn.supervisor.internal.triggers.trigger import Trigger
-from modyn.utils.utils import SECONDS_PER_UNIT
 
 
 class TimeTrigger(Trigger):
@@ -13,7 +12,7 @@ class TimeTrigger(Trigger):
     Clock starts with the first observed datapoint"""
 
     def __init__(self, config: TimeTriggerConfig):
-        self.trigger_every_s: int = config.every * SECONDS_PER_UNIT[config.unit]
+        self.trigger_every_s: int = config.every_seconds
         self.next_trigger_at: int | None = None
 
         if self.trigger_every_s < 1:

--- a/modyn/supervisor/internal/triggers/trigger.py
+++ b/modyn/supervisor/internal/triggers/trigger.py
@@ -1,14 +1,24 @@
 import pathlib
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Generator
+
+from modyn.config.schema.config import ModynConfig
+from modyn.config.schema.pipeline import ModynPipelineConfig
+
+
+@dataclass
+class TriggerContext:
+    pipeline_id: int
+    pipeline_config: ModynPipelineConfig
+    modyn_config: ModynConfig
+    base_dir: pathlib.Path
 
 
 class Trigger(ABC):
-    def __init__(self, trigger_config: dict) -> None:
-        assert trigger_config is not None, "trigger_config cannot be None."
 
     # pylint: disable=unnecessary-pass
-    def init_trigger(self, pipeline_id: int, pipeline_config: dict, modyn_config: dict, base_dir: pathlib.Path) -> None:
+    def init_trigger(self, context: TriggerContext) -> None:
         """The supervisor initializes the concrete Trigger with Trigger-type-specific configurations
         base_dir: the base directory to store Trigger outputs. A location at the supervisor.
         """

--- a/modyn/supervisor/internal/triggers/trigger_datasets/dataloader_info.py
+++ b/modyn/supervisor/internal/triggers/trigger_datasets/dataloader_info.py
@@ -15,7 +15,7 @@ class DataLoaderInfo:
         selector_address: str,
         num_prefetched_partitions: int,
         parallel_prefetch_requests: int,
-        tokenizer: Optional[None],
+        tokenizer: Optional[str],
     ):
         self.pipeline_id = pipeline_id
         self.dataset_id = dataset_id

--- a/modyn/supervisor/internal/triggers/utils.py
+++ b/modyn/supervisor/internal/triggers/utils.py
@@ -4,46 +4,11 @@ from typing import Optional, Union
 
 import pandas as pd
 import torch
-from evidently.metrics import EmbeddingsDriftMetric
-from evidently.metrics.data_drift import embedding_drift_methods
 from modyn.supervisor.internal.triggers.embedding_encoder_utils import EmbeddingEncoder
 from modyn.supervisor.internal.triggers.trigger_datasets import DataLoaderInfo, FixedKeysDataset, OnlineTriggerDataset
 from torch.utils.data import DataLoader
 
 logger = logging.getLogger(__name__)
-
-
-def get_evidently_metrics(
-    column_mapping_name: str, trigger_config: Optional[dict] = None
-) -> list[EmbeddingsDriftMetric]:
-    """This function instantiates an Evidently metric given metric configuration.
-    If we want to support multiple metrics in the future, we can change the code to looping through the configurations.
-
-    Evidently metric configurations follow exactly the four DriftMethods defined in embedding_drift_methods:
-    model, distance, mmd, ratio
-    If metric_name not given, we use the default 'model' metric.
-    Otherwise, we use the metric given by metric_name, with optional metric configuration specific to the metric.
-    """
-    if trigger_config is None:
-        trigger_config = {}
-
-    metric_name: str = "model"
-    metric_config: dict = {}
-
-    if "metric_name" in trigger_config.keys():
-        metric_name = trigger_config["metric_name"]
-        if "metric_config" in trigger_config.keys():
-            metric_config = trigger_config["metric_config"]
-
-    metric = getattr(embedding_drift_methods, metric_name)(**metric_config)
-
-    metrics = [
-        EmbeddingsDriftMetric(
-            column_mapping_name,
-            drift_method=metric,
-        )
-    ]
-    return metrics
 
 
 def prepare_trigger_dataloader_by_trigger(

--- a/modyn/tests/config/test_config_integrity.py
+++ b/modyn/tests/config/test_config_integrity.py
@@ -1,11 +1,7 @@
 from pathlib import Path
 
 import pytest
-from experiments.yearbook.compare_trigger_policies.pipeline_config import (
-    gen_pipeline_config as yearbook_pipeline_config,
-)
 from modyn.config import read_modyn_config, read_pipeline
-from modyn.config.schema.pipeline import OffsetEvalStrategyConfig, OffsetEvalStrategyModel, TimeTriggerConfig, TriggerConfig
 from modynclient.config import read_client_config
 
 """Directories can either be file paths or directories.

--- a/modyn/tests/config/test_config_integrity.py
+++ b/modyn/tests/config/test_config_integrity.py
@@ -60,17 +60,3 @@ def test_client_config_integrity(config_path: str) -> None:
     file = PROJECT_ROOT / config_path
     assert file.exists(), f"Client config file {config_path} does not exist."
     read_client_config(file)
-
-
-def test_dynamic_experiment_configs() -> None:
-    yearbook_pipeline_config(
-        name="test",
-        trigger=TimeTriggerConfig(
-            id="TimeTrigger",
-            every=1,
-            unit="y",
-        ),
-        eval_strategy=OffsetEvalStrategyModel(
-            name="OffsetEvalStrategy", config=OffsetEvalStrategyConfig(offsets=["1d"])
-        ),
-    )

--- a/modyn/tests/config/test_config_integrity.py
+++ b/modyn/tests/config/test_config_integrity.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
 import pytest
+from experiments.yearbook.compare_trigger_policies.pipeline_config import (
+    gen_pipeline_config as yearbook_pipeline_config,
+)
 from modyn.config import read_modyn_config, read_pipeline
+from modyn.config.schema.pipeline import OffsetEvalStrategyConfig, OffsetEvalStrategyModel, TimeTriggerConfig, TriggerConfig
 from modynclient.config import read_client_config
 
 """Directories can either be file paths or directories.
@@ -56,3 +60,17 @@ def test_client_config_integrity(config_path: str) -> None:
     file = PROJECT_ROOT / config_path
     assert file.exists(), f"Client config file {config_path} does not exist."
     read_client_config(file)
+
+
+def test_dynamic_experiment_configs() -> None:
+    yearbook_pipeline_config(
+        name="test",
+        trigger=TimeTriggerConfig(
+            id="TimeTrigger",
+            every=1,
+            unit="y",
+        ),
+        eval_strategy=OffsetEvalStrategyModel(
+            name="OffsetEvalStrategy", config=OffsetEvalStrategyConfig(offsets=["1d"])
+        ),
+    )

--- a/modyn/tests/conftest.py
+++ b/modyn/tests/conftest.py
@@ -15,6 +15,7 @@ from modyn.config.schema.config import (
 )
 from modyn.config.schema.pipeline import (
     CheckpointingConfig,
+    DataAmountTriggerConfig,
     DataConfig,
     EvalDataConfig,
     EvaluationConfig,
@@ -31,7 +32,6 @@ from modyn.config.schema.pipeline import (
     Pipeline,
     PipelineModelStorageConfig,
     TrainingConfig,
-    TriggerConfig,
 )
 
 # --------------------------------------------------- Modyn config --------------------------------------------------- #
@@ -210,8 +210,5 @@ def dummy_pipeline_config(pipeline_training_config: TrainingConfig) -> ModynPipe
             dataset_id="test",
             bytes_parser_function="def bytes_parser_function(x):\n\treturn x",
         ),
-        trigger=TriggerConfig(
-            id="DataAmountTrigger",
-            trigger_config={"data_points_for_trigger": 1},
-        ),
+        trigger=DataAmountTriggerConfig(num_samples=1),
     )

--- a/modyn/tests/supervisor/internal/triggers/test_amounttrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_amounttrigger.py
@@ -1,30 +1,22 @@
-import pytest
+from modyn.config.schema.pipeline import DataAmountTriggerConfig
 from modyn.supervisor.internal.triggers import DataAmountTrigger
 
 
 def test_initialization() -> None:
-    trigger = DataAmountTrigger({"data_points_for_trigger": 42})
+    trigger = DataAmountTrigger(DataAmountTriggerConfig(num_samples=42))
     assert trigger.data_points_for_trigger == 42
     assert trigger.remaining_data_points == 0
 
 
-def test_init_fails_if_invalid() -> None:
-    with pytest.raises(ValueError, match="Trigger config is missing `data_points_for_trigger` field"):
-        DataAmountTrigger({})
-
-    with pytest.raises(AssertionError, match="data_points_for_trigger needs to be at least 1"):
-        DataAmountTrigger({"data_points_for_trigger": 0})
-
-
 def test_inform() -> None:
-    trigger = DataAmountTrigger({"data_points_for_trigger": 1})
+    trigger = DataAmountTrigger(DataAmountTriggerConfig(num_samples=1))
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert list(trigger.inform([])) == []
     assert list(trigger.inform([(10, 1)])) == [0]
     assert list(trigger.inform([(10, 1), (10, 1)])) == [0, 1]
     assert list(trigger.inform([(10, 1), (10, 1), (10, 1)])) == [0, 1, 2]
 
-    trigger = DataAmountTrigger({"data_points_for_trigger": 2})
+    trigger = DataAmountTrigger(DataAmountTriggerConfig(num_samples=2))
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert list(trigger.inform([(10, 1)])) == []
     assert list(trigger.inform([(10, 1)])) == [0]
@@ -35,7 +27,7 @@ def test_inform() -> None:
     assert list(trigger.inform([(10, 1), (10, 1), (10, 1), (10, 1), (10, 1)])) == [1, 3]
     assert list(trigger.inform([(10, 1)])) == [0]
 
-    trigger = DataAmountTrigger({"data_points_for_trigger": 5})
+    trigger = DataAmountTrigger(DataAmountTriggerConfig(num_samples=5))
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert list(trigger.inform([(10, 1), (10, 1), (10, 1), (10, 1)])) == []
     assert list(trigger.inform([(10, 1), (10, 1), (10, 1)])) == [0]

--- a/modyn/tests/supervisor/internal/triggers/test_datadrifttrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_datadrifttrigger.py
@@ -4,77 +4,16 @@ import pathlib
 from typing import Optional
 from unittest.mock import patch
 
-import pytest
+from modyn.config.schema.config import ModynConfig
+from modyn.config.schema.pipeline import DataDriftTriggerConfig, ModynPipelineConfig
 from modyn.supervisor.internal.triggers import DataDriftTrigger
 from modyn.supervisor.internal.triggers.embedding_encoder_utils import EmbeddingEncoderDownloader
+from modyn.supervisor.internal.triggers.trigger import TriggerContext
 from modyn.supervisor.internal.triggers.trigger_datasets import DataLoaderInfo
 
 BASEDIR: pathlib.Path = pathlib.Path(os.path.realpath(__file__)).parent / "test_eval_dir"
 PIPELINE_ID = 42
 SAMPLE = (10, 1, 1)
-
-
-def get_minimal_training_config() -> dict:
-    return {
-        "gpus": 1,
-        "device": "cpu",
-        "dataloader_workers": 1,
-        "use_previous_model": True,
-        "initial_model": "random",
-        "batch_size": 42,
-        "optimizers": [
-            {"name": "default1", "algorithm": "SGD", "source": "PyTorch", "param_groups": [{"module": "model"}]},
-        ],
-        "optimization_criterion": {"name": "CrossEntropyLoss"},
-        "checkpointing": {"activated": False},
-        "selection_strategy": {"name": "NewDataStrategy", "maximum_keys_in_memory": 10},
-    }
-
-
-def get_minimal_evaluation_config() -> dict:
-    return {
-        "eval_strategy": {
-            "name": "MatrixEvalStrategy",
-            "config": {
-                "eval_every": "100s",
-                "eval_start_from": 0,
-                "eval_end_at": 300,
-            },
-        },
-        "device": "cpu",
-        "datasets": [
-            {
-                "dataset_id": "MNIST_eval",
-                "bytes_parser_function": "def bytes_parser_function(data: bytes) -> bytes:\n\treturn data",
-                "dataloader_workers": 2,
-                "batch_size": 64,
-                "metrics": [{"name": "Accuracy"}],
-            }
-        ],
-    }
-
-
-def get_minimal_trigger_config() -> dict:
-    return {}
-
-
-def get_minimal_pipeline_config() -> dict:
-    return {
-        "pipeline": {"name": "Test"},
-        "model": {"id": "ResNet18"},
-        "model_storage": {"full_model_strategy": {"name": "PyTorchFullModel"}},
-        "training": get_minimal_training_config(),
-        "data": {"dataset_id": "test", "bytes_parser_function": "def bytes_parser_function(x):\n\treturn x"},
-        "trigger": {"id": "DataDriftTrigger", "trigger_config": get_minimal_trigger_config()},
-    }
-
-
-def get_simple_system_config() -> dict:
-    return {
-        "storage": {"hostname": "test", "port": 42},
-        "selector": {"hostname": "test", "port": 42},
-        "model_storage": {"hostname": "test", "port": 42},
-    }
 
 
 def noop(self) -> None:
@@ -109,8 +48,8 @@ def noop_dataloader_info_constructor_mock(
 
 
 def test_initialization() -> None:
-    trigger = DataDriftTrigger({"data_points_for_detection": 42})
-    assert trigger.detection_interval == 42
+    trigger = DataDriftTrigger(DataDriftTriggerConfig(detection_interval_data_points=42))
+    assert trigger.config.detection_interval_data_points == 42
     assert trigger.previous_trigger_id is None
     assert trigger.previous_model_id is None
     assert not trigger.model_updated
@@ -118,33 +57,26 @@ def test_initialization() -> None:
     assert trigger.leftover_data_points == 0
 
 
-def test_init_fails_if_invalid() -> None:
-    with pytest.raises(AssertionError, match="data_points_for_detection needs to be at least 1"):
-        DataDriftTrigger({"data_points_for_detection": 0})
-
-    with pytest.raises(AssertionError, match="sample_size needs to be at least 1"):
-        DataDriftTrigger({"sample_size": 0})
-
-
 @patch.object(EmbeddingEncoderDownloader, "__init__", noop_embedding_encoder_downloader_constructor_mock)
 @patch.object(DataLoaderInfo, "__init__", noop_dataloader_info_constructor_mock)
-def test_init_trigger() -> None:
-    trigger = DataDriftTrigger(get_minimal_trigger_config())
+def test_init_trigger(
+    dummy_pipeline_config: ModynPipelineConfig,
+    dummy_system_config: ModynConfig,
+) -> None:
+    trigger = DataDriftTrigger(DataDriftTriggerConfig())
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     with patch("os.makedirs", return_value=None):
-        pipeline_config = get_minimal_pipeline_config()
-        modyn_config = get_simple_system_config()
-        trigger.init_trigger(PIPELINE_ID, pipeline_config, modyn_config, BASEDIR)
-        assert trigger.pipeline_id == PIPELINE_ID
-        assert trigger.pipeline_config == pipeline_config
-        assert trigger.modyn_config == modyn_config
-        assert trigger.base_dir == BASEDIR
+        trigger.init_trigger(TriggerContext(PIPELINE_ID, dummy_pipeline_config, dummy_system_config, BASEDIR))
+        assert trigger.context.pipeline_id == PIPELINE_ID
+        assert trigger.context.pipeline_config == dummy_pipeline_config
+        assert trigger.context.modyn_config == dummy_system_config
+        assert trigger.context.base_dir == BASEDIR
         assert isinstance(trigger.dataloader_info, DataLoaderInfo)
         assert isinstance(trigger.encoder_downloader, EmbeddingEncoderDownloader)
 
 
 def test_inform_previous_trigger_and_data_points() -> None:
-    trigger = DataDriftTrigger(get_minimal_trigger_config())
+    trigger = DataDriftTrigger(DataDriftTriggerConfig())
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     trigger.inform_previous_trigger_and_data_points(42, 42)
     assert trigger.previous_trigger_id == 42
@@ -152,7 +84,7 @@ def test_inform_previous_trigger_and_data_points() -> None:
 
 
 def test_inform_previous_model_id() -> None:
-    trigger = DataDriftTrigger(get_minimal_trigger_config())
+    trigger = DataDriftTrigger(DataDriftTriggerConfig())
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     trigger.inform_previous_model(42)
     assert trigger.previous_model_id == 42
@@ -160,7 +92,7 @@ def test_inform_previous_model_id() -> None:
 
 @patch.object(DataDriftTrigger, "detect_drift", return_value=True)
 def test_inform_always_drift(test_detect_drift) -> None:
-    trigger = DataDriftTrigger({"data_points_for_detection": 1})
+    trigger = DataDriftTrigger(DataDriftTriggerConfig(detection_interval_data_points=1))
     num_triggers = 0
     for _ in trigger.inform([SAMPLE, SAMPLE, SAMPLE, SAMPLE, SAMPLE]):
         num_triggers += 1
@@ -169,7 +101,7 @@ def test_inform_always_drift(test_detect_drift) -> None:
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert num_triggers == 5
 
-    trigger = DataDriftTrigger({"data_points_for_detection": 2})
+    trigger = DataDriftTrigger(DataDriftTriggerConfig(detection_interval_data_points=2))
     num_triggers = 0
     for _ in trigger.inform([SAMPLE, SAMPLE, SAMPLE, SAMPLE, SAMPLE]):
         num_triggers += 1
@@ -178,7 +110,7 @@ def test_inform_always_drift(test_detect_drift) -> None:
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert num_triggers == 2
 
-    trigger = DataDriftTrigger({"data_points_for_detection": 5})
+    trigger = DataDriftTrigger(DataDriftTriggerConfig(detection_interval_data_points=5))
     num_triggers = 0
     for _ in trigger.inform([SAMPLE, SAMPLE, SAMPLE, SAMPLE, SAMPLE]):
         num_triggers += 1
@@ -190,7 +122,7 @@ def test_inform_always_drift(test_detect_drift) -> None:
 
 @patch.object(DataDriftTrigger, "detect_drift", return_value=False)
 def test_inform_no_drift(test_detect_no_drift) -> None:
-    trigger = DataDriftTrigger({"data_points_for_detection": 1})
+    trigger = DataDriftTrigger(DataDriftTriggerConfig(detection_interval_data_points=1))
     num_triggers = 0
     for _ in trigger.inform([SAMPLE, SAMPLE, SAMPLE, SAMPLE, SAMPLE]):
         num_triggers += 1
@@ -199,7 +131,7 @@ def test_inform_no_drift(test_detect_no_drift) -> None:
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert num_triggers == 1
 
-    trigger = DataDriftTrigger({"data_points_for_detection": 2})
+    trigger = DataDriftTrigger(DataDriftTriggerConfig(detection_interval_data_points=2))
     num_triggers = 0
     for _ in trigger.inform([SAMPLE, SAMPLE, SAMPLE, SAMPLE, SAMPLE]):
         num_triggers += 1
@@ -208,7 +140,7 @@ def test_inform_no_drift(test_detect_no_drift) -> None:
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert num_triggers == 1
 
-    trigger = DataDriftTrigger({"data_points_for_detection": 5})
+    trigger = DataDriftTrigger(DataDriftTriggerConfig(detection_interval_data_points=5))
     num_triggers = 0
     for _ in trigger.inform([SAMPLE, SAMPLE, SAMPLE, SAMPLE, SAMPLE]):
         num_triggers += 1

--- a/modyn/tests/supervisor/internal/triggers/test_timetrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_timetrigger.py
@@ -3,13 +3,13 @@ from modyn.supervisor.internal.triggers import TimeTrigger
 
 
 def test_initialization() -> None:
-    trigger = TimeTrigger(TimeTriggerConfig(every=2, unit="s"))
+    trigger = TimeTrigger(TimeTriggerConfig(every="2s"))
     assert trigger.trigger_every_s == 2
     assert trigger.next_trigger_at is None
 
 
 def test_inform() -> None:
-    trigger = TimeTrigger(TimeTriggerConfig(every=1000, unit="s"))
+    trigger = TimeTrigger(TimeTriggerConfig(every="1000s"))
     LABEL = 2  # pylint: disable=invalid-name
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert list(trigger.inform([])) == []

--- a/modyn/tests/supervisor/internal/triggers/test_timetrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_timetrigger.py
@@ -1,23 +1,15 @@
-import pytest
+from modyn.config.schema.pipeline import TimeTriggerConfig
 from modyn.supervisor.internal.triggers import TimeTrigger
 
 
 def test_initialization() -> None:
-    trigger = TimeTrigger({"trigger_every": "2s"})
+    trigger = TimeTrigger(TimeTriggerConfig(every=2, unit="s"))
     assert trigger.trigger_every_s == 2
     assert trigger.next_trigger_at is None
 
 
-def test_init_fails_if_invalid() -> None:
-    with pytest.raises(ValueError, match="Trigger config is missing `trigger_every` field"):
-        TimeTrigger({})
-
-    with pytest.raises(ValueError, match="trigger_every must be > 0, but is 0"):
-        TimeTrigger({"trigger_every": "0s"})
-
-
 def test_inform() -> None:
-    trigger = TimeTrigger({"trigger_every": "1000s"})
+    trigger = TimeTrigger(TimeTriggerConfig(every=1000, unit="s"))
     LABEL = 2  # pylint: disable=invalid-name
     # pylint: disable-next=use-implicit-booleaness-not-comparison
     assert list(trigger.inform([])) == []

--- a/modyn/tests/supervisor/internal/triggers/test_trigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_trigger.py
@@ -6,4 +6,4 @@ from modyn.supervisor.internal.triggers import Trigger
 
 @patch.multiple(Trigger, __abstractmethods__=set())
 def test_initialization() -> None:
-    _ = Trigger({})
+    _ = Trigger()

--- a/modyn/utils/utils.py
+++ b/modyn/utils/utils.py
@@ -25,7 +25,7 @@ import torch
 
 logger = logging.getLogger(__name__)
 UNAVAILABLE_PKGS = []
-SECONDS_PER_UNIT = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800, "mth": 86400 * 30, "y": 365 * 86400}
+SECONDS_PER_UNIT = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800, "y": 365 * 86400}
 MAX_MESSAGE_SIZE = 1024 * 1024 * 128  # 128 MB
 EMIT_MESSAGE_PERCENTAGES = [0.25, 0.5, 0.75]
 

--- a/modynclient/config/examples/dummy.yaml
+++ b/modynclient/config/examples/dummy.yaml
@@ -47,5 +47,4 @@ data:
       return arr.astype(np.float32)
 trigger:
   id: DataAmountTrigger
-  trigger_config:
-    data_points_for_trigger: 2
+  num_samples: 2

--- a/modynclient/config/examples/mnist.yaml
+++ b/modynclient/config/examples/mnist.yaml
@@ -46,8 +46,7 @@ data:
       return Image.open(io.BytesIO(data)).convert("RGB")
 trigger:
   id: DataAmountTrigger
-  trigger_config:
-    data_points_for_trigger: 2000
+  num_samples: 2000
 evaluation:
   eval_strategy:
     name: MatrixEvalStrategy


### PR DESCRIPTION
# Motivation

Previously it was rather hard to find out which fields and configuration items need to be set for different trigger policies, especially for drift policies as they have more parameters.

The pipeline configurations within the repository had a quite sparse coverage of the allowed flags. What is more it wasn't documented which of those fields are required, which are optional, and what the defaults are.

# Changes

Now we have dedicated configuration models for every trigger policy and do not need to run the pipeline to determine if a configuration is valid. The typing alone now assures a valid configuration and makes it easier for others to configure their own triggers.

#448 will be based on this