### PR TITLE
Pin numpy to the last stable version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - sqlalchemy>=2.0
   - pyaml
   - pydantic
-  - numpy
+  - numpy==1.26.*
   - pandas
   - bitstring
   - tensorboard


### PR DESCRIPTION
Numpy releases yesterday (16 June 2024) 2.0, which causes the current CI failures. This PR pins numpy to the last stable version to not block development.