### PR TITLE
feat: Enable `torch.inference_mode` if downsampler supports it

### DIFF
--- a/modyn/selector/internal/selector_strategies/new_data_strategy.py
+++ b/modyn/selector/internal/selector_strategies/new_data_strategy.py
@@ -50,8 +50,7 @@ class NewDataStrategy(AbstractSelectionStrategy):
             )
         else:
             raise NotImplementedError(
-                f'Unknown storage backend "{
-                    self._config.storage_backend}". Supported: local, database'
+                f'Unknown storage backend "{self._config.storage_backend}". Supported: local, database'
             )
         return _storage_backend
 

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_abstract_matrix_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_abstract_matrix_downsampling_strategy.py
@@ -34,30 +34,30 @@ def test_init():
 @patch.multiple(AbstractMatrixDownsamplingStrategy, __abstractmethods__=set())
 def test_collect_embeddings():
     amds = AbstractMatrixDownsamplingStrategy(*get_sampler_config())
+    with torch.inference_mode(mode=(not amds.requires_grad)):
+        amds.matrix_content = MatrixContent.EMBEDDINGS
 
-    amds.matrix_content = MatrixContent.EMBEDDINGS
+        assert amds.requires_coreset_supporting_module
+        assert not amds.matrix_elements  # thank you pylint! amds.matrix_elements == []
 
-    assert amds.requires_coreset_supporting_module
-    assert not amds.matrix_elements  # thank you pylint! amds.matrix_elements == []
+        first_embedding = torch.randn((4, 5))
+        second_embedding = torch.randn((3, 5))
+        amds.inform_samples([1, 2, 3, 4], None, None, first_embedding)
+        amds.inform_samples([21, 31, 41], None, None, second_embedding)
 
-    first_embedding = torch.randn((4, 5))
-    second_embedding = torch.randn((3, 5))
-    amds.inform_samples([1, 2, 3, 4], None, None, first_embedding)
-    amds.inform_samples([21, 31, 41], None, None, second_embedding)
+        assert np.concatenate(amds.matrix_elements).shape == (7, 5)
+        assert all(torch.equal(el1, el2) for el1, el2 in zip(amds.matrix_elements, [first_embedding, second_embedding]))
+        assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41]
 
-    assert np.concatenate(amds.matrix_elements).shape == (7, 5)
-    assert all(torch.equal(el1, el2) for el1, el2 in zip(amds.matrix_elements, [first_embedding, second_embedding]))
-    assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41]
+        third_embedding = torch.randn((23, 5))
+        amds.inform_samples(list(range(1000, 1023)), None, None, third_embedding)
 
-    third_embedding = torch.randn((23, 5))
-    amds.inform_samples(list(range(1000, 1023)), None, None, third_embedding)
-
-    assert np.concatenate(amds.matrix_elements).shape == (30, 5)
-    assert all(
-        torch.equal(el1, el2)
-        for el1, el2 in zip(amds.matrix_elements, [first_embedding, second_embedding, third_embedding])
-    )
-    assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41] + list(range(1000, 1023))
+        assert np.concatenate(amds.matrix_elements).shape == (30, 5)
+        assert all(
+            torch.equal(el1, el2)
+            for el1, el2 in zip(amds.matrix_elements, [first_embedding, second_embedding, third_embedding])
+        )
+        assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41] + list(range(1000, 1023))
 
 
 @patch.multiple(AbstractMatrixDownsamplingStrategy, __abstractmethods__=set())
@@ -66,58 +66,59 @@ def test_collect_embeddings():
 )
 def test_collect_embedding_balance(test_amds):
     amds = AbstractMatrixDownsamplingStrategy(*get_sampler_config(True))
+    with torch.inference_mode(mode=(not amds.requires_grad)):
+        amds.matrix_content = MatrixContent.EMBEDDINGS
 
-    amds.matrix_content = MatrixContent.EMBEDDINGS
+        assert amds.requires_coreset_supporting_module
+        assert amds.requires_data_label_by_label
+        assert not amds.matrix_elements  # thank you pylint! amds.matrix_elements == []
 
-    assert amds.requires_coreset_supporting_module
-    assert amds.requires_data_label_by_label
-    assert not amds.matrix_elements  # thank you pylint! amds.matrix_elements == []
+        first_embedding = torch.randn((4, 5))
+        second_embedding = torch.randn((3, 5))
+        amds.inform_samples([1, 2, 3, 4], None, None, first_embedding)
+        amds.inform_samples([21, 31, 41], None, None, second_embedding)
 
-    first_embedding = torch.randn((4, 5))
-    second_embedding = torch.randn((3, 5))
-    amds.inform_samples([1, 2, 3, 4], None, None, first_embedding)
-    amds.inform_samples([21, 31, 41], None, None, second_embedding)
+        assert np.concatenate(amds.matrix_elements).shape == (7, 5)
+        assert all(torch.equal(el1, el2) for el1, el2 in zip(amds.matrix_elements, [first_embedding, second_embedding]))
+        assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41]
 
-    assert np.concatenate(amds.matrix_elements).shape == (7, 5)
-    assert all(torch.equal(el1, el2) for el1, el2 in zip(amds.matrix_elements, [first_embedding, second_embedding]))
-    assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41]
+        amds.inform_end_of_current_label()
 
-    amds.inform_end_of_current_label()
+        third_embedding = torch.randn((23, 5))
+        assert len(amds.matrix_elements) == 0
+        amds.inform_samples(list(range(1000, 1023)), None, None, third_embedding)
 
-    third_embedding = torch.randn((23, 5))
-    assert len(amds.matrix_elements) == 0
-    amds.inform_samples(list(range(1000, 1023)), None, None, third_embedding)
-
-    assert np.concatenate(amds.matrix_elements).shape == (23, 5)
-    assert all(torch.equal(el1, el2) for el1, el2 in zip(amds.matrix_elements, [third_embedding]))
-    assert amds.index_sampleid_map == list(range(1000, 1023))
-    assert amds.already_selected_samples == [1, 3]
-    amds.inform_end_of_current_label()
-    assert amds.already_selected_samples == [1, 3, 1000, 1002]
+        assert np.concatenate(amds.matrix_elements).shape == (23, 5)
+        assert all(torch.equal(el1, el2) for el1, el2 in zip(amds.matrix_elements, [third_embedding]))
+        assert amds.index_sampleid_map == list(range(1000, 1023))
+        assert amds.already_selected_samples == [1, 3]
+        amds.inform_end_of_current_label()
+        assert amds.already_selected_samples == [1, 3, 1000, 1002]
 
 
 @patch.multiple(AbstractMatrixDownsamplingStrategy, __abstractmethods__=set())
 def test_collect_gradients():
     amds = AbstractMatrixDownsamplingStrategy(*get_sampler_config())
-    amds.matrix_content = MatrixContent.GRADIENTS
+    with torch.inference_mode(mode=(not amds.requires_grad)):
+        amds.matrix_content = MatrixContent.GRADIENTS
 
-    first_output = torch.randn((4, 2))
-    first_output.requires_grad = True
-    first_target = torch.tensor([1, 1, 1, 0])
-    first_embedding = torch.randn((4, 5))
-    amds.inform_samples([1, 2, 3, 4], first_output, first_target, first_embedding)
+        first_output = torch.randn((4, 2))
+        first_output.requires_grad = True
+        first_target = torch.tensor([1, 1, 1, 0])
+        first_embedding = torch.randn((4, 5))
+        amds.inform_samples([1, 2, 3, 4], first_output, first_target, first_embedding)
 
