### PR TITLE
More robust gRPC connections, using `tenacity` where possible

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
     - types-protobuf==5.26.*
     - evidently==0.4.27
     - alibi-detect==0.12.*
+    - tenacity
   - jsonschema
   - psycopg2
   - sqlalchemy>=2.0

--- a/modyn/evaluator/internal/dataset/evaluation_dataset.py
+++ b/modyn/evaluator/internal/dataset/evaluation_dataset.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Callable, Generator, Iterable, Optional
 
 import grpc
@@ -16,6 +17,7 @@ from modyn.utils.utils import (
     grpc_connection_established,
     instantiate_class,
 )
+from tenacity import after_log, before_log, retry, stop_after_attempt, wait_random_exponential
 from torch.utils.data import IterableDataset, get_worker_info
 from torchvision import transforms
 
@@ -78,6 +80,13 @@ class EvaluationDataset(IterableDataset):
         if len(self._transform_list) > 0:
             self._transform = transforms.Compose(self._transform_list)
 
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_random_exponential(multiplier=1, min=2, max=60),
+        before=before_log(logger, logging.ERROR),
+        after=after_log(logger, logging.ERROR),
+        reraise=True,
+    )
     def _init_grpc(self) -> None:
         storage_channel = grpc.insecure_channel(
             self._storage_address,
@@ -103,22 +112,81 @@ class EvaluationDataset(IterableDataset):
 
     def _get_keys_from_storage(self, worker_id: int, total_workers: int) -> Iterable[list[int]]:
         self._info("Getting keys from storage", worker_id)
-        req_keys = GetDataPerWorkerRequest(
-            dataset_id=self._dataset_id,
-            worker_id=worker_id,
-            total_workers=total_workers,
-            start_timestamp=self._start_timestamp,
-            end_timestamp=self._end_timestamp,
-        )
-        resp_keys: GetDataPerWorkerResponse
-        for resp_keys in self._storagestub.GetDataPerWorker(req_keys):
-            yield resp_keys.keys
+        # We don't use tenacity here due to the last_processed_index logic which would be cumbersome to redo in tenacity
+        max_retries = 5
+        retries = 0
+        last_processed_index = -1
+        backoff = 2
+        while retries < max_retries:
+            try:
+                req_keys = GetDataPerWorkerRequest(
+                    dataset_id=self._dataset_id,
+                    worker_id=worker_id,
+                    total_workers=total_workers,
+                    start_timestamp=self._start_timestamp,
+                    end_timestamp=self._end_timestamp,
+                )
+                resp_keys: GetDataPerWorkerResponse
+                for index, resp_keys in enumerate(self._storagestub.GetDataPerWorker(req_keys)):
+                    if index <= last_processed_index:
+                        continue  # Skip already processed responses
+                    yield resp_keys.keys
+                    last_processed_index = index
 
-    def _get_data_from_storage(self, keys: list[int]) -> Iterable[list[tuple[int, bytes, int]]]:
-        request = GetRequest(dataset_id=self._dataset_id, keys=keys)
-        response: GetResponse
-        for response in self._storagestub.Get(request):
-            yield list(zip(response.keys, response.samples, response.labels))
+                # If the loop completes without errors, break out of the retry loop
+                break
+
+            except grpc.RpcError as e:
+                self._info(
+                    f"Attempt {retries + 1}: gRPC error occurred, last index = "
+                    + f"{last_processed_index}: {e.code()} - {e.details()}",
+                    worker_id,
+                )
+                self._info(f"Stringified exception: {str(e)}", worker_id)
+                self._info(f"Error occured while asking {self._dataset_id} for worker data:\n{worker_id}", worker_id)
+                self._init_grpc(worker_id=worker_id)
+                retries += 1
+                if retries >= max_retries:
+                    raise RuntimeError(f"Failed to get data after {max_retries} attempts.") from e
+                else:
+                    time.sleep(backoff)
+                    backoff *= 2
+
+    def _get_data_from_storage(
+        self, keys: list[int], worker_id: Optional[int] = None
+    ) -> Iterable[list[tuple[int, bytes, int]]]:
+        max_retries = 5
+        retries = 0
+        last_processed_index = -1
+        backoff = 2
+        while retries < max_retries:
+            try:
+                request = GetRequest(dataset_id=self._dataset_id, keys=keys)
+                response: GetResponse
+                for index, response in enumerate(self._storagestub.Get(request)):
+                    if index <= last_processed_index:
+                        continue  # Skip already processed responses
+                    yield list(zip(response.keys, response.samples, response.labels))
+                    last_processed_index = index
+
+                # If the loop completes without errors, break out of the retry loop
+                break
+
+            except grpc.RpcError as e:
+                self._info(
+                    f"Attempt {retries + 1}: gRPC error occurred, last index = "
+                    + f"{last_processed_index}: {e.code()} - {e.details()}",
+                    worker_id,
+                )
+                self._info(f"Stringified exception: {str(e)}", worker_id)
+                self._info(f"Error occured while asking {self._dataset_id} for keys:\n{keys}", worker_id)
+                self._init_grpc(worker_id=worker_id)
+                retries += 1
+                if retries >= max_retries:
+                    raise RuntimeError(f"Failed to get data after {max_retries} attempts.") from e
+                else:
+                    time.sleep(backoff)
+                    backoff *= 2
 
     def __iter__(self) -> Generator:
         worker_info = get_worker_info()
@@ -144,6 +212,6 @@ class EvaluationDataset(IterableDataset):
 
         # TODO(#175): we might want to do/accelerate prefetching here.
         for keys in self._get_keys_from_storage(worker_id, total_workers):
-            for data in self._get_data_from_storage(keys):
+            for data in self._get_data_from_storage(keys, worker_id):
                 for key, sample, label in data:
                     yield key, self._transform(sample), label

--- a/modyn/evaluator/internal/dataset/evaluation_dataset.py
+++ b/modyn/evaluator/internal/dataset/evaluation_dataset.py
@@ -140,7 +140,7 @@ class EvaluationDataset(IterableDataset):
                     self._info(
                         f"Error occured while asking {self._dataset_id} for worker data:\n{worker_id}", worker_id
                     )
-                    self._init_grpc(worker_id=worker_id)
+                    self._init_grpc()
                     raise e
 
     def _get_data_from_storage(
@@ -167,7 +167,7 @@ class EvaluationDataset(IterableDataset):
                     )
                     self._info(f"Stringified exception: {str(e)}", worker_id)
                     self._info(f"Error occured while asking {self._dataset_id} for keys:\n{keys}", worker_id)
-                    self._init_grpc(worker_id=worker_id)
+                    self._init_grpc()
                     raise e
 
     def __iter__(self) -> Generator:

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -271,6 +271,7 @@ class GRPCHandler(TrainerServerGRPCHandlerMixin):
 
         return EvaluateModelRequest(**start_evaluation_kwargs)
 
+    # pylint: disable=too-many-branches
     def wait_for_evaluation_completion(
         self, training_id: int, evaluations: dict[int, EvaluationStatusReporter]
     ) -> None:

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from collections import deque
 from time import sleep
 from typing import Any, Iterable, Optional, Sequence
@@ -48,6 +47,7 @@ from modyn.storage.internal.grpc.generated.storage_pb2_grpc import StorageStub
 from modyn.supervisor.internal.eval.result_writer import AbstractEvaluationResultWriter
 from modyn.supervisor.internal.utils import EvaluationStatusReporter
 from modyn.utils import grpc_common_config, grpc_connection_established
+from tenacity import Retrying, stop_after_attempt, wait_random_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -294,27 +294,17 @@ class GRPCHandler(TrainerServerGRPCHandlerMixin):
             current_evaluation_reporter = evaluations[current_evaluation_id]
             req = EvaluationStatusRequest(evaluation_id=current_evaluation_id)
 
-            # Fault tolerant watching of evaluation
-            max_retries = 5
-            retries = 0
-            backoff = 1
-            while retries < max_retries:
-                try:
-                    res: EvaluationStatusResponse = self.evaluator.get_evaluation_status(req)
-                    break
-                except grpc.RpcError as e:
-                    logger.error(e)
-                    logger.error(
-                        f"[Training {training_id}]: Attempt {retries + 1}: gRPC connection error, trying to reconnect."
-                    )
-                    self.init_evaluator()
-                    retries += 1
-                    if retries >= max_retries:
-                        raise RuntimeError(f"Failed to evaluate model after {max_retries} attempts.") from e
-                    else:
-                        logger.error(f"Sleeping for {backoff} seconds before trying again.")
-                        time.sleep(backoff)
-                        backoff *= 2  # Exponential backoff
+            for attempt in Retrying(
+                stop=stop_after_attempt(5), wait=wait_random_exponential(multiplier=1, min=2, max=60), reraise=True
+            ):
+                with attempt:
+                    try:
+                        res: EvaluationStatusResponse = self.evaluator.get_evaluation_status(req)
+                    except grpc.RpcError as e:  # We catch and reraise to easily reconnect
+                        logger.error(e)
+                        logger.error(f"[Training {training_id}]: gRPC connection error, trying to reconnect.")
+                        self.init_evaluator()
+                        raise e
 
             if not res.valid:
                 exception_msg = f"Evaluation {current_evaluation_id} is invalid at server:\n{res}\n"

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections import deque
 from time import sleep
 from typing import Any, Iterable, Optional, Sequence
@@ -292,7 +293,28 @@ class GRPCHandler(TrainerServerGRPCHandlerMixin):
             current_evaluation_id = working_queue.popleft()
             current_evaluation_reporter = evaluations[current_evaluation_id]
             req = EvaluationStatusRequest(evaluation_id=current_evaluation_id)
-            res: EvaluationStatusResponse = self.evaluator.get_evaluation_status(req)
+
+            # Fault tolerant watching of evaluation
+            max_retries = 5
+            retries = 0
+            backoff = 1
+            while retries < max_retries:
+                try:
+                    res: EvaluationStatusResponse = self.evaluator.get_evaluation_status(req)
+                    break
+                except grpc.RpcError as e:
+                    logger.error(e)
+                    logger.error(
+                        f"[Training {training_id}]: Attempt {retries + 1}: gRPC connection error, trying to reconnect."
+                    )
+                    self.init_evaluator()
+                    retries += 1
+                    if retries >= max_retries:
+                        raise RuntimeError(f"Failed to evaluate model after {max_retries} attempts.") from e
+                    else:
+                        logger.error(f"Sleeping for {backoff} seconds before trying again.")
+                        time.sleep(backoff)
+                        backoff *= 2  # Exponential backoff
 
             if not res.valid:
                 exception_msg = f"Evaluation {current_evaluation_id} is invalid at server:\n{res}\n"

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -58,13 +58,13 @@ class EvaluationExecutor:
         pipeline_logdir: Path,
         config: ModynConfig,
         pipeline: ModynPipelineConfig,
-        grpc: GRPCHandler,
+        grpc_handler: GRPCHandler,
     ):
         self.pipeline_id = pipeline_id
         self.pipeline_logdir = pipeline_logdir
         self.config = config
         self.pipeline = pipeline
