### PR TITLE
feat: Log commit sha

### DIFF
--- a/modyn/supervisor/internal/pipeline_executor/models.py
+++ b/modyn/supervisor/internal/pipeline_executor/models.py
@@ -11,15 +11,14 @@ from pathlib import Path
 from typing import Any, Callable, Literal, Optional, Union, cast
 
 import pandas as pd
-from pydantic import BaseModel, Field, model_serializer, model_validator
-from typing_extensions import override
-
 from modyn.config.schema.pipeline import ModynPipelineConfig
 from modyn.config.schema.system.config import ModynConfig
 from modyn.supervisor.internal.eval.handler import EvalRequest
 from modyn.supervisor.internal.grpc.enums import PipelineStage
 from modyn.supervisor.internal.utils.evaluation_status_reporter import EvaluationStatusReporter
 from modyn.supervisor.internal.utils.git_utils import get_head_sha
+from pydantic import BaseModel, Field, model_serializer, model_validator
+from typing_extensions import override
 
 logger = logging.getLogger(__name__)
 

--- a/modyn/supervisor/internal/utils/git_utils.py
+++ b/modyn/supervisor/internal/utils/git_utils.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def get_head_sha() -> str:
+    """When launched in a git repository, return the SHA of the current HEAD."""
+
+    result = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True)
+    assert result.returncode == 0, f"Failed to get HEAD SHA: {result.stderr}, {result.stdout}"
+    return result.stdout.strip()

--- a/modyn/supervisor/internal/utils/git_utils.py
+++ b/modyn/supervisor/internal/utils/git_utils.py
@@ -1,9 +1,12 @@
 import subprocess
+from pathlib import Path
 
 
 def get_head_sha() -> str:
     """When launched in a git repository, return the SHA of the current HEAD."""
 
-    result = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True, cwd=Path(__file__).parent
+    )
     assert result.returncode == 0, f"Failed to get HEAD SHA: {result.stderr}, {result.stdout}"
     return result.stdout.strip()


### PR DESCRIPTION
# Motivation

To be able to link a pipeline rune with the code that has executed it, we want to log the git sha of the last commit in the pipeline logfile.