-    second_output = torch.randn((3, 2))
-    second_output.requires_grad = True
-    second_target = torch.tensor([0, 1, 0])
-    second_embedding = torch.randn((3, 5))
-    amds.inform_samples([21, 31, 41], second_output, second_target, second_embedding)
+        second_output = torch.randn((3, 2))
+        second_output.requires_grad = True
+        second_target = torch.tensor([0, 1, 0])
+        second_embedding = torch.randn((3, 5))
+        amds.inform_samples([21, 31, 41], second_output, second_target, second_embedding)
 
-    assert len(amds.matrix_elements) == 2
+        assert len(amds.matrix_elements) == 2
 
-    # expected shape = (a,b)
-    # a = 7 (4 samples in the first batch and 3 samples in the second batch)
-    # b = 5 * 2 + 2 where 5 is the input dimension of the last layer and 2 is the output one
-    assert np.concatenate(amds.matrix_elements).shape == (7, 12)
+        # expected shape = (a,b)
+        # a = 7 (4 samples in the first batch and 3 samples in the second batch)
+        # b = 5 * 2 + 2 where 5 is the input dimension of the last layer and 2 is the output one
+        assert np.concatenate(amds.matrix_elements).shape == (7, 12)
 
-    assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41]
+        assert amds.index_sampleid_map == [1, 2, 3, 4, 21, 31, 41]

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_craig_remote_downsampling.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_craig_remote_downsampling.py
@@ -25,18 +25,20 @@ def get_sampler_config(balance=False):
 
 def test_inform_samples():
     sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    # Test data
-    sample_ids = [1, 2, 3]
-    forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1])  # 3 target labels
-    embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        # Test data
+        sample_ids = [1, 2, 3]
+        forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1])  # 3 target labels
+        embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
 
-    expected_shape = (1, 3, forward_output.shape[1] * (1 + embedding.shape[1]))
-    assert len(sampler.current_class_gradients) == 1
-    assert np.array(sampler.current_class_gradients).shape == expected_shape
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
+
+        expected_shape = (1, 3, forward_output.shape[1] * (1 + embedding.shape[1]))
+        assert len(sampler.current_class_gradients) == 1
+        assert np.array(sampler.current_class_gradients).shape == expected_shape
 
 
 # Dummy distance matrix for testing
@@ -45,143 +47,149 @@ initial_matrix = np.array([[0, 1], [1, 0]])
 
 def test_add_to_distance_matrix_single_submatrix():
     sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    submatrix = np.array([[2]])
-    sampler.add_to_distance_matrix(initial_matrix)
-    sampler.add_to_distance_matrix(submatrix)
-    expected_result = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 2]])
-    assert np.array_equal(sampler.distance_matrix, expected_result)
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        submatrix = np.array([[2]])
+        sampler.add_to_distance_matrix(initial_matrix)
+        sampler.add_to_distance_matrix(submatrix)
+        expected_result = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 2]])
+        assert np.array_equal(sampler.distance_matrix, expected_result)
 
 
 def test_add_to_distance_matrix_multiple_submatrix():
     sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    sampler.add_to_distance_matrix(initial_matrix)
-    submatrix = np.array([[3, 4], [4, 3]])
-    sampler.add_to_distance_matrix(submatrix)
-    expected_result = np.array([[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 3, 4], [0, 0, 4, 3]])
-    assert np.array_equal(sampler.distance_matrix, expected_result)
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sampler.add_to_distance_matrix(initial_matrix)
+        submatrix = np.array([[3, 4], [4, 3]])
+        sampler.add_to_distance_matrix(submatrix)
+        expected_result = np.array([[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 3, 4], [0, 0, 4, 3]])
+        assert np.array_equal(sampler.distance_matrix, expected_result)
 
 
 def test_add_to_distance_matrix_large_submatrix():
     sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    sampler.add_to_distance_matrix(initial_matrix)
-    submatrix = np.array([[5, 6, 7], [6, 5, 7], [7, 7, 5]])
-    sampler.add_to_distance_matrix(submatrix)
-    sampler.add_to_distance_matrix(np.array([[0, 0], [0, 0]]))
-    expected_result = np.array(
-        [
-            [0, 1, 0, 0, 0, 0, 0],
-            [1, 0, 0, 0, 0, 0, 0],
-            [0, 0, 5, 6, 7, 0, 0],
-            [0, 0, 6, 5, 7, 0, 0],
-            [0, 0, 7, 7, 5, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0],
-        ]
-    )
-    assert np.array_equal(sampler.distance_matrix, expected_result)
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sampler.add_to_distance_matrix(initial_matrix)
+        submatrix = np.array([[5, 6, 7], [6, 5, 7], [7, 7, 5]])
+        sampler.add_to_distance_matrix(submatrix)
+        sampler.add_to_distance_matrix(np.array([[0, 0], [0, 0]]))
+        expected_result = np.array(
+            [
+                [0, 1, 0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0, 0, 0],
+                [0, 0, 5, 6, 7, 0, 0],
+                [0, 0, 6, 5, 7, 0, 0],
+                [0, 0, 7, 7, 5, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+            ]
+        )
+        assert np.array_equal(sampler.distance_matrix, expected_result)
 
 
 def test_inform_end_of_current_label_and_select():
     sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    sample_ids = [1, 2, 3]
-    forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1])
-    embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [1, 2, 3]
+        forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1])
+        embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (0, 0)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (3, 3)
-    assert len(sampler.current_class_gradients) == 0
+        assert sampler.distance_matrix.shape == (0, 0)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (3, 3)
+        assert len(sampler.current_class_gradients) == 0
 
-    sample_ids = [10, 11, 12, 13]
-    forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([0, 0, 0, 0])  # 4 target labels
-    embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
+        sample_ids = [10, 11, 12, 13]
+        forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([0, 0, 0, 0])  # 4 target labels
+        embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (3, 3)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (7, 7)
-    assert len(sampler.current_class_gradients) == 0
-    assert sampler.index_sampleid_map == [1, 2, 3, 10, 11, 12, 13]
+        assert sampler.distance_matrix.shape == (3, 3)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (7, 7)
+        assert len(sampler.current_class_gradients) == 0
+        assert sampler.index_sampleid_map == [1, 2, 3, 10, 11, 12, 13]
 
-    selected_points, selected_weights = sampler.select_points()
+        selected_points, selected_weights = sampler.select_points()
 
-    assert len(selected_points) == 3
-    assert len(selected_weights) == 3
-    assert all(weight > 0 for weight in selected_weights)
-    assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
+        assert len(selected_points) == 3
+        assert len(selected_weights) == 3
+        assert all(weight > 0 for weight in selected_weights)
+        assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
 
 
 def test_inform_end_of_current_label_and_select_balanced():
     sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config(True))
-    sample_ids = [1, 2, 3, 4]
-    forward_output = torch.randn(4, 5)
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1, 1])
-    embedding = torch.randn(4, 10)
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [1, 2, 3, 4]
+        forward_output = torch.randn(4, 5)
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1, 1])
+        embedding = torch.randn(4, 10)
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (0, 0)
-    sampler.inform_end_of_current_label()
-    assert len(sampler.already_selected_samples) == 2
-    assert len(sampler.already_selected_weights) == 2
-    assert sampler.distance_matrix.shape == (0, 0)
-    assert len(sampler.current_class_gradients) == 0
+        assert sampler.distance_matrix.shape == (0, 0)
+        sampler.inform_end_of_current_label()
+        assert len(sampler.already_selected_samples) == 2
+        assert len(sampler.already_selected_weights) == 2
+        assert sampler.distance_matrix.shape == (0, 0)
+        assert len(sampler.current_class_gradients) == 0
 
