### PR TITLE
Add description and scripts for downloading and generating the CGLM dataset

### DIFF
--- a/benchmark/cglm/README.md
+++ b/benchmark/cglm/README.md
@@ -1,0 +1,89 @@
+# CLOC Data
+
+In this directory, you can find the files necessary to run experiments with the CGLM dataset. 
+This dataset contains pictures of landmarks (e.g., the Montblanc) over time.
+The dataset was introduced [in this paper](https://drimpossible.github.io/documents/ACM.pdf).
+However, their host is down and we have to regenerate the dataset.
+It makes use of the [Google Landmarks V2 dataset](https://github.com/cvdfoundation/google-landmark).
+
+## Generating the dataset for Modyn
+
+As a first step, you will need to download the Google Landmarks v2 Images.
+You can check out [their repository](https://github.com/cvdfoundation/google-landmark) for instructions, or try this snippet:
+
+```bash
+wget -c https://raw.githubusercontent.com/cvdfoundation/google-landmark/master/download-dataset.sh
+mkdir cglm && cd cglm
+bash ../download-dataset.sh train 499
+```
+
+Next, we need the image metadata.
+We have pregenerated and host the metadata on Github for convenience.
+If you want to check out how we generate this metadata, check out the next file.
+
+```bash
+wget https://github.com/eth-easl/cglm-metadata/raw/main/cglm_labels_timestamps_clean.csv
+```
+
+Next, you can use the `data_generation.py` script in this directory to generate the dataset.
+Note that there are different versions of CGLM you can generate:
+- You can filter out classes that have less than `n` samples using the `--min_samples_per_class` flag. This defaults to 25.
+- If you supply the `--clean` flag, then the [cleaned version](https://arxiv.org/abs/2003.11211) of the landmark dataset is used. This dataset has been cleaned to contain more consistent images of each landmark, but is a lot smaller.
+- Using `--labeltype`, you can control which label we use. By default, we use the (remapped) landmark id. However, the team behind the landmark datasets supplies two classes of hierarchical labels (supercategory and hierarchical) that can alternatively be used, to make the classification problem smaller.
+
+The script will tell you at the end how many classes your dataset contains.
+Note that the size of the dataset is not consistent with what is reported in the initial paper on CGLM, but since their code on metadata processing is not open source, we cannot investigate the difference here.
+
+## Regenerate the metadata
+This paragraph is only relevant if you are interested in how we generated the `cglm_labels_timestamps_clean.csv` file.
+For this, relevant scripts are supplied in the `metadata_regeneration` subdirectory.
+First, we need to scrape the metadata from the commonsapi.
+Note that you might consider hosting this API yourself (https://bitbucket.org/magnusmanske/magnus-toolserver/src/master/public_html/commonsapi.php) instead of using the public host that is in the script (`scrape.py`).
+We thank the authors of the CGLM for the [initial version of the scraper](https://github.com/drimpossible/ACM/blob/main/scripts/cglm_scrape.py), which we extended to parallelize across machines, show the progress correctly, and be more robust.
+Note that scraping the metadata might take several days here.
+
+Next we need to parse the scraped XML data using the `xml_to_csv.py` script. 
+Using both XML parsing and regex, this script tries to extract the upload date from the downloaded metadata, and generates a csv containing the timestamp for each file ID.
+
+Next, we need to accumulate all those csvs on a single machine (in case you decided to parallelize the scraping and parsing across machines).
+Furthermore, we need to download the additional metadata about what samples belong to the cleaned dataset, and the hierarchical labels to our directory.
+
+```bash
+wget https://s3.amazonaws.com/google-landmark/metadata/train_clean.csv
+wget https://s3.amazonaws.com/google-landmark/metadata/train.csv
+wget https://s3.amazonaws.com/google-landmark/metadata/train_label_to_hierarchical.csv
+```
+
+Last, we join all this information using the `join_metadata.py` script, generating the final csv that you can also download from Github as outlined above.
+
+## License
+
+The Google Landmarks Dataset v2 annotations comes with a CC BY 4.0 license.
+Check out their [repository](https://github.com/cvdfoundation/google-landmark) for more information.
+The adjusted code used to scrape the metadata from wikipedia comes from the repository of the paper [Online Continual Learning Without the Storage Constraint
+](https://github.com/drimpossible/ACM).
+It is served under the following MIT license:
+
+### CGLM Scrape License
+
+MIT License
+
+Copyright (c) 2022 Ameya Prabhu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/benchmark/cglm/README.md
+++ b/benchmark/cglm/README.md
@@ -1,4 +1,4 @@
-# CLOC Data
+# CGLM Dataset
 
 In this directory, you can find the files necessary to run experiments with the CGLM dataset. 
 This dataset contains pictures of landmarks (e.g., the Montblanc) over time.

--- a/benchmark/cglm/data_generation.py
+++ b/benchmark/cglm/data_generation.py
@@ -76,7 +76,7 @@ def main():
     label_type_to_column = {"landmark": 'landmark_id', "supercategory": "supercategory_label", "hierarchical": "hierarchical_label_label"}
     label_column = label_type_to_column[args.labeltype]
 
-    df = pd.read_csv("cglm_labels_timestamps_clean.csv")
+    df = pd.read_csv(args.metadata)
     df = df[df["clean"] == args.clean]
     df = df[df[label_column].notnull()]
     label_counts = df[label_column].value_counts()

--- a/benchmark/cglm/data_generation.py
+++ b/benchmark/cglm/data_generation.py
@@ -1,0 +1,151 @@
+import argparse
+import logging
+import os
+import pathlib
+import shutil
+from datetime import datetime
+
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from tqdm import tqdm
+
+logging.basicConfig(
+    level=logging.NOTSET,
+    format="[%(asctime)s]  [%(filename)15s:%(lineno)4d] %(levelname)-8s %(message)s",
+    datefmt="%Y-%m-%d:%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def setup_argparser() -> argparse.ArgumentParser:
+    parser_ = argparse.ArgumentParser(description=f"CGLM Benchmark Data Generation")
+    parser_.add_argument(
+        "sourcedir", type=pathlib.Path, action="store", help="Path to source data directory"
+    )
+    parser_.add_argument(
+        "output", type=pathlib.Path, action="store", help="Path where we will output the dataset"
+    )
+
+    parser_.add_argument(
+        "--metadata", type=pathlib.Path, default="cglm_labels_timestamps_clean.csv", action="store", help="The path to the csv file containing the metadata"
+    )
+
+    parser_.add_argument(
+        "--dummy",
+        action="store_true",
+        help="Add a final dummy item in the fair future to train also on the last trigger in Modyn",
+    )
+
+    parser_.add_argument(
+        "--min_samples_per_class",
+        type=int,
+        default=25,
+        action="store",
+        help="Classes that have less than `min_samples_per_class` samples will be deleted. Defaults to 25.",
+    )
+
+    parser_.add_argument(
+        "--clean",
+        action="store_true",
+        help="If given, the GLM cleaned subset is used. Check out the repo for more details on how this was generated.",
+    )
+
+    parser_.add_argument(
+        "--labeltype",
+        default="landmark",
+        help="Which label type should be used. `landmark` are the default labels from the CGLM paper, and `supercategory` and `hierarchical` are higher order labels provided by Google.",
+        choices=["landmark", "supercategory", "hierarchical"]
+    )
+
+    parser_.add_argument(
+        "--eval_split",
+        type=str,
+        choices=["uniform", "yearly"],
+        help="Generate an evaluation split. 'uniform' samples 10% uniformly at random, 'yearly' samples 10% from each year.",
+    )
+
+    return parser_
+
+
+def main():
+    parser = setup_argparser()
+    args = parser.parse_args()
+    identifier = f"cglm{'_clean' if args.clean else ''}_{args.labeltype}_min{args.min_samples_per_class}"
+    logger.info(f"Final destination is {args.output / identifier}. Generating subset to use. Identifier is {identifier}.")
+
+    label_type_to_column = {"landmark": 'landmark_id', "supercategory": "supercategory_label", "hierarchical": "hierarchical_label_label"}
+    label_column = label_type_to_column[args.labeltype]
+
+    df = pd.read_csv("cglm_labels_timestamps_clean.csv")
+    df = df[df["clean"] == args.clean]
+    df = df[df[label_column].notnull()]
+    label_counts = df[label_column].value_counts()
+    label_ids_to_drop = label_counts[label_counts < args.min_samples_per_class].index
+    df = df[~df[label_column].isin(label_ids_to_drop)]
+
+    label_to_new_label = {old_label: label for label, old_label in enumerate(df[label_column].unique())}
+    df['label'] = df[label_column].map(label_to_new_label)
+
+    print(f"We got {df.shape[0]} samples with {len(label_to_new_label)} classes for this configuration. Generating subset.")
+
+    if args.eval_split:
+        if args.eval_split == "uniform":
+            train_df, eval_df = train_test_split(df, test_size=0.1, random_state=42)
+        elif args.eval_split == "yearly":
+            df["year"] = df["upload_date"].apply(lambda x: datetime.fromtimestamp(x).year)
+            train_dfs, eval_dfs = [], []
+            for _year, group in df.groupby("year"):
+                train_group, eval_group = train_test_split(group, test_size=0.1, random_state=42)
+                train_dfs.append(train_group)
+                eval_dfs.append(eval_group)
+            train_df = pd.concat(train_dfs)
+            eval_df = pd.concat(eval_dfs)
+
+        loop_iterator = [("train", train_df, args.output / identifier / "train"), ("eval", eval_df, args.output / identifier / "eval")]
+    else:
+        loop_iterator = [("train", df, args.output / identifier / "train")]
+    
+    for split, split_df, output_dir in loop_iterator:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"Generating {split} split with {len(split_df)} samples...")
+        for _, row in tqdm(split_df.iterrows(), total=len(split_df)):
+            id = row["id"]
+            label = row["label"]
+            timestamp = row["upload_date"]
+            file_path = args.sourcedir / f"{id[0]}/{id[1]}/{id[2]}/{id}.jpg"
+
+            if not file_path.exists():
+                logger.error(f"File {file_path} is supposed to exist, but it does not. Skipping...")
+                continue
+
+            destination_path = output_dir / f"{id}.jpg"
+
+            if destination_path.exists():
+                logger.error(f"File {destination_path} already exists. Skipping...")
+                continue
+
+            shutil.copy(file_path, destination_path)
+            os.utime(destination_path, (timestamp, timestamp))
+
+            with open(output_dir / f"{id}.label", "w", encoding="utf-8") as file:
+                file.write(str(int(label)))
+            os.utime(output_dir / f"{id}.label", (timestamp, timestamp))
+
+    if args.dummy:
+        dummy_path =  args.output / identifier / "train" / "dummy.jpg"
+        shutil.copy(file_path, dummy_path) # just use the last file_path
+        dummy_ts = timestamp + 24 * 60 * 60 * 1000
+        os.utime(dummy_path, (dummy_ts, dummy_ts))
+        with open(args.output / identifier / "train" / "dummy.label", "w", encoding="utf-8") as file:
+            file.write(str(int(label)))
+        os.utime(args.output / identifier / "train" / "dummy.label", (dummy_ts, dummy_ts))
+
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/benchmark/cglm/metadata_regeneration/istarmap.py
+++ b/benchmark/cglm/metadata_regeneration/istarmap.py
@@ -1,0 +1,26 @@
+import multiprocessing.pool as mpp
+
+
+# Thanks to https://stackoverflow.com/a/57364423
+def istarmap(self, func, iterable, chunksize=1):
+    """starmap-version of imap
+    """
+    self._check_running()
+    if chunksize < 1:
+        raise ValueError(
+            "Chunksize must be 1+, not {0:n}".format(
+                chunksize))
+
+    task_batches = mpp.Pool._get_tasks(func, iterable, chunksize)
+    result = mpp.IMapIterator(self)
+    self._taskqueue.put(
+        (
+            self._guarded_task_generation(result._job,
+                                          mpp.starmapstar,
+                                          task_batches),
+            result._set_length
+        ))
+    return (item for chunk in result for item in chunk)
+
+
+mpp.Pool.istarmap = istarmap

--- a/benchmark/cglm/metadata_regeneration/join_metadata.py
+++ b/benchmark/cglm/metadata_regeneration/join_metadata.py
@@ -1,0 +1,51 @@
+import os
+
+import pandas as pd
+
+
+def read_second_csvs(directory):
+    dfs = []
+    for file_name in os.listdir(directory):
+        if file_name.endswith('.csv'):
+            file_path = os.path.join(directory, file_name)
+            dfs.append(pd.read_csv(file_path, dtype={'upload_date': 'int'}))
+
+    return pd.concat(dfs, ignore_index=True).drop("filename", axis=1).rename(columns={'fileid': 'id'})
+
+# Directory containing the timestamp csv files
+second_csv_directory = '/scratch/maximilian.boether/scrape/outputs'
+
+full_source = pd.read_csv('/scratch/maximilian.boether/scrape/train_attribution.csv')
+second_csv_file_ids = read_second_csvs(second_csv_directory)
+
+# Attach timestamp to each file
+timestamped_df = pd.merge(full_source, second_csv_file_ids, on='id', how='inner')
+
+# Attach label to each file
+landmarks_df = pd.read_csv('/scratch/maximilian.boether/scrape/train.csv').drop("url", axis=1)
+labeled_df = pd.merge(timestamped_df, landmarks_df, on='id', how='inner')
+
+# Attach clean marker
+clean_df = pd.read_csv('/scratch/maximilian.boether/scrape/train_clean.csv')
+clean_df['images'] = clean_df['images'].str.split()
+landmark_dict = dict(zip(clean_df['landmark_id'], clean_df['images']))
+
+def is_clean(row):
+    file_id = row['id']
+    landmark_id = row['landmark_id']
+    if landmark_id in landmark_dict:
+        return file_id in landmark_dict[landmark_id]
+    return False
+
+labeled_df['clean'] = labeled_df.apply(is_clean, axis=1)
+
+hierarchy_df = pd.read_csv('/scratch/maximilian.boether/scrape/index_label_to_hierarchical.csv').drop('category', axis=1)
+supercategory_to_label = {supercategory: label for label, supercategory in enumerate(hierarchy_df['supercategory'].unique())}
+hierarchical_label_to_label = {hierarchical_label: label for label, hierarchical_label in enumerate(hierarchy_df['hierarchical_label'].unique())}
+hierarchy_df['supercategory_label'] = hierarchy_df['supercategory'].map(supercategory_to_label)
+hierarchy_df['hierarchical_label_label'] = hierarchy_df['hierarchical_label'].map(hierarchical_label_to_label)
+
+final_df = pd.merge(labeled_df, hierarchy_df, on='landmark_id', how='inner')
+
+final_df.to_csv("cglm_labels_timestamps_clean.csv", index=False)
+

--- a/benchmark/cglm/metadata_regeneration/scrape.py
+++ b/benchmark/cglm/metadata_regeneration/scrape.py
@@ -1,3 +1,5 @@
+# isort: skip_file
+
 import os
 import random
 import time

--- a/benchmark/cglm/metadata_regeneration/scrape.py
+++ b/benchmark/cglm/metadata_regeneration/scrape.py
@@ -1,0 +1,118 @@
+import os
+import random
+import time
+from . import istarmap  # fmt: skip  # noqa  # isort:skip
+
+from multiprocessing import Manager, Pool
+
+import requests
+import tqdm
+
+
+# This scraper is based on https://github.com/drimpossible/ACM/blob/main/scripts/cglm_scrape.py
+
+TOTAL_MACHINES=1
+MACHINE_ID=0
+
+OUTPUT_DIR = './metadata/'
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+PATH_TO_TRAINATTRIBUTIONS = './train_attribution.csv'
+
+ids = []
+
+fr = open(PATH_TO_TRAINATTRIBUTIONS, 'r')
+lines = fr.readlines()
+fr.close()
+
+# Get photo_id, line_match fields from the file
+for num_line,line in enumerate(lines):
+    if num_line % TOTAL_MACHINES == MACHINE_ID:
+        photo_id = line.strip().split(',')[1].split(':')[-1].strip()
+        line_match = line.strip().split(',')[0].strip()
+        ids.append((photo_id, line_match))
+
+# Function to save failed items to disk
+def save_failed_items(failed_items):
+    with open(os.path.join(OUTPUT_DIR, 'failed_items.txt'), 'w') as f:
+        for item in failed_items:
+            f.write(f"{item[0]},{item[1]}\n")
+    #print(f"Failed items persisted to '{os.path.join(OUTPUT_DIR, 'failed_items.txt')}'.")
+
+# Function to download and store the metadata
+def download_metadata(id, failed_items):
+    photo_id, line_match = id
+    delay = 3  # Initial delay in seconds
+    max_retries = 3
+    timeout = 10  # Timeout in seconds
+    output_path = os.path.join(OUTPUT_DIR, line_match+'.txt')
+    if os.path.isfile(output_path):
+        return
+
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'Accept-Encoding': 'gzip, deflate, br',
+        'Connection': 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+        'Cache-Control': 'max-age=0'
+    }
+
+    for retry in range(max_retries):
+        time.sleep(random.uniform(0.2, 2.5))
+        try:
+            # You might want to host the server yourself.
+            #res = requests.get('http://localhost:9000/public_html/commonsapi.php?meta&image='+photo_id, timeout=timeout, headers=headers)
+            res = requests.get('https://opendata.utou.ch/glam/magnus-toolserver/commonsapi.php?meta&image='+photo_id, timeout=timeout, headers=headers)
+
+
+            if res.status_code == 200:
+                content = res.content.decode('utf8')
+                if 'HTTP/1.1 429' in content:
+                    print(f"Rate limited in response content. Retrying...")
+                    time.sleep(delay)
+                    delay *= 2  # Double the delay for rate limiting in response content
+                    continue
+
+                with open(output_path, 'w') as f:
+                    f.write(content+'\n')
+                    f.flush()
+
+                time.sleep(random.uniform(0.2, 1.5))
+                return
+            elif res.status_code == 429:
+                retry_after = int(res.headers.get('Retry-After', str(delay)))
+                delay = max(delay, retry_after * 2)  # Double the delay suggested by the server
+                print(f"Rate limited. Retrying in {delay} seconds.")
+                time.sleep(delay)
+            else:
+                print(f"Request failed with status code {res.status_code}. Retrying...")
+                time.sleep(delay)
+                delay *= 2  # Double the delay for other failed status codes
+        except requests.exceptions.Timeout:
+            #print(f"Request timed out. Retrying...")
+            time.sleep(delay)
+            delay *= 2  # Double the delay for timeouts
+        except Exception as e:
+            print(f"Error occurred: {str(e)}. Retrying...")
+            time.sleep(delay)
+            delay *= 2  # Double the delay for exceptions
+
+    failed_items.append(id)
+    save_failed_items(failed_items)  # Save failed items to disk
+
+if __name__ == '__main__':
+    manager = Manager()
+    failed_items = manager.list()
+    progress = manager.Value('i', 0)
+
+    pool_size = 16  # Adjust this number if necessary
+    with Pool(pool_size) as pool:
+        print(f"Pool with {pool_size} workers initialized.")
+
+        inputs = [(id, failed_items) for id in ids]
+        for _ in tqdm.tqdm(pool.istarmap(download_metadata, inputs), total=len(inputs)):
+            pass
+
+    # Persist the list of failed items to disk at the end
+    save_failed_items(failed_items)

--- a/benchmark/cglm/metadata_regeneration/xml_to_csv.py
+++ b/benchmark/cglm/metadata_regeneration/xml_to_csv.py
@@ -1,0 +1,98 @@
+import os
+import re
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+
+import pandas as pd
+
+
+def process_file(file_path):
+    try:
+        file_id = os.path.splitext(os.path.basename(file_path))[0]
+
+        with open(file_path, 'r') as file:
+            xml_content = file.read()
+        
+        root = ET.fromstring(xml_content)
+
+        if root.tag == 'error':
+            error_message = root.text.strip()
+            if error_message.startswith("File does not exist"):
+                file_not_found.append(file_id)
+            else:
+                parsing_errors.append(file_id)
+
+            return None
+        
+        file_element = root.find('file')
+        if file_element is None:
+            parsing_errors.append(file_id)
+            return None
+        
+        name = file_element.find('name').text
+        upload_date_element = file_element.find('upload_date')
+        
+        if upload_date_element is None:
+            file_id = os.path.splitext(os.path.basename(file_path))[0]
+            no_upload_date.append(file_id)
+            return None
+        
+        upload_date = datetime.strptime(upload_date_element.text, '%Y-%m-%dT%H:%M:%SZ').timestamp()
+        
+        return file_id, name, upload_date
+    
+    except ET.ParseError:
+        # Try to extract upload_date using regular expression
+        match = re.search(r'<upload_date>(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)</upload_date>', xml_content)
+        if match:
+            upload_date = datetime.strptime(match.group(1), '%Y-%m-%dT%H:%M:%SZ').timestamp()
+            return file_id, None, upload_date
+        else:
+            parsing_errors.append(file_id)
+            return None
+    
+    except ValueError as e:
+        # Handle ValueError when parsing upload_date
+        if "time data" in str(e):
+            no_upload_date.append(file_id)
+        else:
+            parsing_errors.append(file_id)
+        return None
+    
+    except Exception as e:
+        # Handle other exceptions
+        parsing_errors.append(file_id)
+        return None
+    
+def process_directory(directory):
+    file_paths = [os.path.join(directory, file) for file in os.listdir(directory) if file.endswith('.txt')]
+    
+    with ThreadPoolExecutor() as executor:
+        results = list(executor.map(process_file, file_paths))
+    
+    results = [result for result in results if result is not None]
+    
+    if results:
+        fileids, filenames, upload_dates = zip(*results)
+        df = pd.DataFrame({'fileid': fileids, 'filename': filenames, 'upload_date': upload_dates})
+        df.to_csv('output.csv', index=False)
+    else:
+        print("No valid data found.")
+    
+    with open('file_not_found.txt', 'w') as file:
+        file.write('\n'.join(file_not_found))
+    
+    with open('no_upload_date.txt', 'w') as file:
+        file.write('\n'.join(no_upload_date))
+    
+    with open('parsing_errors.txt', 'w') as file:
+        file.write('\n'.join(parsing_errors))
+
+if __name__ == '__main__':
+    directory = '/scratch/maximilian.boether/scrape/metadata'
+    file_not_found = []
+    no_upload_date = []
+    parsing_errors = []
+    
+    process_directory(directory)


### PR DESCRIPTION
This adds a data generation script and some documentation on the CGLM dataset. This can be further improved but for now gets the job done. 

I also wanted to persist the scripts for scraping the metadata somewhere, but they are not cleaned at all. I am okay with this, since I do not want to put a lot of energy into that right now and we provide the final scraped data anyways, so it's mostly for documentation purposes (unless you want to scrape wikimedia for 2 weeks ;D).