### PR TITLE
Remove availability logic from trainer server

### DIFF
--- a/modyn/tests/trainer_server/internal/grpc/test_trainer_server_grpc_servicer.py
+++ b/modyn/tests/trainer_server/internal/grpc/test_trainer_server_grpc_servicer.py
@@ -220,22 +220,6 @@ def test_trainer_available(test_connect_to_model_storage):
     "connect_to_model_storage",
     return_value=DummyModelStorageStub(),
 )
-@patch.object(mp.Process, "is_alive", return_value=True)
-def test_trainer_not_available(test_is_alive, test_connect_to_model_storage):
-    with tempfile.TemporaryDirectory() as modyn_temp:
-        trainer_server = TrainerServerGRPCServicer(modyn_config, modyn_temp)
-        trainer_server._training_process_dict[10] = TrainingProcessInfo(
-            mp.Process(), mp.Queue(), mp.Queue(), mp.Queue(), mp.Queue(), mp.Queue()
-        )
-        response = trainer_server.trainer_available(trainer_available_request, None)
-        assert not response.available
-
-
-@patch.object(
-    TrainerServerGRPCServicer,
-    "connect_to_model_storage",
-    return_value=DummyModelStorageStub(),
-)
 @patch(
     "modyn.trainer_server.internal.grpc.trainer_server_grpc_servicer.hasattr",
     return_value=False,

--- a/modyn/trainer_server/internal/grpc/trainer_server_grpc_servicer.py
+++ b/modyn/trainer_server/internal/grpc/trainer_server_grpc_servicer.py
@@ -82,11 +82,10 @@ class TrainerServerGRPCServicer:
         request: TrainerAvailableRequest,  # pylint: disable=unused-argument
         context: grpc.ServicerContext,  # pylint: disable=unused-argument
     ) -> TrainerAvailableResponse:
-        # if there is already another training job running, the node is considered unavailable
-        for _, training in self._training_process_dict.items():
-            if training.process_handler.is_alive():
-                return TrainerAvailableResponse(available=False)
-
+        # Right now, we are always available.
+        # In the future, we might want to implement some resource management to not overload the GPU(s).
+        # Currently, the client specifys the device, in the future this should all be managed by the
+        # trainer server.
         return TrainerAvailableResponse(available=True)
 
     # pylint: disable=too-many-locals


### PR DESCRIPTION
The current availability logic in the trainer server is a bit flawed. If a training is running, the TS is considered unavailable. However, the task of figuring out resources is currently left to the client anyways: We specify the GPU and if we want to, we can start several pipelines as long as another pipeline is currently not training (but instead, e.g. evaluating). 

This lead to some experiments not working out because the trainer server not being available, although I wanted to train on a different GPU. Let's remove this old logic and keep the full responsibility at client for now. In the future, the TS should be responsible for managing its resources, but as long as the client specifies the GPU, this logic does not make sense.