### PR TITLE
Fix device for initial RHO-LOSS tensor

### DIFF
--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rho_loss_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rho_loss_downsampling.py
@@ -36,10 +36,11 @@ class RemoteRHOLossDownsampling(AbstractRemoteDownsamplingStrategy):
         )
         self.rho_loss: torch.Tensor = torch.tensor([])
         self.number_of_points_seen = 0
+        self._device = device
 
     def init_downsampler(self) -> None:
         self.index_sampleid_map: list[int] = []
-        self.rho_loss = torch.tensor([])
+        self.rho_loss = torch.tensor([]).to(self._device)
         self.number_of_points_seen = 0
 
     def inform_samples(


### PR DESCRIPTION
The initial tensor resides on CPU. For me, it failed when running RHO-LOSS, since the very first `        self.rho_loss = torch.cat([self.rho_loss, training_loss - irreducible_loss]).to(training_loss.dtype)` was on two different devices, the CPU (initial tensor) and the GPU (training loss and IR loss). This PR fixes that by moving the initial tensor to the correct device.