-    sample_ids = [10, 11, 12, 13, 14, 15]
-    forward_output = torch.randn(6, 5)  # 4 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([0, 0, 0, 0, 0, 0])  # 4 target labels
-    embedding = torch.randn(6, 10)  # 4 samples, embedding dimension 10
+        sample_ids = [10, 11, 12, 13, 14, 15]
+        forward_output = torch.randn(6, 5)  # 4 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([0, 0, 0, 0, 0, 0])  # 4 target labels
+        embedding = torch.randn(6, 10)  # 4 samples, embedding dimension 10
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (0, 0)
-    sampler.inform_end_of_current_label()
-    assert len(sampler.already_selected_samples) == 5
-    assert len(sampler.already_selected_weights) == 5
-    assert sampler.distance_matrix.shape == (0, 0)
-    assert len(sampler.current_class_gradients) == 0
+        assert sampler.distance_matrix.shape == (0, 0)
+        sampler.inform_end_of_current_label()
+        assert len(sampler.already_selected_samples) == 5
+        assert len(sampler.already_selected_weights) == 5
+        assert sampler.distance_matrix.shape == (0, 0)
+        assert len(sampler.current_class_gradients) == 0
 
-    selected_points, selected_weights = sampler.select_points()
+        selected_points, selected_weights = sampler.select_points()
 
-    assert len(selected_points) == 5
-    assert len(selected_weights) == 5
-    assert all(weight > 0 for weight in selected_weights)
-    assert all(id in [1, 2, 3, 4, 10, 11, 12, 13, 14, 15] for id in selected_points)
-    assert sum(id in [1, 2, 3, 4] for id in selected_points) == 2
-    assert sum(id in [10, 11, 12, 13, 14, 15] for id in selected_points) == 3
+        assert len(selected_points) == 5
+        assert len(selected_weights) == 5
+        assert all(weight > 0 for weight in selected_weights)
+        assert all(id in [1, 2, 3, 4, 10, 11, 12, 13, 14, 15] for id in selected_points)
+        assert sum(id in [1, 2, 3, 4] for id in selected_points) == 2
+        assert sum(id in [10, 11, 12, 13, 14, 15] for id in selected_points) == 3
 
 
 def test_bts():
     sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    sample_ids = [1, 2, 3, 10, 11, 12, 13]
-    forward_output = torch.randn(7, 5)  # 7 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1, 0, 0, 0, 1])
-    embedding = torch.randn(7, 10)  # 7 samples, embedding dimension 10
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [1, 2, 3, 10, 11, 12, 13]
+        forward_output = torch.randn(7, 5)  # 7 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1, 0, 0, 0, 1])
+        embedding = torch.randn(7, 10)  # 7 samples, embedding dimension 10
 
-    assert sampler.distance_matrix.shape == (0, 0)
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (7, 7)
-    assert len(sampler.current_class_gradients) == 0
+        assert sampler.distance_matrix.shape == (0, 0)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (7, 7)
+        assert len(sampler.current_class_gradients) == 0
 
-    assert sampler.index_sampleid_map == [10, 11, 12, 1, 2, 3, 13]
+        assert sampler.index_sampleid_map == [10, 11, 12, 1, 2, 3, 13]
 
-    selected_points, selected_weights = sampler.select_points()
+        selected_points, selected_weights = sampler.select_points()
 
-    assert len(selected_points) == 3
-    assert len(selected_weights) == 3
-    assert all(weight > 0 for weight in selected_weights)
-    assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
+        assert len(selected_points) == 3
+        assert len(selected_weights) == 3
+        assert all(weight > 0 for weight in selected_weights)
+        assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
 
 
 def test_bts_equals_stb():
@@ -194,33 +202,34 @@ def test_bts_equals_stb():
 
     # BTS, all in one call
     bts_sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    bts_sampler.inform_samples(sample_ids, forward_output, target, embedding)
+    with torch.inference_mode(mode=(not bts_sampler.requires_grad)):
+        bts_sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    bts_selected_points, bts_selected_weights = bts_sampler.select_points()
+        bts_selected_points, bts_selected_weights = bts_sampler.select_points()
 
-    # STB, first class 0 and then class 1
-    class0 = target == 0
-    class1 = target == 1
-    stb_sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
-    stb_sampler.inform_samples(
-        [sample_ids[i] for i, keep in enumerate(class0) if keep],
-        forward_output[class0],
-        target[class0],
-        embedding[class0],
-    )
-    stb_sampler.inform_end_of_current_label()
-    stb_sampler.inform_samples(
-        [sample_ids[i] for i, keep in enumerate(class1) if keep],
-        forward_output[class1],
-        target[class1],
-        embedding[class1],
-    )
-    stb_selected_points, stb_selected_weights = stb_sampler.select_points()
+        # STB, first class 0 and then class 1
+        class0 = target == 0
+        class1 = target == 1
+        stb_sampler = RemoteCraigDownsamplingStrategy(*get_sampler_config())
+        stb_sampler.inform_samples(
+            [sample_ids[i] for i, keep in enumerate(class0) if keep],
+            forward_output[class0],
+            target[class0],
+            embedding[class0],
+        )
+        stb_sampler.inform_end_of_current_label()
+        stb_sampler.inform_samples(
+            [sample_ids[i] for i, keep in enumerate(class1) if keep],
+            forward_output[class1],
+            target[class1],
+            embedding[class1],
+        )
+        stb_selected_points, stb_selected_weights = stb_sampler.select_points()
 
-    assert bts_sampler.index_sampleid_map == stb_sampler.index_sampleid_map == [10, 11, 12, 1, 2, 3, 13]
-    assert bts_sampler.index_sampleid_map == stb_sampler.index_sampleid_map
-    assert stb_selected_points == bts_selected_points
-    assert torch.equal(stb_selected_weights, bts_selected_weights)
+        assert bts_sampler.index_sampleid_map == stb_sampler.index_sampleid_map == [10, 11, 12, 1, 2, 3, 13]
+        assert bts_sampler.index_sampleid_map == stb_sampler.index_sampleid_map
+        assert stb_selected_points == bts_selected_points
+        assert torch.equal(stb_selected_weights, bts_selected_weights)
 
 
 def test_matching_results_with_deepcore():
@@ -332,39 +341,40 @@ def test_matching_results_with_deepcore():
         BCEWithLogitsLoss(reduction="none"),
         "cpu",
     )
-    sample_ids = [0, 1, 2]
-    dummy_model.embedding_recorder.start_recording()
-    forward_output = dummy_model(samples[0:3]).float()
-    target = torch.tensor(targets[0:3]).unsqueeze(dim=1).float()
-    embedding = dummy_model.embedding
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [0, 1, 2]
+        dummy_model.embedding_recorder.start_recording()
+        forward_output = dummy_model(samples[0:3]).float()
+        target = torch.tensor(targets[0:3]).unsqueeze(dim=1).float()
+        embedding = dummy_model.embedding
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (0, 0)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (3, 3)
-    assert len(sampler.current_class_gradients) == 0
+        assert sampler.distance_matrix.shape == (0, 0)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (3, 3)
+        assert len(sampler.current_class_gradients) == 0
 
-    sample_ids = [3, 4, 5, 6, 7, 8, 9]
-    forward_output = dummy_model(samples[3:]).float()
-    target = torch.tensor(targets[3:]).unsqueeze(dim=1).float()
-    embedding = dummy_model.embedding
+        sample_ids = [3, 4, 5, 6, 7, 8, 9]
+        forward_output = dummy_model(samples[3:]).float()
+        target = torch.tensor(targets[3:]).unsqueeze(dim=1).float()
+        embedding = dummy_model.embedding
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (3, 3)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (10, 10)
-    assert len(sampler.current_class_gradients) == 0
-    assert sampler.index_sampleid_map == list(range(10))
+        assert sampler.distance_matrix.shape == (3, 3)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (10, 10)
+        assert len(sampler.current_class_gradients) == 0
+        assert sampler.index_sampleid_map == list(range(10))
 
