### PR TITLE
feat: Support pretrained weights for ResNet models from torchvision

### DIFF
--- a/modyn/models/resnet152/resnet152.py
+++ b/modyn/models/resnet152/resnet152.py
@@ -3,7 +3,7 @@ from typing import Any
 import torch
 from modyn.models.coreset_methods_support import CoresetSupportingModule
 from torch import Tensor, nn
-from torchvision.models.resnet import Bottleneck, ResNet
+from torchvision.models.resnet import Bottleneck, ResNet, ResNet152_Weights
 
 
 class ResNet152:
@@ -19,7 +19,22 @@ class ResNet152:
 
 class ResNet152Modyn(ResNet, CoresetSupportingModule):
     def __init__(self, model_configuration: dict[str, Any]) -> None:
+        _num_classes = model_configuration.get("num_classes", None)
+        weights = None
+        if model_configuration.get("use_pretrained", False):
+            weights = ResNet152_Weights.verify("ResNet152_Weights.DEFAULT")
+            # We need to initialize the model with the number of classees
+            # in the pretrained weights
+            model_configuration["num_classes"] = len(weights.meta["categories"])
+            del model_configuration["use_pretrained"]  # don't want to forward this to torchvision
+
         super().__init__(Bottleneck, [3, 8, 36, 3], **model_configuration)  # type: ignore
+
+        if weights is not None:
+            self.load_state_dict(weights.get_state_dict(progress=True))
+            if _num_classes is not None:
+                # we loaded pretrained weights - need to update linear layer
+                self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:
         x = self.conv1(x)

--- a/modyn/models/resnet152/resnet152.py
+++ b/modyn/models/resnet152/resnet152.py
@@ -34,7 +34,7 @@ class ResNet152Modyn(ResNet, CoresetSupportingModule):
             self.load_state_dict(weights.get_state_dict(progress=True))
             if _num_classes is not None:
                 # we loaded pretrained weights - need to update linear layer
-                self.fc: nn.Linear # to satisfy mypy
+                self.fc: nn.Linear  # to satisfy mypy
                 self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:

--- a/modyn/models/resnet152/resnet152.py
+++ b/modyn/models/resnet152/resnet152.py
@@ -34,6 +34,7 @@ class ResNet152Modyn(ResNet, CoresetSupportingModule):
             self.load_state_dict(weights.get_state_dict(progress=True))
             if _num_classes is not None:
                 # we loaded pretrained weights - need to update linear layer
+                self.fc: nn.Linear # to satisfy mypy
                 self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:

--- a/modyn/models/resnet18/resnet18.py
+++ b/modyn/models/resnet18/resnet18.py
@@ -3,7 +3,7 @@ from typing import Any
 import torch
 from modyn.models.coreset_methods_support import CoresetSupportingModule
 from torch import Tensor, nn
-from torchvision.models.resnet import BasicBlock, ResNet
+from torchvision.models.resnet import BasicBlock, ResNet, ResNet18_Weights
 
 
 class ResNet18:
@@ -19,7 +19,22 @@ class ResNet18:
 
 class ResNet18Modyn(ResNet, CoresetSupportingModule):
     def __init__(self, model_configuration: dict[str, Any]) -> None:
+        _num_classes = model_configuration.get("num_classes", None)
+        weights = None
+        if model_configuration.get("use_pretrained", False):
+            weights = ResNet18_Weights.verify("ResNet18_Weights.DEFAULT")
+            # We need to initialize the model with the number of classees
+            # in the pretrained weights
+            model_configuration["num_classes"] = len(weights.meta["categories"])
+            del model_configuration["use_pretrained"]  # don't want to forward this to torchvision
+
         super().__init__(BasicBlock, [2, 2, 2, 2], **model_configuration)  # type: ignore
+
+        if weights is not None:
+            self.load_state_dict(weights.get_state_dict(progress=True))
+            if _num_classes is not None:
+                # we loaded pretrained weights - need to update linear layer
+                self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:
         x = self.conv1(x)

