### PR TITLE
Fix metric in `UncertaintyDownsamplingStrategy`

### DIFF
--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/uncertainty_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/uncertainty_downsampling_strategy.py
@@ -21,8 +21,7 @@ class UncertaintyDownsamplingStrategy(AbstractDownsamplingStrategy):
     def downsampling_params(self) -> dict:
         config = super().downsampling_params
 
-        config["score_metric"] = self.downsampling_config["score_metric"]
-
+        config["score_metric"] = self.downsampling_config.score_metric
         config["balance"] = self.balance
         if config["balance"] and self.downsampling_mode == DownsamplingMode.BATCH_THEN_SAMPLE:
             raise ValueError("Balanced sampling (balance=True) can be used only in Sample then Batch mode.")

--- a/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_uncertainty_downsampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_uncertainty_downsampling_strategy.py
@@ -1,0 +1,31 @@
+import os
+import pathlib
+import tempfile
+
+from modyn.config.schema.pipeline.sampling.downsampling_config import UncertaintyDownsamplingConfig
+from modyn.selector.internal.selector_strategies.downsampling_strategies import UncertaintyDownsamplingStrategy
+
+database_path = pathlib.Path(os.path.abspath(__file__)).parent / "test_storage.db"
+TMP_DIR = tempfile.mkdtemp()
+
+
+def test_init_uncert():
+    # Test init works
+    strat = UncertaintyDownsamplingStrategy(
+        UncertaintyDownsamplingConfig(ratio=10, score_metric="Margin"),
+        {},
+        0,
+        1000,
+    )
+
+    assert strat.downsampling_ratio == 10
+    assert strat.requires_remote_computation
+    assert strat.maximum_keys_in_memory == 1000
+
+    name = strat.remote_downsampling_strategy_name
+    assert isinstance(name, str)
+    assert name == "RemoteUncertaintyDownsamplingStrategy"
+
+    params = strat.downsampling_params
+    assert "score_metric" in params
+    assert params["score_metric"] == "Margin"


### PR DESCRIPTION
Before this, getting the downsampling params of a `UncertaintyDownsamplingStrategy` failed.

Step 3/n of porting over SIGMOD changes