-    selected_samples, selected_weights = sampler.select_points()
+        selected_samples, selected_weights = sampler.select_points()
 
-    assert len(selected_samples) == 2
-    assert len(selected_weights) == 2
-    assert_close_matrices(expected_distance_matrix, sampler.distance_matrix.tolist())
-    assert selected_samples_deepcore == selected_samples
-    assert selected_weights_deepcore == selected_weights.tolist()
+        assert len(selected_samples) == 2
+        assert len(selected_weights) == 2
+        assert_close_matrices(expected_distance_matrix, sampler.distance_matrix.tolist())
+        assert selected_samples_deepcore == selected_samples
+        assert selected_weights_deepcore == selected_weights.tolist()
 
 
 def test_matching_results_with_deepcore_permutation():
@@ -385,37 +395,39 @@ def test_matching_results_with_deepcore_permutation():
         BCEWithLogitsLoss(reduction="none"),
         "cpu",
     )
-    sample_ids = [2, 3, 4]
-    dummy_model.embedding_recorder.start_recording()
-    forward_output = dummy_model(samples[targets == 0]).float()
-    target = torch.tensor(targets[targets == 0]).unsqueeze(dim=1).float()
-    embedding = dummy_model.embedding
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sample_ids = [2, 3, 4]
+        dummy_model.embedding_recorder.start_recording()
+        forward_output = dummy_model(samples[targets == 0]).float()
+        target = torch.tensor(targets[targets == 0]).unsqueeze(dim=1).float()
+        embedding = dummy_model.embedding
 
-    assert sampler.distance_matrix.shape == (0, 0)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (3, 3)
-    assert len(sampler.current_class_gradients) == 0
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    sample_ids = [0, 1, 5, 6, 7, 8, 9]
-    forward_output = dummy_model(samples[targets == 1]).float()
-    target = torch.tensor(targets[targets == 1]).unsqueeze(dim=1).float()
-    embedding = dummy_model.embedding
+        assert sampler.distance_matrix.shape == (0, 0)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (3, 3)
+        assert len(sampler.current_class_gradients) == 0
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sample_ids = [0, 1, 5, 6, 7, 8, 9]
+        forward_output = dummy_model(samples[targets == 1]).float()
+        target = torch.tensor(targets[targets == 1]).unsqueeze(dim=1).float()
+        embedding = dummy_model.embedding
 
-    assert sampler.distance_matrix.shape == (3, 3)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (10, 10)
-    assert len(sampler.current_class_gradients) == 0
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    selected_samples, selected_weights = sampler.select_points()
+        assert sampler.distance_matrix.shape == (3, 3)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (10, 10)
+        assert len(sampler.current_class_gradients) == 0
 
-    assert len(selected_samples) == 3
-    assert len(selected_weights) == 3
-    assert selected_samples_deepcore == selected_samples
-    assert selected_weights_deepcore == selected_weights.tolist()
+        selected_samples, selected_weights = sampler.select_points()
+
+        assert len(selected_samples) == 3
+        assert len(selected_weights) == 3
+        assert selected_samples_deepcore == selected_samples
+        assert selected_weights_deepcore == selected_weights.tolist()
 
 
 def test_matching_results_with_deepcore_permutation_fancy_ids():
@@ -441,36 +453,37 @@ def test_matching_results_with_deepcore_permutation_fancy_ids():
         BCEWithLogitsLoss(reduction="none"),
         "cpu",
     )
-    sample_ids = [index_mapping[i] for i in [2, 3, 4]]
-    dummy_model.embedding_recorder.start_recording()
-    forward_output = dummy_model(samples[targets == 0]).float()
-    target = torch.tensor(targets[targets == 0]).unsqueeze(dim=1).float()
-    embedding = dummy_model.embedding
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [index_mapping[i] for i in [2, 3, 4]]
+        dummy_model.embedding_recorder.start_recording()
+        forward_output = dummy_model(samples[targets == 0]).float()
+        target = torch.tensor(targets[targets == 0]).unsqueeze(dim=1).float()
+        embedding = dummy_model.embedding
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (0, 0)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (3, 3)
-    assert len(sampler.current_class_gradients) == 0
+        assert sampler.distance_matrix.shape == (0, 0)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (3, 3)
+        assert len(sampler.current_class_gradients) == 0
 
-    sample_ids = [index_mapping[i] for i in [0, 1, 5, 6, 7, 8, 9]]
-    forward_output = dummy_model(samples[targets == 1]).float()
-    target = torch.tensor(targets[targets == 1]).unsqueeze(dim=1).float()
-    embedding = dummy_model.embedding
+        sample_ids = [index_mapping[i] for i in [0, 1, 5, 6, 7, 8, 9]]
+        forward_output = dummy_model(samples[targets == 1]).float()
+        target = torch.tensor(targets[targets == 1]).unsqueeze(dim=1).float()
+        embedding = dummy_model.embedding
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert sampler.distance_matrix.shape == (3, 3)
-    sampler.inform_end_of_current_label()
-    assert sampler.distance_matrix.shape == (10, 10)
-    assert len(sampler.current_class_gradients) == 0
+        assert sampler.distance_matrix.shape == (3, 3)
+        sampler.inform_end_of_current_label()
+        assert sampler.distance_matrix.shape == (10, 10)
+        assert len(sampler.current_class_gradients) == 0
 
-    selected_samples, selected_weights = sampler.select_points()
+        selected_samples, selected_weights = sampler.select_points()
 
-    assert len(selected_samples) == 5
-    assert len(selected_weights) == 5
+        assert len(selected_samples) == 5
+        assert len(selected_weights) == 5
 
-    # Allow for flakiness with two options
-    assert selected_samples in (selected_samples_deepcore, selected_samples_deepcore2)
-    assert selected_weights_deepcore == selected_weights.tolist()
+        # Allow for flakiness with two options
+        assert selected_samples in (selected_samples_deepcore, selected_samples_deepcore2)
+        assert selected_weights_deepcore == selected_weights.tolist()

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_gradnorm_downsample.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_gradnorm_downsample.py
@@ -15,25 +15,26 @@ def test_sample_shape_ce():
 
     params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
     sampler = RemoteGradNormDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
 
-    data = torch.randn(8, 10)
-    target = torch.randint(2, size=(8,))
-    ids = list(range(8))
-    forward_outputs = model(data)
-    sampler.inform_samples(ids, forward_outputs, target)
-    downsampled_indexes, weights = sampler.select_points()
+        data = torch.randn(8, 10)
+        target = torch.randint(2, size=(8,))
+        ids = list(range(8))
+        forward_outputs = model(data)
+        sampler.inform_samples(ids, forward_outputs, target)
+        downsampled_indexes, weights = sampler.select_points()
 
-    assert len(downsampled_indexes) == 4  # 50% of 8
-    assert weights.shape[0] == 4
+        assert len(downsampled_indexes) == 4  # 50% of 8
+        assert weights.shape[0] == 4
 
-    sampled_data, sampled_target = get_tensors_subset(downsampled_indexes, data, target, ids)
+        sampled_data, sampled_target = get_tensors_subset(downsampled_indexes, data, target, ids)
 