--- a/modyn/models/resnet18/resnet18.py
+++ b/modyn/models/resnet18/resnet18.py
@@ -34,6 +34,7 @@ class ResNet18Modyn(ResNet, CoresetSupportingModule):
             self.load_state_dict(weights.get_state_dict(progress=True))
             if _num_classes is not None:
                 # we loaded pretrained weights - need to update linear layer
+                self.fc: nn.Linear # to satisfy mypy
                 self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:

--- a/modyn/models/resnet18/resnet18.py
+++ b/modyn/models/resnet18/resnet18.py
@@ -34,7 +34,7 @@ class ResNet18Modyn(ResNet, CoresetSupportingModule):
             self.load_state_dict(weights.get_state_dict(progress=True))
             if _num_classes is not None:
                 # we loaded pretrained weights - need to update linear layer
-                self.fc: nn.Linear # to satisfy mypy
+                self.fc: nn.Linear  # to satisfy mypy
                 self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:

--- a/modyn/models/resnet50/resnet50.py
+++ b/modyn/models/resnet50/resnet50.py
@@ -34,6 +34,7 @@ class ResNet50Modyn(ResNet, CoresetSupportingModule):
             self.load_state_dict(weights.get_state_dict(progress=True))
             if _num_classes is not None:
                 # we loaded pretrained weights - need to update linear layer
+                self.fc: nn.Linear # to satisfy mypy
                 self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:

--- a/modyn/models/resnet50/resnet50.py
+++ b/modyn/models/resnet50/resnet50.py
@@ -3,7 +3,7 @@ from typing import Any
 import torch
 from modyn.models.coreset_methods_support import CoresetSupportingModule
 from torch import Tensor, nn
-from torchvision.models.resnet import Bottleneck, ResNet
+from torchvision.models.resnet import Bottleneck, ResNet, ResNet50_Weights
 
 
 class ResNet50:
@@ -19,7 +19,22 @@ class ResNet50:
 
 class ResNet50Modyn(ResNet, CoresetSupportingModule):
     def __init__(self, model_configuration: dict[str, Any]) -> None:
+        _num_classes = model_configuration.get("num_classes", None)
+        weights = None
+        if model_configuration.get("use_pretrained", False):
+            weights = ResNet50_Weights.verify("ResNet50_Weights.DEFAULT")
+            # We need to initialize the model with the number of classees
+            # in the pretrained weights
+            model_configuration["num_classes"] = len(weights.meta["categories"])
+            del model_configuration["use_pretrained"]  # don't want to forward this to torchvision
+
         super().__init__(Bottleneck, [3, 4, 6, 3], **model_configuration)  # type: ignore
+
+        if weights is not None:
+            self.load_state_dict(weights.get_state_dict(progress=True))
+            if _num_classes is not None:
+                # we loaded pretrained weights - need to update linear layer
+                self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:
         x = self.conv1(x)

--- a/modyn/models/resnet50/resnet50.py
+++ b/modyn/models/resnet50/resnet50.py
@@ -34,7 +34,7 @@ class ResNet50Modyn(ResNet, CoresetSupportingModule):
             self.load_state_dict(weights.get_state_dict(progress=True))
             if _num_classes is not None:
                 # we loaded pretrained weights - need to update linear layer
-                self.fc: nn.Linear # to satisfy mypy
+                self.fc: nn.Linear  # to satisfy mypy
                 self.fc = nn.Linear(self.fc.in_features, _num_classes)
 
     def _forward_impl(self, x: Tensor) -> Tensor:


### PR DESCRIPTION
For CLOC/CGLM, @Sipondo suggested using a pretrained model. I somewhat agree this makes sense. Hence, I add support for loading the pretrained weights from torch. We need to call some internal functions here because we somewhat hijacked the implementation to record the embeddings. No unit tests for this because I do not want to download data in the tests, but I tested it locally and it works :)