### PR TITLE
More `RHO LOSS` flavors

### DIFF
--- a/modyn/config/schema/pipeline/sampling/downsampling_config.py
+++ b/modyn/config/schema/pipeline/sampling/downsampling_config.py
@@ -117,7 +117,6 @@ class ILTrainingConfig(TrainingConfig):
     # hardcode values that are not relevant in the IL training
     gpus: Literal[1] = 1
     num_samples_to_pass: Literal[None] = None
-    use_previous_model: Literal[False] = False
     initial_model: Literal["random"] = "random"
     initial_model_id: Literal[None] = None
     checkpointing: NoCheckpointingConfig = Field(default=NoCheckpointingConfig())

--- a/modyn/config/schema/pipeline/sampling/downsampling_config.py
+++ b/modyn/config/schema/pipeline/sampling/downsampling_config.py
@@ -127,7 +127,6 @@ class RHOLossDownsamplingConfig(BaseDownsamplingConfig):
     """Config for the RHO Loss downsampling strategy."""
 
     strategy: Literal["RHOLoss"] = "RHOLoss"
-    sample_then_batch: Literal[False] = False
     holdout_set_ratio: int = Field(
         description=("How much of the training set is used as the holdout set."),
         min=0,


### PR DESCRIPTION
1. Make it possible to train the il model from last trigger's il model.
2. Enable `sample-then-batch` for `RHO Loss`.

Address https://github.com/eth-easl/modyn/issues/504