-    assert weights.shape[0] == sampled_target.shape[0]
-    assert sampled_data.shape[0] == 4
-    assert sampled_data.shape[1] == data.shape[1]
-    assert weights.shape[0] == 4
-    assert sampled_target.shape[0] == 4
-    assert set(downsampled_indexes) <= set(range(8))
+        assert weights.shape[0] == sampled_target.shape[0]
+        assert sampled_data.shape[0] == 4
+        assert sampled_data.shape[1] == data.shape[1]
+        assert weights.shape[0] == 4
+        assert sampled_target.shape[0] == 4
+        assert set(downsampled_indexes) <= set(range(8))
 
 
 def test_sample_shape_other_losses():
@@ -43,26 +44,26 @@ def test_sample_shape_other_losses():
 
     params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
     sampler = RemoteGradNormDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        data = torch.randn(8, 10)
+        target = torch.randint(2, size=(8,), dtype=torch.float32).unsqueeze(1)
+        ids = list(range(8))
 
-    data = torch.randn(8, 10)
-    target = torch.randint(2, size=(8,), dtype=torch.float32).unsqueeze(1)
-    ids = list(range(8))
+        forward_outputs = model(data)
 
-    forward_outputs = model(data)
+        sampler.inform_samples(ids, forward_outputs, target)
+        downsampled_indexes, weights = sampler.select_points()
 
-    sampler.inform_samples(ids, forward_outputs, target)
-    downsampled_indexes, weights = sampler.select_points()
+        assert len(downsampled_indexes) == 4
+        assert weights.shape[0] == 4
 
-    assert len(downsampled_indexes) == 4
-    assert weights.shape[0] == 4
+        sampled_data, sampled_target = get_tensors_subset(downsampled_indexes, data, target, ids)
 
-    sampled_data, sampled_target = get_tensors_subset(downsampled_indexes, data, target, ids)
-
-    assert weights.shape[0] == sampled_target.shape[0]
-    assert sampled_data.shape[0] == 4
-    assert sampled_data.shape[1] == data.shape[1]
-    assert weights.shape[0] == 4
-    assert sampled_target.shape[0] == 4
+        assert weights.shape[0] == sampled_target.shape[0]
+        assert sampled_data.shape[0] == 4
+        assert sampled_data.shape[1] == data.shape[1]
+        assert weights.shape[0] == 4
+        assert sampled_target.shape[0] == 4
 
 
 def test_sampling_crossentropy():
@@ -82,22 +83,23 @@ def test_sampling_crossentropy():
 
     # Here we use autograd since the number of classes is not provided
     sampler = RemoteGradNormDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
-    forward_outputs = model(data)
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        forward_outputs = model(data)
 
-    sampler.inform_samples(ids, forward_outputs, target)
-    _, autograd_weights = sampler.select_points()
-    # Here we use the closed form shortcut
-    sampler = RemoteGradNormDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+        sampler.inform_samples(ids, forward_outputs, target)
+        _, autograd_weights = sampler.select_points()
+        # Here we use the closed form shortcut
+        sampler = RemoteGradNormDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
 
-    sampler.inform_samples(ids, forward_outputs, target)
-    _, closed_form_weights = sampler.select_points()
+        sampler.inform_samples(ids, forward_outputs, target)
+        _, closed_form_weights = sampler.select_points()
 
-    # We sort them since in this case sampling is just a permutation (we sample every point without replacement
-    autograd_weights, _ = torch.sort(autograd_weights)
-    closed_form_weights, _ = torch.sort(closed_form_weights)
+        # We sort them since in this case sampling is just a permutation (we sample every point without replacement
+        autograd_weights, _ = torch.sort(autograd_weights)
+        closed_form_weights, _ = torch.sort(closed_form_weights)
 
-    # compare the sorted tensors for equality
-    assert torch.all(torch.isclose(closed_form_weights, autograd_weights))
+        # compare the sorted tensors for equality
+        assert torch.all(torch.isclose(closed_form_weights, autograd_weights))
 
 
 class DictLikeModel(nn.Module):
@@ -126,22 +128,23 @@ def test_sample_dict_input():
 
     params_from_selector = {"downsampling_ratio": 50, "sample_then_batch": False}
     sampler = RemoteGradNormDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
 
-    forward_outputs = model(data)
+        forward_outputs = model(data)
 
-    sampler.inform_samples(ids, forward_outputs, target)
-    downsampled_indexes, weights = sampler.select_points()
+        sampler.inform_samples(ids, forward_outputs, target)
+        downsampled_indexes, weights = sampler.select_points()
 
-    assert len(downsampled_indexes) == 3
-    assert weights.shape == (3,)
+        assert len(downsampled_indexes) == 3
+        assert weights.shape == (3,)
 
-    sampled_data, sampled_target = get_tensors_subset(downsampled_indexes, data, target, ids)
+        sampled_data, sampled_target = get_tensors_subset(downsampled_indexes, data, target, ids)
 
-    # check that the output has the correct shape and type
-    assert isinstance(sampled_data, dict)
+        # check that the output has the correct shape and type
+        assert isinstance(sampled_data, dict)
 
-    assert all(sampled_data[key].shape == (3, 10) for key in sampled_data)
+        assert all(sampled_data[key].shape == (3, 10) for key in sampled_data)
 
-    assert sampled_target.shape == (3,)
-    assert len(downsampled_indexes) == 3
-    assert set(downsampled_indexes) <= set(ids)
+        assert sampled_target.shape == (3,)
+        assert len(downsampled_indexes) == 3
+        assert set(downsampled_indexes) <= set(ids)

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_kcenter_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_kcenter_downsampling_strategy.py
@@ -22,78 +22,80 @@ def get_sampler_config(balance=False):
 
 def test_select():
     sampler = RemoteKcenterGreedyDownsamplingStrategy(*get_sampler_config())
-    sample_ids = [1, 2, 3]
-    forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1])
-    embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [1, 2, 3]
+        forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1])
+        embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert len(sampler.matrix_elements) == 1
-    assert sampler.matrix_elements[0].shape == (3, 10)
+        assert len(sampler.matrix_elements) == 1
+        assert sampler.matrix_elements[0].shape == (3, 10)
 
-    sample_ids = [10, 11, 12, 13]
-    forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1, 1])  # 4 target labels
-    embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
+        sample_ids = [10, 11, 12, 13]
+        forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1, 1])  # 4 target labels
+        embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert len(sampler.matrix_elements) == 2
-    assert sampler.matrix_elements[0].shape == (3, 10)
-    assert sampler.matrix_elements[1].shape == (4, 10)
-    assert sampler.index_sampleid_map == [1, 2, 3, 10, 11, 12, 13]
+        assert len(sampler.matrix_elements) == 2
+        assert sampler.matrix_elements[0].shape == (3, 10)
+        assert sampler.matrix_elements[1].shape == (4, 10)
+        assert sampler.index_sampleid_map == [1, 2, 3, 10, 11, 12, 13]
 
-    selected_points, selected_weights = sampler.select_points()
+        selected_points, selected_weights = sampler.select_points()
 
-    assert len(selected_points) == 3
-    assert len(selected_weights) == 3
-    assert all(weight > 0 for weight in selected_weights)
-    assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
+        assert len(selected_points) == 3
+        assert len(selected_weights) == 3
+        assert all(weight > 0 for weight in selected_weights)
+        assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
 
 
 def test_select_balanced():
     sampler = RemoteKcenterGreedyDownsamplingStrategy(*get_sampler_config(True))
-    sample_ids = [1, 2, 3]
-    forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1])
-    embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [1, 2, 3]
+        forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1])
+        embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert len(sampler.matrix_elements) == 1
-    assert sampler.matrix_elements[0].shape == (3, 10)
+        assert len(sampler.matrix_elements) == 1
+        assert sampler.matrix_elements[0].shape == (3, 10)
 
