### PR TITLE
Fix various issues in RS2

### DIFF
--- a/modyn/config/schema/pipeline/sampling/downsampling_config.py
+++ b/modyn/config/schema/pipeline/sampling/downsampling_config.py
@@ -159,6 +159,7 @@ SingleDownsamplingConfig = Annotated[
         GradNormDownsamplingConfig,
         NoDownsamplingConfig,
         RHOLossDownsamplingConfig,
+        RS2DownsamplingConfig,
     ],
     Field(discriminator="strategy"),
 ]

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/uncertainty_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/uncertainty_downsampling_strategy.py
@@ -21,7 +21,8 @@ class UncertaintyDownsamplingStrategy(AbstractDownsamplingStrategy):
     def downsampling_params(self) -> dict:
         config = super().downsampling_params
 
-        config["score_metric"] = self.downsampling_config.score_metric
+        config["score_metric"] = self.downsampling_config["score_metric"]
+
         config["balance"] = self.balance
         if config["balance"] and self.downsampling_mode == DownsamplingMode.BATCH_THEN_SAMPLE:
             raise ValueError("Balanced sampling (balance=True) can be used only in Sample then Batch mode.")

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/uncertainty_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/uncertainty_downsampling_strategy.py
@@ -21,8 +21,7 @@ class UncertaintyDownsamplingStrategy(AbstractDownsamplingStrategy):
     def downsampling_params(self) -> dict:
         config = super().downsampling_params
 
-        config["score_metric"] = self.downsampling_config["score_metric"]
-
+        config["score_metric"] = self.downsampling_config.score_metric
         config["balance"] = self.balance
         if config["balance"] and self.downsampling_mode == DownsamplingMode.BATCH_THEN_SAMPLE:
             raise ValueError("Balanced sampling (balance=True) can be used only in Sample then Batch mode.")

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rs2_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rs2_downsampling.py
@@ -57,8 +57,13 @@ class RemoteRS2Downsampling(AbstractRemoteDownsamplingStrategy):
         self._current_subset = 0
 
     def _epoch_step_no_r(self, target_size: int) -> None:
-        max_subset = len(self._all_sample_ids) // target_size
+        if (max_subset := len(self._all_sample_ids) // target_size) == 0:
+            self._current_subset = 0
+            self._subsets = [[]]
+            return
+
         self._current_subset += 1
+
         # len(self._subsets) == 0 holds in the very first epoch
         if self._current_subset >= max_subset or len(self._subsets) == 0:
             random.shuffle(self._all_sample_ids)
@@ -76,6 +81,9 @@ class RemoteRS2Downsampling(AbstractRemoteDownsamplingStrategy):
     def select_points(self) -> tuple[list[int], torch.Tensor]:
         self._first_epoch = False
         self._epoch_step()
+        assert self._current_subset < len(
+            self._subsets
+        ), f"Inconsistent state: {self._current_subset}\n{self._subsets}\n{self._first_epoch}\n{self._all_sample_ids}"
         return self._subsets[self._current_subset], torch.ones(len(self._subsets[self._current_subset]))
 
     @property


### PR DESCRIPTION
We had a couple of issues with RS2 (config not being in the union, when the training data is smaller than the expected training size). 

Part 5/n of porting over SIGMOD changes.