-        self.grpc = grpc
+        self.grpc = grpc_handler
         self.context: AfterPipelineEvalContext | None = None
         self.eval_handlers = (
             [EvalHandler(eval_handler_config) for eval_handler_config in pipeline.evaluation.handlers]

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import pickle
 import sys
-import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
@@ -33,6 +32,7 @@ from modyn.supervisor.internal.pipeline_executor.models import (
 from modyn.supervisor.internal.utils.evaluation_status_reporter import EvaluationStatusReporter
 from modyn.utils.utils import current_time_micros, dynamic_module_import
 from pydantic import BaseModel
+from tenacity import Retrying, stop_after_attempt, wait_random_exponential
 
 eval_strategy_module = dynamic_module_import("modyn.supervisor.internal.eval.strategies")
 
@@ -274,26 +274,17 @@ class EvaluationExecutor:
             eval_req.interval_start,
             eval_req.interval_end,
         )
-
-        # Fault tolerant starting of evaluation
-        max_retries = 5
-        retries = 0
-        backoff = 2
-        while retries < max_retries:
-            try:
-                response: EvaluateModelResponse = self.grpc.evaluator.evaluate_model(request)
-                break
-            except grpc.RpcError as e:
-                logger.error(e)
-                logger.error(f"Attempt {retries + 1}: gRPC connection error, trying to reconnect...")
-                self.grpc.init_evaluator()
-                retries += 1
-                if retries >= max_retries:
-                    raise RuntimeError(f"Failed to evaluate model after {max_retries} attempts.") from e
-                else:
-                    logger.error(f"Sleeping for {backoff} seconds before trying again.")
-                    time.sleep(backoff)
-                    backoff *= 2  # Exponential backoff
+        for attempt in Retrying(
+            stop=stop_after_attempt(5), wait=wait_random_exponential(multiplier=1, min=2, max=60), reraise=True
+        ):
+            with attempt:
+                try:
+                    response: EvaluateModelResponse = self.grpc.evaluator.evaluate_model(request)
+                except grpc.RpcError as e:  # We catch and reraise to reconnect
+                    logger.error(e)
+                    logger.error("gRPC connection error, trying to reconnect...")
+                    self.grpc.init_evaluator()
+                    raise e
 
         if not response.evaluation_started:
             log.info.failure_reason = EvaluationAbortedReason.DESCRIPTOR.values_by_number[

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_evaluation_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_evaluation_executor.py
@@ -61,7 +61,7 @@ def evaluation_executor(
         pipeline_logdir=tmp_dir_tests,
         config=dummy_system_config,
         pipeline=pipeline_config,
-        grpc=GRPCHandler(eval_state_config.config.model_dump(by_alias=True)),
+        grpc_handler=GRPCHandler(eval_state_config.config.model_dump(by_alias=True)),
     )
 
 

--- a/modyn/trainer_server/internal/dataset/key_sources/local_key_source.py
+++ b/modyn/trainer_server/internal/dataset/key_sources/local_key_source.py
@@ -33,11 +33,11 @@ class LocalKeySource(AbstractKeySource):
     def end_of_trigger_cleaning(self) -> None:
         self._trigger_sample_storage.clean_trigger_data(self._pipeline_id, self._trigger_id)
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         del state["_trigger_sample_storage"]  # not pickable
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
         self._trigger_sample_storage = TriggerSampleStorage(self.offline_dataset_path)

--- a/modyn/trainer_server/internal/dataset/key_sources/selector_key_source.py
+++ b/modyn/trainer_server/internal/dataset/key_sources/selector_key_source.py
@@ -27,6 +27,7 @@ class SelectorKeySource(AbstractKeySource):
         self._selectorstub = None  # connection is made when the pytorch worker is started
         self._uses_weights: Optional[bool] = None  # get via gRPC, so unavailable if the connection is not yet made.
 
+    @staticmethod
     def retry_reconnection_callback(retry_state: Any) -> None:
         self: SelectorKeySource = retry_state.args[0]
         logger.error(f"Retry attempt {retry_state.attempt_number}. State = \n {str(retry_state)}")

--- a/modyn/trainer_server/internal/dataset/key_sources/selector_key_source.py
+++ b/modyn/trainer_server/internal/dataset/key_sources/selector_key_source.py
@@ -1,6 +1,5 @@
 import logging
-import time
-from typing import Optional
+from typing import Any, Optional
 
 import grpc
 
@@ -15,6 +14,7 @@ from modyn.selector.internal.grpc.generated.selector_pb2 import (
 from modyn.selector.internal.grpc.generated.selector_pb2_grpc import SelectorStub
 from modyn.trainer_server.internal.dataset.key_sources import AbstractKeySource
 from modyn.utils import MAX_MESSAGE_SIZE, flatten, grpc_connection_established
+from tenacity import after_log, before_log, retry, stop_after_attempt, wait_random_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,19 @@ class SelectorKeySource(AbstractKeySource):
         self._selectorstub = None  # connection is made when the pytorch worker is started
         self._uses_weights: Optional[bool] = None  # get via gRPC, so unavailable if the connection is not yet made.
 
+    def retry_reconnection_callback(retry_state: Any) -> None:
+        self: SelectorKeySource = retry_state.args[0]
+        logger.error(f"Retry attempt {retry_state.attempt_number}. State = \n {str(retry_state)}")
+        self._connect_to_selector()
+
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_random_exponential(multiplier=1, min=2, max=60),
+        before=before_log(logger, logging.ERROR),
+        after=after_log(logger, logging.ERROR),
+        reraise=True,
+        retry_error_callback=retry_reconnection_callback,
+    )
     def get_keys_and_weights(self, worker_id: int, partition_id: int) -> tuple[list[int], Optional[list[float]]]:
         assert self._selectorstub is not None
         assert self._uses_weights is not None
@@ -90,26 +103,24 @@ class SelectorKeySource(AbstractKeySource):
         self._selectorstub = self._connect_to_selector()
         self._uses_weights = self.uses_weights()
 
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_random_exponential(multiplier=1, min=2, max=60),
+        before=before_log(logger, logging.ERROR),
+        after=after_log(logger, logging.ERROR),
+        reraise=True,
+    )
     def _connect_to_selector(self) -> SelectorStub:  # pragma: no cover
-        max_retries = 5
-        retry_delay = 1  # seconds
+        selector_channel = grpc.insecure_channel(
+            self._selector_address,
+            options=[
+                ("grpc.max_receive_message_length", MAX_MESSAGE_SIZE),
+                ("grpc.max_send_message_length", MAX_MESSAGE_SIZE),
+            ],
+        )
+        if grpc_connection_established(selector_channel):
+            return SelectorStub(selector_channel)
 
-        for attempt in range(1, max_retries + 1):
-            selector_channel = grpc.insecure_channel(
-                self._selector_address,
-                options=[
-                    ("grpc.max_receive_message_length", MAX_MESSAGE_SIZE),
-                    ("grpc.max_send_message_length", MAX_MESSAGE_SIZE),
-                ],
-            )
-            if grpc_connection_established(selector_channel):
-                return SelectorStub(selector_channel)
-
-            logger.info(f"gRPC connection attempt {attempt} failed. Retrying in {retry_delay} seconds...")
-            time.sleep(retry_delay)
-            retry_delay *= 2  # Exponential backoff
-
-        logger.error(f"Failed to establish gRPC connection after {max_retries} attempts.")
         raise ConnectionError(f"Could not establish gRPC connection to selector at address {self._selector_address}.")
 
     def end_of_trigger_cleaning(self) -> None:

--- a/modyn/trainer_server/internal/dataset/online_dataset.py
+++ b/modyn/trainer_server/internal/dataset/online_dataset.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import random
 import threading
-import time
 from typing import Any, Callable, Generator, Iterator, Optional, Tuple, cast
 
 import grpc
@@ -26,7 +25,7 @@ from modyn.utils import (
     grpc_connection_established,
     instantiate_class,
 )
-from tenacity import after_log, before_log, retry, stop_after_attempt, wait_random_exponential
+from tenacity import Retrying, after_log, before_log, retry, stop_after_attempt, wait_random_exponential
 from torch.utils.data import IterableDataset, get_worker_info
 from torchvision import transforms
 
@@ -157,44 +156,36 @@ class OnlineDataset(IterableDataset):
     def _get_data_from_storage(
         self, selector_keys: list[int], worker_id: Optional[int] = None
     ) -> Iterator[Tuple[list[int], list[bytes], list[int], int]]:
-        # We don't use tenacity here due to the last_processed_index logic which would be cumbersome to redo in tenacity
-        max_retries = 5
-        retries = 0
         last_processed_index = -1
-        backoff = 2
 
-        while retries < max_retries:
-            try:
-                req = GetRequest(dataset_id=self._dataset_id, keys=selector_keys)
-                stopw = Stopwatch()
+        for attempt in Retrying(
+            stop=stop_after_attempt(5), wait=wait_random_exponential(multiplier=1, min=2, max=60), reraise=True
+        ):
+            with attempt:
+                try:
+                    req = GetRequest(dataset_id=self._dataset_id, keys=selector_keys)
+                    stopw = Stopwatch()
 
-                response: GetResponse
-                stopw.start("ResponseTime", overwrite=True)
-                for index, response in enumerate(self._storagestub.Get(req)):
-                    if index <= last_processed_index:
-                        continue  # Skip already processed responses
-                    yield list(response.keys), list(response.samples), list(response.labels), stopw.stop("ResponseTime")
-                    last_processed_index = index  # Update the last processed index
+                    response: GetResponse
                     stopw.start("ResponseTime", overwrite=True)
+                    for index, response in enumerate(self._storagestub.Get(req)):
+                        if index <= last_processed_index:
+                            continue  # Skip already processed responses
+                        yield list(response.keys), list(response.samples), list(response.labels), stopw.stop(
+                            "ResponseTime"
+                        )
+                        last_processed_index = index  # Update the last processed index
+                        stopw.start("ResponseTime", overwrite=True)
 
-                # If the loop completes without errors, break out of the retry loop
-                break
-
-            except grpc.RpcError as e:
-                self._info(
-                    f"Attempt {retries + 1}: gRPC error occurred, last index = "
-                    + f"{last_processed_index}: {e.code()} - {e.details()}",
-                    worker_id,
-                )
-                self._info(f"Stringified exception: {str(e)}", worker_id)
-                self._info(f"Error occured while asking {self._dataset_id} for keys:\n{selector_keys}", worker_id)
-                self._init_grpc(worker_id=worker_id)
-                retries += 1
-                if retries >= max_retries:
-                    raise RuntimeError(f"Failed to get data after {max_retries} attempts.") from e
-                else:
-                    time.sleep(backoff)
-                    backoff *= 2
+                except grpc.RpcError as e:  # We catch and reraise to reconnect to rpc and do logging
+                    self._info(
+                        "gRPC error occurred, last index = " + f"{last_processed_index}: {e.code()} - {e.details()}",
+                        worker_id,
+                    )
+                    self._info(f"Stringified exception: {str(e)}", worker_id)
+                    self._info(f"Error occured while asking {self._dataset_id} for keys:\n{selector_keys}", worker_id)
+                    self._init_grpc(worker_id=worker_id)
+                    raise e
 
     # pylint: disable=too-many-locals
 

--- a/modyn/trainer_server/internal/dataset/online_dataset.py
+++ b/modyn/trainer_server/internal/dataset/online_dataset.py
@@ -26,6 +26,7 @@ from modyn.utils import (
     grpc_connection_established,
     instantiate_class,
 )
+from tenacity import after_log, before_log, retry, stop_after_attempt, wait_random_exponential
 from torch.utils.data import IterableDataset, get_worker_info
 from torchvision import transforms
 
@@ -126,23 +127,22 @@ class OnlineDataset(IterableDataset):
         self._transform = self._bytes_parser_function
         self._setup_composed_transform()
 
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_random_exponential(multiplier=1, min=2, max=60),
+        before=before_log(logger, logging.ERROR),
+        after=after_log(logger, logging.ERROR),
+        reraise=True,
+    )
     def _init_grpc(self, worker_id: Optional[int] = None) -> None:  # pragma: no cover