-    sampler.inform_end_of_current_label()
-    assert len(sampler.already_selected_samples) == 1
-    assert len(sampler.already_selected_weights) == 1
+        sampler.inform_end_of_current_label()
+        assert len(sampler.already_selected_samples) == 1
+        assert len(sampler.already_selected_weights) == 1
 
-    sample_ids = [10, 11, 12, 13]
-    forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1, 1])  # 4 target labels
-    embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
+        sample_ids = [10, 11, 12, 13]
+        forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1, 1])  # 4 target labels
+        embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
 
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
 
-    assert len(sampler.matrix_elements) == 1
-    assert sampler.matrix_elements[0].shape == (4, 10)
-    assert sampler.index_sampleid_map == [10, 11, 12, 13]
-    sampler.inform_end_of_current_label()
-    assert len(sampler.already_selected_samples) == 3
-    assert len(sampler.already_selected_weights) == 3
+        assert len(sampler.matrix_elements) == 1
+        assert sampler.matrix_elements[0].shape == (4, 10)
+        assert sampler.index_sampleid_map == [10, 11, 12, 13]
+        sampler.inform_end_of_current_label()
+        assert len(sampler.already_selected_samples) == 3
+        assert len(sampler.already_selected_weights) == 3
 
-    selected_points, selected_weights = sampler.select_points()
+        selected_points, selected_weights = sampler.select_points()
 
-    assert len(selected_points) == 3
-    assert len(selected_weights) == 3
-    assert all(weight > 0 for weight in selected_weights)
-    assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
-    assert sum(id in [1, 2, 3] for id in selected_points) == 1
-    assert sum(id in [10, 11, 12, 13] for id in selected_points) == 2
+        assert len(selected_points) == 3
+        assert len(selected_weights) == 3
+        assert all(weight > 0 for weight in selected_weights)
+        assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
+        assert sum(id in [1, 2, 3] for id in selected_points) == 1
+        assert sum(id in [10, 11, 12, 13] for id in selected_points) == 2
 
 
 def test_matching_results_with_deepcore():
@@ -134,12 +136,13 @@ def test_matching_results_with_deepcore():
             BCEWithLogitsLoss(reduction="none"),
             "cpu",
         )
-        sampler.inform_samples(sample_ids, forward_output, target, embedding)
-        assert sampler.index_sampleid_map == list(range(10))
-        selected_samples, selected_weights = sampler.select_points()
-        assert len(selected_samples) == num_of_target_samples
-        assert len(selected_weights) == num_of_target_samples
-        assert sorted(selected_samples_deepcore[num_of_target_samples]) == sorted(selected_samples)
+        with torch.inference_mode(mode=(not sampler.requires_grad)):
+            sampler.inform_samples(sample_ids, forward_output, target, embedding)
+            assert sampler.index_sampleid_map == list(range(10))
+            selected_samples, selected_weights = sampler.select_points()
+            assert len(selected_samples) == num_of_target_samples
+            assert len(selected_weights) == num_of_target_samples
+            assert sorted(selected_samples_deepcore[num_of_target_samples]) == sorted(selected_samples)
 
 
 def test_matching_results_with_deepcore_permutation_fancy_ids():
@@ -156,15 +159,15 @@ def test_matching_results_with_deepcore_permutation_fancy_ids():
     sampler = RemoteKcenterGreedyDownsamplingStrategy(
         0, 0, 5, {"downsampling_ratio": 50, "balance": False}, BCEWithLogitsLoss(reduction="none"), "cpu"
     )
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        dummy_model.embedding_recorder.start_recording()
+        forward_output = dummy_model(samples).float()
+        embedding = dummy_model.embedding
 
-    dummy_model.embedding_recorder.start_recording()
-    forward_output = dummy_model(samples).float()
-    embedding = dummy_model.embedding
+        sampler.inform_samples(index_mapping, forward_output, targets, embedding)
 
-    sampler.inform_samples(index_mapping, forward_output, targets, embedding)
+        selected_samples, selected_weights = sampler.select_points()
 
-    selected_samples, selected_weights = sampler.select_points()
-
-    assert len(selected_samples) == 5
-    assert len(selected_weights) == 5
-    assert sorted(selected_samples_deepcore) == sorted(selected_samples)
+        assert len(selected_samples) == 5
+        assert len(selected_weights) == 5
+        assert sorted(selected_samples_deepcore) == sorted(selected_samples)

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_loss_downsample.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_loss_downsample.py
@@ -13,22 +13,22 @@ def test_sample_shape():
 
     params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
     sampler = RemoteLossDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        data = torch.randn(8, 10)
+        target = torch.randint(2, size=(8,))
+        ids = list(range(8))
 
-    data = torch.randn(8, 10)
-    target = torch.randint(2, size=(8,))
-    ids = list(range(8))
+        forward_output = model(data)
+        sampler.inform_samples(ids, forward_output, target)
+        indexes, weights = sampler.select_points()
 
-    forward_output = model(data)
-    sampler.inform_samples(ids, forward_output, target)
-    indexes, weights = sampler.select_points()
+        sampled_data, sampled_target = get_tensors_subset(indexes, data, target, ids)
 
-    sampled_data, sampled_target = get_tensors_subset(indexes, data, target, ids)
-
-    assert sampled_data.shape[0] == 4  # (50% of 8)
-    assert sampled_data.shape[1] == data.shape[1]
-    assert weights.shape[0] == 4
-    assert sampled_target.shape[0] == 4
-    assert len(indexes) == 4
+        assert sampled_data.shape[0] == 4  # (50% of 8)
+        assert sampled_data.shape[1] == data.shape[1]
+        assert weights.shape[0] == 4
+        assert sampled_target.shape[0] == 4
+        assert len(indexes) == 4
 
 
 def test_sample_weights():
@@ -38,17 +38,17 @@ def test_sample_weights():
 
     params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
     sampler = RemoteLossDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        data = torch.randn(8, 10)
+        target = torch.randint(2, size=(8,))
+        ids = list(range(8))
 
-    data = torch.randn(8, 10)
-    target = torch.randint(2, size=(8,))
-    ids = list(range(8))
+        forward_output = model(data)
+        sampler.inform_samples(ids, forward_output, target)
+        selected_ids, weights = sampler.select_points()
 
-    forward_output = model(data)
-    sampler.inform_samples(ids, forward_output, target)
-    selected_ids, weights = sampler.select_points()
-
-    assert weights.sum() > 0
-    assert set(selected_ids) <= set(list(range(8)))
+        assert weights.sum() > 0
+        assert set(selected_ids) <= set(list(range(8)))
 
 
 # Create a model that always predicts the same class
@@ -64,24 +64,24 @@ def test_sample_loss_dependent_sampling():
 
     params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
     sampler = RemoteLossDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        # Create a target with two classes, where half have a true label of 0 and half have a true label of 1
+        target = torch.cat([torch.zeros(4), torch.ones(4)])
 
-    # Create a target with two classes, where half have a true label of 0 and half have a true label of 1
-    target = torch.cat([torch.zeros(4), torch.ones(4)])
+        # Create a data tensor with four points that have a loss of zero and four points that have a non-zero loss
+        data = torch.cat([torch.randn(4, 10), torch.randn(4, 10)], dim=0)
 
-    # Create a data tensor with four points that have a loss of zero and four points that have a non-zero loss
-    data = torch.cat([torch.randn(4, 10), torch.randn(4, 10)], dim=0)
+        ids = list(range(8))
 
-    ids = list(range(8))
+        forward_output = model(data)
+        sampler.inform_samples(ids, forward_output, target)
+        indexes, _ = sampler.select_points()
 
-    forward_output = model(data)
-    sampler.inform_samples(ids, forward_output, target)
-    indexes, _ = sampler.select_points()
+        _, sampled_target = get_tensors_subset(indexes, data, target, ids)
 
