### PR TITLE
Fix unsynced warmup across selector instances

### DIFF
--- a/modyn/selector/selector.py
+++ b/modyn/selector/selector.py
@@ -146,6 +146,7 @@ class Selector:
         return self._trigger_partition_cache[trigger_id]
 
     def get_available_labels(self) -> list[int]:
+        self._strategy._update_next_trigger_id()
         return self._strategy.get_available_labels()
 
     def uses_weights(self) -> bool:
@@ -153,6 +154,7 @@ class Selector:
 
     def get_selection_strategy_remote(self) -> tuple[bool, str, dict]:
         if isinstance(self._strategy, CoresetStrategy):
+            self._strategy._update_next_trigger_id()
             return (
                 self._strategy.requires_remote_computation,
                 self._strategy.downsampling_strategy,


### PR DESCRIPTION
This PR acts more as a patch rather than a fundamental fix to the asynchronism across different selector instances.

A fundamental fix should make the selection strategy *stateless*: by getting rid of the field`self._next_trigger_id` and providing it in the upstream as an argument.

This PR reduces the statefullness by removing the `self.is_warmup`.