-        max_retries = 5
-        retry_delay = 1  # seconds
+        self._storage_channel = grpc.insecure_channel(self._storage_address, options=grpc_common_config())
+        if grpc_connection_established(self._storage_channel):
+            self._storagestub = StorageStub(self._storage_channel)
+            return
 
-        for attempt in range(1, max_retries + 1):
-            self._storage_channel = grpc.insecure_channel(self._storage_address, options=grpc_common_config())
-            if grpc_connection_established(self._storage_channel):
-                self._storagestub = StorageStub(self._storage_channel)
-                return
-            # no connection established
-
-            self._info(f"gRPC connection attempt {attempt} failed. Retrying in {retry_delay} seconds...", worker_id)
-            time.sleep(retry_delay)
-            retry_delay *= 2  # Exponential backoff
-
-        self._info(f"Failed to establish gRPC connection after {max_retries} attempts.", worker_id)
-        raise ConnectionError(f"Could not establish gRPC connection to storage at address {self._storage_address}.")
+        raise ConnectionError(
+            f"[Worker {worker_id}]: Could not establish gRPC connection to storage at address {self._storage_address}."
+        )
 
     def _silence_pil(self) -> None:  # pragma: no cover
         pil_logger = logging.getLogger("PIL")
@@ -156,20 +156,48 @@ class OnlineDataset(IterableDataset):
 
     def _get_data_from_storage(
         self, selector_keys: list[int], worker_id: Optional[int] = None
-    ) -> Iterator[tuple[list[int], list[bytes], list[int], int]]:
-        req = GetRequest(dataset_id=self._dataset_id, keys=selector_keys)
-        stopw = Stopwatch()
+    ) -> Iterator[Tuple[list[int], list[bytes], list[int], int]]:
+        # We don't use tenacity here due to the last_processed_index logic which would be cumbersome to redo in tenacity
+        max_retries = 5
+        retries = 0
+        last_processed_index = -1
+        backoff = 2
 