-    _, sampled_target = get_tensors_subset(indexes, data, target, ids)
-
-    # Assert that no points with a loss of zero were selected
-    assert (sampled_target == 0).sum() == 0
-    assert (sampled_target > 0).sum() > 0
+        # Assert that no points with a loss of zero were selected
+        assert (sampled_target == 0).sum() == 0
+        assert (sampled_target > 0).sum() > 0
 
 
 class DictLikeModel(nn.Module):
@@ -111,18 +111,18 @@ def test_sample_dict_input():
 
     params_from_selector = {"downsampling_ratio": 50, "sample_then_batch": False}
     sampler = RemoteLossDownsampling(0, 0, 0, params_from_selector, per_sample_loss_fct, "cpu")
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        forward_output = mymodel(data)
+        sampler.inform_samples(sample_ids, forward_output, target)
+        indexes, weights = sampler.select_points()
+        sampled_data, sampled_target = get_tensors_subset(indexes, data, target, sample_ids)
 
-    forward_output = mymodel(data)
-    sampler.inform_samples(sample_ids, forward_output, target)
-    indexes, weights = sampler.select_points()
-    sampled_data, sampled_target = get_tensors_subset(indexes, data, target, sample_ids)
+        # check that the output has the correct shape and type
+        assert isinstance(sampled_data, dict)
 
-    # check that the output has the correct shape and type
-    assert isinstance(sampled_data, dict)
+        assert all(sampled_data[key].shape == (3, 10) for key in sampled_data)
 
-    assert all(sampled_data[key].shape == (3, 10) for key in sampled_data)
-
-    assert weights.shape == (3,)
-    assert sampled_target.shape == (3, 8)
-    assert len(indexes) == 3
-    assert set(indexes) <= set(sample_ids)
+        assert weights.shape == (3,)
+        assert sampled_target.shape == (3, 8)
+        assert len(indexes) == 3
+        assert set(indexes) <= set(sample_ids)

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_submodular_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_submodular_downsampling_strategy.py
@@ -36,71 +36,73 @@ def test_select_different_submodulars_balanced():
 
 def _test_select_subm(submodular, balance=False):
     sampler = RemoteSubmodularDownsamplingStrategy(*get_sampler_config(submodular, balance))
-    sample_ids = [1, 2, 3]
-    forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1])
-    embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
-    assert len(sampler.matrix_elements) == 1
-    # 3 samples of dim 5 * 10 + 5
-    assert sampler.matrix_elements[0].shape == (3, 55)
-    sample_ids = [10, 11, 12, 13]
-    forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1, 1])  # 4 target labels
-    embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
-    assert len(sampler.matrix_elements) == 2
-    assert sampler.matrix_elements[0].shape == (3, 55)
-    assert sampler.matrix_elements[1].shape == (4, 55)
-    assert sampler.index_sampleid_map == [1, 2, 3, 10, 11, 12, 13]
-    selected_points, selected_weights = sampler.select_points()
-    assert len(selected_points) == 3
-    assert len(selected_weights) == 3
-    assert all(weight > 0 for weight in selected_weights)
-    assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [1, 2, 3]
+        forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1])
+        embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        assert len(sampler.matrix_elements) == 1
+        # 3 samples of dim 5 * 10 + 5
+        assert sampler.matrix_elements[0].shape == (3, 55)
+        sample_ids = [10, 11, 12, 13]
+        forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1, 1])  # 4 target labels
+        embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        assert len(sampler.matrix_elements) == 2
+        assert sampler.matrix_elements[0].shape == (3, 55)
+        assert sampler.matrix_elements[1].shape == (4, 55)
+        assert sampler.index_sampleid_map == [1, 2, 3, 10, 11, 12, 13]
+        selected_points, selected_weights = sampler.select_points()
+        assert len(selected_points) == 3
+        assert len(selected_weights) == 3
+        assert all(weight > 0 for weight in selected_weights)
+        assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
 
 
 def _test_select_subm_balance(submodular):
     sampler = RemoteSubmodularDownsamplingStrategy(*get_sampler_config(submodular, True))
-    sample_ids = [1, 2, 3]
-    forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1])
-    embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
-    assert len(sampler.matrix_elements) == 1
-    # 3 samples of dim 5 * 10 + 5
-    assert sampler.matrix_elements[0].shape == (3, 55)
+    with torch.inference_mode(mode=(not sampler.requires_grad)):
+        sample_ids = [1, 2, 3]
+        forward_output = torch.randn(3, 5)  # 3 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1])
+        embedding = torch.randn(3, 10)  # 3 samples, embedding dimension 10
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        assert len(sampler.matrix_elements) == 1
+        # 3 samples of dim 5 * 10 + 5
+        assert sampler.matrix_elements[0].shape == (3, 55)
 
-    sampler.inform_end_of_current_label()
-    assert len(sampler.already_selected_weights) == 1
-    assert len(sampler.already_selected_samples) == 1
-    assert len(sampler.index_sampleid_map) == 0
-    assert len(sampler.matrix_elements) == 0
+        sampler.inform_end_of_current_label()
+        assert len(sampler.already_selected_weights) == 1
+        assert len(sampler.already_selected_samples) == 1
+        assert len(sampler.index_sampleid_map) == 0
+        assert len(sampler.matrix_elements) == 0
 
-    sample_ids = [10, 11, 12, 13]
-    forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
-    forward_output.requires_grad = True
-    target = torch.tensor([1, 1, 1, 1])  # 4 target labels
-    embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
-    sampler.inform_samples(sample_ids, forward_output, target, embedding)
-    assert len(sampler.matrix_elements) == 1
-    assert sampler.matrix_elements[0].shape == (4, 55)
-    assert sampler.index_sampleid_map == [10, 11, 12, 13]
+        sample_ids = [10, 11, 12, 13]
+        forward_output = torch.randn(4, 5)  # 4 samples, 5 output classes
+        forward_output.requires_grad = True
+        target = torch.tensor([1, 1, 1, 1])  # 4 target labels
+        embedding = torch.randn(4, 10)  # 4 samples, embedding dimension 10
+        sampler.inform_samples(sample_ids, forward_output, target, embedding)
+        assert len(sampler.matrix_elements) == 1
+        assert sampler.matrix_elements[0].shape == (4, 55)
+        assert sampler.index_sampleid_map == [10, 11, 12, 13]
 
-    sampler.inform_end_of_current_label()
-    assert len(sampler.already_selected_weights) == 3
-    assert len(sampler.already_selected_samples) == 3
-    assert len(sampler.index_sampleid_map) == 0
-    assert len(sampler.matrix_elements) == 0
+        sampler.inform_end_of_current_label()
+        assert len(sampler.already_selected_weights) == 3
+        assert len(sampler.already_selected_samples) == 3
+        assert len(sampler.index_sampleid_map) == 0
+        assert len(sampler.matrix_elements) == 0
 
-    selected_points, selected_weights = sampler.select_points()
-    assert len(selected_points) == 3
-    assert len(selected_weights) == 3
-    assert all(weight > 0 for weight in selected_weights)
-    assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
+        selected_points, selected_weights = sampler.select_points()
+        assert len(selected_points) == 3
+        assert len(selected_weights) == 3
+        assert all(weight > 0 for weight in selected_weights)
+        assert all(id in [1, 2, 3, 10, 11, 12, 13] for id in selected_points)
 
 
 def _get_selected_samples(submodular, num_of_target_samples, sample_ids, forward_output, target, embedding):

--- a/modyn/trainer_server/internal/trainer/pytorch_trainer.py
+++ b/modyn/trainer_server/internal/trainer/pytorch_trainer.py
@@ -689,9 +689,12 @@ class PytorchTrainer:
         self._model.model.eval()
         self._downsampler.init_downsampler()
         self.start_embedding_recording_if_needed()
-        big_batch_output = self._model.model(data)
-        embeddings = self.get_embeddings_if_recorded()
-        self._downsampler.inform_samples(sample_ids, big_batch_output, target, embeddings)
+
+        with torch.inference_mode(mode=(not self._downsampler.requires_grad)):
+            big_batch_output = self._model.model(data)
+            embeddings = self.get_embeddings_if_recorded()
+            self._downsampler.inform_samples(sample_ids, big_batch_output, target, embeddings)
+
         self.end_embedding_recorder_if_needed()
 
         # TODO(#218) Persist information on the sample IDs/weights when downsampling is performed
@@ -824,11 +827,12 @@ class PytorchTrainer:
             sample_ids, target, data = self.preprocess_batch(batch)
             number_of_samples += len(sample_ids)
 
-            with torch.autocast(self._device_type, enabled=self._amp):
-                # compute the scores and accumulate them
-                model_output = self._model.model(data)
-                embeddings = self.get_embeddings_if_recorded()
-                self._downsampler.inform_samples(sample_ids, model_output, target, embeddings)
+            with torch.inference_mode(mode=(not self._downsampler.requires_grad)):
+                with torch.autocast(self._device_type, enabled=self._amp):
+                    # compute the scores and accumulate them
+                    model_output = self._model.model(data)
+                    embeddings = self.get_embeddings_if_recorded()
+                    self._downsampler.inform_samples(sample_ids, model_output, target, embeddings)
 
         return batch_number, number_of_samples
 

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_matrix_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_matrix_downsampling_strategy.py
@@ -26,6 +26,7 @@ class AbstractMatrixDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingStrat
         params_from_selector: dict,
         per_sample_loss: Any,
         device: str,
+        matrix_content: MatrixContent,
     ):
         super().__init__(pipeline_id, trigger_id, batch_size, params_from_selector, device)
 
@@ -37,7 +38,7 @@ class AbstractMatrixDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingStrat
 
         # actual classes must specify which content should be stored. Can be either Gradients or Embeddings. Use the
         # enum defined above to specify what should be stored
-        self.matrix_content: Optional[MatrixContent] = None
+        self.matrix_content = matrix_content
 
         # if true, the downsampling is balanced across classes ex class sizes = [10, 50, 30] and 50% downsampling
         # yields the following downsampled class sizes [5, 25, 15] while without balance something like [0, 45, 0] can
@@ -124,4 +125,4 @@ class AbstractMatrixDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingStrat
     @property
     def requires_grad(self) -> bool:
         # Default to true if None
-        return self.matrix_content is None or self.matrix_content == MatrixContent.GRADIENTS
+        return self.matrix_content == MatrixContent.GRADIENTS

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_matrix_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_matrix_downsampling_strategy.py
@@ -120,3 +120,8 @@ class AbstractMatrixDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingStrat
     def _select_indexes_from_matrix(self, matrix: np.ndarray, target_size: int) -> tuple[list[int], torch.Tensor]:
         # Here is where the actual selection happens
         raise NotImplementedError()
+
+    @property
+    def requires_grad(self) -> bool:
+        # Default to true if None
+        return self.matrix_content is None or self.matrix_content == MatrixContent.GRADIENTS

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_remote_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_remote_downsampling_strategy.py
@@ -79,3 +79,8 @@ class AbstractRemoteDownsamplingStrategy(ABC):
     @abstractmethod
     def select_points(self) -> tuple[list[int], torch.Tensor]:
         raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def requires_grad(self) -> bool:
+        raise NotImplementedError

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_craig_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_craig_downsampling.py
@@ -199,3 +199,7 @@ class RemoteCraigDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingStrategy
         if self.balance:
             self.already_selected_samples = []
             self.already_selected_weights = torch.tensor([]).float()
+
+    @property
+    def requires_grad(self) -> bool:
+        return True

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_grad_match_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_grad_match_downsampling_strategy.py
@@ -35,8 +35,9 @@ class RemoteGradMatchDownsamplingStrategy(AbstractMatrixDownsamplingStrategy):
         per_sample_loss: Any,
         device: str,
     ):
-        super().__init__(pipeline_id, trigger_id, batch_size, params_from_selector, per_sample_loss, device)
-        self.matrix_content = MatrixContent.GRADIENTS
+        super().__init__(
+            pipeline_id, trigger_id, batch_size, params_from_selector, per_sample_loss, device, MatrixContent.GRADIENTS
+        )
 
     def _select_indexes_from_matrix(self, matrix: np.ndarray, target_size: int) -> tuple[list[int], torch.Tensor]:
         cur_val_gradients = np.mean(matrix, axis=0)

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_gradnorm_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_gradnorm_downsampling.py
@@ -90,3 +90,10 @@ class RemoteGradNormDownsampling(AbstractRemoteDownsamplingStrategy):
 
         selected_ids = [self.index_sampleid_map[sample] for sample in downsampled_idxs]
         return selected_ids, weights
+
+    @property
+    def requires_grad(self) -> bool:
+        if isinstance(self.per_sample_loss_fct, torch.nn.CrossEntropyLoss):
+            return False
+
+        return True

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_kcenter_greedy_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_kcenter_greedy_downsampling_strategy.py
@@ -31,9 +31,10 @@ class RemoteKcenterGreedyDownsamplingStrategy(AbstractMatrixDownsamplingStrategy
         per_sample_loss: Any,
         device: str,
     ):
-        super().__init__(pipeline_id, trigger_id, batch_size, params_from_selector, per_sample_loss, device)
+        super().__init__(
+            pipeline_id, trigger_id, batch_size, params_from_selector, per_sample_loss, device, MatrixContent.EMBEDDINGS
+        )
 
-        self.matrix_content = MatrixContent.EMBEDDINGS
         self.metric = euclidean_dist
 
     def _select_indexes_from_matrix(self, matrix: np.ndarray, target_size: int) -> tuple[list[int], torch.Tensor]:

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_loss_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_loss_downsampling.py
@@ -71,3 +71,7 @@ class RemoteLossDownsampling(AbstractRemoteDownsamplingStrategy):
 
         selected_ids = [self.index_sampleid_map[sample] for sample in downsampled_idxs]
         return selected_ids, weights
+
+    @property
+    def requires_grad(self) -> bool:
+        return False

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_submodular_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_submodular_downsampling_strategy.py
@@ -42,8 +42,9 @@ class RemoteSubmodularDownsamplingStrategy(AbstractMatrixDownsamplingStrategy):
         per_sample_loss: Any,
         device: str,
     ):
-        super().__init__(pipeline_id, trigger_id, batch_size, params_from_selector, per_sample_loss, device)
-        self.matrix_content = MatrixContent.GRADIENTS
+        super().__init__(
+            pipeline_id, trigger_id, batch_size, params_from_selector, per_sample_loss, device, MatrixContent.GRADIENTS
+        )
 
         self.selection_batch = params_from_selector["selection_batch"]
 

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_uncertainty_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_uncertainty_downsampling_strategy.py
@@ -120,3 +120,7 @@ class RemoteUncertaintyDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingSt
 
     def _select_indexes_from_scores(self, target_size: int) -> tuple[list[int], torch.Tensor]:
         return np.argsort(self.scores[::-1])[:target_size], torch.ones(target_size).float()
+
+    @property
+    def requires_grad(self) -> bool:
+        return False


### PR DESCRIPTION
Not all downsamplers need information from autograd. With this change, we make the forward pass cheaper for those downsampling strategies.