-        response: GetResponse
-        stopw.start("ResponseTime", overwrite=True)
-        for _, response in enumerate(self._storagestub.Get(req)):
-            yield list(response.keys), list(response.samples), list(response.labels), stopw.stop("ResponseTime")
-            if not grpc_connection_established(self._storage_channel):
-                self._info("gRPC connection lost, trying to reconnect!", worker_id)
+        while retries < max_retries:
+            try:
+                req = GetRequest(dataset_id=self._dataset_id, keys=selector_keys)
+                stopw = Stopwatch()
+
+                response: GetResponse
+                stopw.start("ResponseTime", overwrite=True)
+                for index, response in enumerate(self._storagestub.Get(req)):
+                    if index <= last_processed_index:
+                        continue  # Skip already processed responses
+                    yield list(response.keys), list(response.samples), list(response.labels), stopw.stop("ResponseTime")
+                    last_processed_index = index  # Update the last processed index
+                    stopw.start("ResponseTime", overwrite=True)
+
+                # If the loop completes without errors, break out of the retry loop
+                break
+
+            except grpc.RpcError as e:
+                self._info(
+                    f"Attempt {retries + 1}: gRPC error occurred, last index = "
+                    + f"{last_processed_index}: {e.code()} - {e.details()}",
+                    worker_id,
+                )
+                self._info(f"Stringified exception: {str(e)}", worker_id)
+                self._info(f"Error occured while asking {self._dataset_id} for keys:\n{selector_keys}", worker_id)
                 self._init_grpc(worker_id=worker_id)
-            stopw.start("ResponseTime", overwrite=True)
+                retries += 1
+                if retries >= max_retries:
+                    raise RuntimeError(f"Failed to get data after {max_retries} attempts.") from e
+                else:
+                    time.sleep(backoff)
+                    backoff *= 2
 
     # pylint: disable=too-many-locals
+
     def _get_data(
         self,
         data_container: dict,

--- a/modyn/trainer_server/internal/trainer/pytorch_trainer.py
+++ b/modyn/trainer_server/internal/trainer/pytorch_trainer.py
@@ -736,6 +736,7 @@ class PytorchTrainer:
             strategy_name, downsampler_config, modyn_config, self._criterion_nored
         )
         assert "sample_then_batch" in downsampler_config
+        self._log["received_downsampler_config"] = downsampler_config
         if downsampler_config["sample_then_batch"]:
             self._downsampling_mode = DownsamplingMode.SAMPLE_THEN_BATCH
             assert "downsampling_period" in downsampler_config


### PR DESCRIPTION
Sometimes, we face outages/random disconnections during training. This fixes it in places where I encountered it last night. I tried to integrate `tenacity` as suggested by @robinholzi, but it's not always possible since the retry logic involves keeping track of already done work, which I don't want to put into class state

Part 6/n of porting over SIGMOD changes.