### PR TITLE
Implement `ratio_max` scaling for downsamplers

### DIFF
--- a/modyn/config/schema/pipeline/config.py
+++ b/modyn/config/schema/pipeline/config.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Self
 
 from modyn.config.schema.base_model import ModynBaseModel
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from .data import DataConfig
 from .evaluation.config import EvaluationConfig
 from .model import ModelConfig
 from .model_storage import PipelineModelStorageConfig
-from .sampling.config import SelectionStrategy
+from .sampling.config import CoresetStrategyConfig, SelectionStrategy
+from .sampling.downsampling_config import MultiDownsamplingConfig
 from .training import TrainingConfig
 from .trigger import TriggerConfig
 
@@ -32,3 +33,25 @@ class ModynPipelineConfig(ModynBaseModel):
     trigger: TriggerConfig
     selection_strategy: SelectionStrategy
     evaluation: EvaluationConfig | None = Field(None)
+
+    @model_validator(mode="after")
+    def validate_bts_training_selection_works(self) -> Self:
+        # Validates that when using Downsampling with BtS, we choose a functional ratio
+        if isinstance(self.selection_strategy, CoresetStrategyConfig) and not isinstance(
+            self.selection_strategy.downsampling_config, MultiDownsamplingConfig
+        ):
+            if not self.selection_strategy.downsampling_config.sample_then_batch:  # bts
+                ratio = self.selection_strategy.downsampling_config.ratio
+                ratio_max = self.selection_strategy.downsampling_config.ratio_max
+                batch_size = self.training.batch_size
+
+                post_downsampling_size = max((ratio * batch_size) // ratio_max, 1)
+                if batch_size % post_downsampling_size != 0:
+                    raise ValueError(
+                        f"The target batch size of {batch_size} is not a multiple of the batch size "
+                        + f"after downsampling with ratio {ratio} a batch in BtS mode ({post_downsampling_size}). "
+                        + "We cannot accumulate batches. "
+                        + "Please choose the downsampling ratio and batch size such that this is possible."
+                    )
+
+        return self

--- a/modyn/config/schema/pipeline/evaluation/metrics.py
+++ b/modyn/config/schema/pipeline/evaluation/metrics.py
@@ -13,8 +13,6 @@ class _BaseMetricConfig(ModynBaseModel):
         description="A function used to transform the model output before evaluation.",
     )
 
-    config: dict = Field(default={})
-
     @field_validator("evaluation_transformer_function", mode="before")
     @classmethod
     def validate_evaluation_transformer_function(cls, value: str) -> str | None:
@@ -51,7 +49,7 @@ F1ScoreTypes = Literal["macro", "micro", "weighted", "binary"]
 
 class F1ScoreMetricConfig(_BaseMetricConfig):
     name: Literal["F1Score"] = Field("F1Score")
-    num_classes: int = Field(description="The total number of classes.", default=172)
+    num_classes: int = Field(description="The total number of classes.")
     average: Literal["macro", "micro", "weighted", "binary"] = Field(
         "macro", description="The method used to average f1-score in the multiclass setting."
     )

--- a/modyn/config/schema/pipeline/evaluation/metrics.py
+++ b/modyn/config/schema/pipeline/evaluation/metrics.py
@@ -13,6 +13,8 @@ class _BaseMetricConfig(ModynBaseModel):
         description="A function used to transform the model output before evaluation.",
     )
 
+    config: dict = Field(default={})
+
     @field_validator("evaluation_transformer_function", mode="before")
     @classmethod
     def validate_evaluation_transformer_function(cls, value: str) -> str | None:
@@ -49,7 +51,7 @@ F1ScoreTypes = Literal["macro", "micro", "weighted", "binary"]
 
 class F1ScoreMetricConfig(_BaseMetricConfig):
     name: Literal["F1Score"] = Field("F1Score")
-    num_classes: int = Field(description="The total number of classes.")
+    num_classes: int = Field(description="The total number of classes.", default=172)
     average: Literal["macro", "micro", "weighted", "binary"] = Field(
         "macro", description="The method used to average f1-score in the multiclass setting."
     )

--- a/modyn/config/schema/pipeline/sampling/downsampling_config.py
+++ b/modyn/config/schema/pipeline/sampling/downsampling_config.py
@@ -20,9 +20,20 @@ class BaseDownsamplingConfig(ModynBaseModel):
         ),
     )
     ratio: int = Field(
-        description="Ratio post_sampling_size/pre_sampling_size. E.g. with 160 records and a ratio of 50 we keep 80.",
+        description=(
+            "Ratio post_sampling_size/pre_sampling_size * ratio_max. "
+            "For the default of ratio_max of 100, this implies percent, "
+            "e.g., with 160 records and a ratio of 50 we keep 80."
+        ),
         min=0,
-        max=100,
+    )
+    ratio_max: int = Field(
+        description=(
+            "Reference maximum ratio value. Defaults to 100, which implies percent."
+            " If you set this to 1000, ratio describes promille instead."
+        ),
+        default=100,
+        min=1,
     )
     period: int = Field(
         1,
@@ -33,6 +44,12 @@ class BaseDownsamplingConfig(ModynBaseModel):
         ),
         min=0,
     )
+
+    @model_validator(mode="after")
+    def validate_ratio(self) -> Self:
+        if self.ratio > self.ratio_max:
+            raise ValueError("ratio cannot be greater than ratio_max.")
+        return self
 
 
 class UncertaintyDownsamplingConfig(BaseDownsamplingConfig):

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/abstract_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/abstract_downsampling_strategy.py
@@ -38,6 +38,7 @@ class AbstractDownsamplingStrategy(ABC):
 
         self.downsampling_period = downsampling_config.period
         self.downsampling_ratio = downsampling_config.ratio
+        self.ratio_max = downsampling_config.ratio_max
 
         self.requires_remote_computation = True
         self.maximum_keys_in_memory = maximum_keys_in_memory
@@ -60,6 +61,7 @@ class AbstractDownsamplingStrategy(ABC):
     def downsampling_params(self) -> dict:
         config = {
             "downsampling_ratio": self.downsampling_ratio,
+            "ratio_max": self.ratio_max,
             "maximum_keys_in_memory": self.maximum_keys_in_memory,
             "sample_then_batch": self.downsampling_mode == DownsamplingMode.SAMPLE_THEN_BATCH,
         }

--- a/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
@@ -301,6 +301,7 @@ def test_downsampling_params(il_training_config: ILTrainingConfig, data_config: 
 
     expected = {
         "downsampling_ratio": 60,
+        "ratio_max": 100,
         "maximum_keys_in_memory": maximum_keys_in_memory,
         "sample_then_batch": False,
         "il_model_id": 3,

--- a/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_scheduler.py
+++ b/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_scheduler.py
@@ -86,6 +86,7 @@ def test_switch_functions():
             "downsampling_ratio": 50,
             "maximum_keys_in_memory": 1000,
             "sample_then_batch": True,
+            "ratio_max": 100,
         }
         assert downs.downsampling_strategy == "RemoteLossDownsampling"
         assert downs.training_status_bar_scale == 50
@@ -98,6 +99,7 @@ def test_switch_functions():
             "downsampling_ratio": 25,
             "maximum_keys_in_memory": 1000,
             "sample_then_batch": False,
+            "ratio_max": 100,
         }
         assert downs.downsampling_strategy == "RemoteGradNormDownsampling"
         assert downs.training_status_bar_scale == 100
@@ -140,6 +142,7 @@ def test_double_threshold():
             "downsampling_ratio": 50,
             "maximum_keys_in_memory": 1000,
             "sample_then_batch": True,
+            "ratio_max": 100,
         }
         assert downs.downsampling_strategy == "RemoteLossDownsampling"
         assert downs.training_status_bar_scale == 50
@@ -152,6 +155,7 @@ def test_double_threshold():
             "downsampling_ratio": 25,
             "maximum_keys_in_memory": 1000,
             "sample_then_batch": False,
+            "ratio_max": 100,
         }
         assert downs.downsampling_strategy == "RemoteGradNormDownsampling"
         assert downs.training_status_bar_scale == 100
@@ -179,6 +183,7 @@ def test_wrong_trigger():
             "downsampling_ratio": 50,
             "maximum_keys_in_memory": 1000,
             "sample_then_batch": True,
+            "ratio_max": 100,
         }
         assert downs.downsampling_strategy == "RemoteLossDownsampling"
         assert downs.training_status_bar_scale == 50
@@ -195,6 +200,7 @@ def test_wrong_trigger():
             "downsampling_ratio": 25,
             "maximum_keys_in_memory": 1000,
             "sample_then_batch": False,
+            "ratio_max": 100,
         }
         assert downs.downsampling_strategy == "RemoteGradNormDownsampling"
         assert downs.training_status_bar_scale == 100

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_abstract_matrix_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_abstract_matrix_downsampling_strategy.py
@@ -19,6 +19,7 @@ def get_sampler_config(dummy_system_config: ModynConfig, balance=False):
         "sample_then_batch": False,
         "args": {},
         "balance": balance,
+        "ratio_max": 100,
     }
     return (
         0,

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_abstract_remote_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_abstract_remote_downsampling_strategy.py
@@ -11,7 +11,7 @@ from modyn.trainer_server.internal.trainer.remote_downsamplers.abstract_remote_d
 def test_batch_then_sample_general(dummy_system_config: ModynConfig):
     downsampling_ratio = 50
 
-    params_from_selector = {"downsampling_ratio": downsampling_ratio}
+    params_from_selector = {"downsampling_ratio": downsampling_ratio, "ratio_max": 100}
     sampler = AbstractRemoteDownsamplingStrategy(
         154, 128, 64, params_from_selector, dummy_system_config.model_dump(by_alias=True), "cpu"
     )

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_craig_remote_downsampling.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_craig_remote_downsampling.py
@@ -20,6 +20,7 @@ def get_sampler_config(modyn_config, balance=False):
         "balance": balance,
         "selection_batch": 64,
         "greedy": "NaiveGreedy",
+        "ratio_max": 100,
     }
     return 0, 0, 0, params_from_selector, modyn_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
 
@@ -347,7 +348,7 @@ def test_matching_results_with_deepcore(dummy_system_config: ModynConfig):
         0,
         0,
         5,
-        {"downsampling_ratio": 20, "balance": False, "selection_batch": 64, "greedy": "NaiveGreedy"},
+        {"downsampling_ratio": 20, "balance": False, "selection_batch": 64, "greedy": "NaiveGreedy", "ratio_max": 100},
         dummy_system_config.model_dump(by_alias=True),
         BCEWithLogitsLoss(reduction="none"),
         "cpu",
@@ -402,7 +403,7 @@ def test_matching_results_with_deepcore_permutation(dummy_system_config: ModynCo
         0,
         0,
         5,
-        {"downsampling_ratio": 30, "balance": False, "selection_batch": 64, "greedy": "NaiveGreedy"},
+        {"downsampling_ratio": 30, "balance": False, "selection_batch": 64, "greedy": "NaiveGreedy", "ratio_max": 100},
         dummy_system_config.model_dump(by_alias=True),
         BCEWithLogitsLoss(reduction="none"),
         "cpu",
@@ -461,7 +462,7 @@ def test_matching_results_with_deepcore_permutation_fancy_ids(dummy_system_confi
         0,
         0,
         5,
-        {"downsampling_ratio": 50, "balance": False, "selection_batch": 64, "greedy": "NaiveGreedy"},
+        {"downsampling_ratio": 50, "balance": False, "selection_batch": 64, "greedy": "NaiveGreedy", "ratio_max": 100},
         dummy_system_config.model_dump(by_alias=True),
         BCEWithLogitsLoss(reduction="none"),
         "cpu",

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_gradmatch_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_gradmatch_downsampling_strategy.py
@@ -19,6 +19,7 @@ def get_sampler_config(modyn_config: ModynConfig, balance=False):
         "sample_then_batch": False,
         "args": {},
         "balance": balance,
+        "ratio_max": 100,
     }
     return 0, 0, 0, params_from_selector, modyn_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
 
@@ -185,7 +186,7 @@ def test_matching_results_with_deepcore(dummy_system_config: ModynConfig):
             0,
             0,
             5,
-            {"downsampling_ratio": 10 * num_of_target_samples, "balance": False},
+            {"downsampling_ratio": 10 * num_of_target_samples, "balance": False, "ratio_max": 100},
             dummy_system_config.model_dump(by_alias=True),
             BCEWithLogitsLoss(reduction="none"),
             "cpu",
@@ -237,7 +238,7 @@ def test_matching_results_with_deepcore_permutation_fancy_ids(dummy_system_confi
         0,
         0,
         5,
-        {"downsampling_ratio": 50, "balance": False},
+        {"downsampling_ratio": 50, "balance": False, "ratio_max": 100},
         dummy_system_config.model_dump(by_alias=True),
         BCEWithLogitsLoss(reduction="none"),
         "cpu",

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_gradnorm_downsample.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_gradnorm_downsample.py
@@ -14,7 +14,7 @@ def test_sample_shape_ce(dummy_system_config: ModynConfig):
     downsampling_ratio = 50
     per_sample_loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
 
-    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
+    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False, "ratio_max": 100}
     sampler = RemoteGradNormDownsampling(
         0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
     )
@@ -45,7 +45,7 @@ def test_sample_shape_other_losses(dummy_system_config: ModynConfig):
     downsampling_ratio = 50
     per_sample_loss_fct = torch.nn.BCEWithLogitsLoss(reduction="none")
 
-    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
+    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False, "ratio_max": 100}
     sampler = RemoteGradNormDownsampling(
         0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
     )
@@ -84,6 +84,7 @@ def test_sampling_crossentropy(dummy_system_config: ModynConfig):
         "downsampling_ratio": downsampling_ratio,
         "replacement": False,
         "sample_then_batch": False,
+        "ratio_max": 100,
     }
 
     # Here we use autograd since the number of classes is not provided
@@ -135,7 +136,7 @@ def test_sample_dict_input(dummy_system_config: ModynConfig):
     model = DictLikeModel()
     per_sample_loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
 
-    params_from_selector = {"downsampling_ratio": 50, "sample_then_batch": False}
+    params_from_selector = {"downsampling_ratio": 50, "sample_then_batch": False, "ratio_max": 100}
     sampler = RemoteGradNormDownsampling(
         0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
     )

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_kcenter_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_kcenter_downsampling_strategy.py
@@ -17,6 +17,7 @@ def get_sampler_config(modyn_config: ModynConfig, balance=False):
         "sample_then_batch": False,
         "args": {},
         "balance": balance,
+        "ratio_max": 100,
     }
     return 0, 0, 0, params_from_selector, modyn_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
 
@@ -137,7 +138,7 @@ def test_matching_results_with_deepcore(dummy_system_config: ModynConfig):
             0,
             0,
             5,
-            {"downsampling_ratio": 10 * num_of_target_samples, "balance": False},
+            {"downsampling_ratio": 10 * num_of_target_samples, "balance": False, "ratio_max": 100},
             dummy_system_config.model_dump(by_alias=True),
             BCEWithLogitsLoss(reduction="none"),
             "cpu",
@@ -166,7 +167,7 @@ def test_matching_results_with_deepcore_permutation_fancy_ids(dummy_system_confi
         0,
         0,
         5,
-        {"downsampling_ratio": 50, "balance": False},
+        {"downsampling_ratio": 50, "balance": False, "ratio_max": 100},
         dummy_system_config.model_dump(by_alias=True),
         BCEWithLogitsLoss(reduction="none"),
         "cpu",

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_loss_downsample.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_loss_downsample.py
@@ -12,7 +12,7 @@ def test_sample_shape(dummy_system_config: ModynConfig):
     downsampling_ratio = 50
     per_sample_loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
 
-    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
+    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False, "ratio_max": 100}
     sampler = RemoteLossDownsampling(
         0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
     )
@@ -39,7 +39,7 @@ def test_sample_weights(dummy_system_config: ModynConfig):
     downsampling_ratio = 50
     per_sample_loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
 
-    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
+    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False, "ratio_max": 100}
     sampler = RemoteLossDownsampling(
         0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
     )
@@ -67,7 +67,7 @@ def test_sample_loss_dependent_sampling(dummy_system_config: ModynConfig):
     downsampling_ratio = 50
     per_sample_loss_fct = torch.nn.MSELoss(reduction="none")
 
-    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False}
+    params_from_selector = {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False, "ratio_max": 100}
     sampler = RemoteLossDownsampling(
         0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
     )
@@ -116,7 +116,7 @@ def test_sample_dict_input(dummy_system_config: ModynConfig):
     mymodel = DictLikeModel()
     per_sample_loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
 
-    params_from_selector = {"downsampling_ratio": 50, "sample_then_batch": False}
+    params_from_selector = {"downsampling_ratio": 50, "sample_then_batch": False, "ratio_max": 100}
     sampler = RemoteLossDownsampling(
         0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
     )

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_rho_loss_downsampling.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_rho_loss_downsampling.py
@@ -29,6 +29,7 @@ def dummy_init_params(dummy_system_config: ModynConfig):
         "il_model_id": 2,
         "downsampling_ratio": 50,
         "sample_then_batch": False,
+        "ratio_max": 100,
     }
     modyn_config = dummy_system_config.model_dump(by_alias=True)
     per_sample_loss_fct = torch.nn.CrossEntropyLoss(reduction="none")

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_rs2_downsampling.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_rs2_downsampling.py
@@ -10,7 +10,7 @@ def test_init(dummy_system_config: ModynConfig):
     pipeline_id = 0
     trigger_id = 0
     batch_size = 32
-    params_from_selector = {"replacement": True, "downsampling_ratio": 50}
+    params_from_selector = {"replacement": True, "downsampling_ratio": 50, "ratio_max": 100}
     per_sample_loss = None
     device = "cpu"
 
@@ -41,7 +41,7 @@ def test_inform_samples(dummy_system_config: ModynConfig):
     pipeline_id = 0
     trigger_id = 0
     batch_size = 32
-    params_from_selector = {"replacement": True, "downsampling_ratio": 50}
+    params_from_selector = {"replacement": True, "downsampling_ratio": 50, "ratio_max": 100}
     per_sample_loss = None
     device = "cpu"
 
@@ -76,7 +76,7 @@ def test_multiple_epochs_with_replacement(dummy_system_config: ModynConfig):
     pipeline_id = 0
     trigger_id = 0
     batch_size = 32
-    params_from_selector = {"replacement": True, "downsampling_ratio": 50}
+    params_from_selector = {"replacement": True, "downsampling_ratio": 50, "ratio_max": 100}
     per_sample_loss = None
     device = "cpu"
 
@@ -110,7 +110,7 @@ def test_multiple_epochs_without_replacement(dummy_system_config: ModynConfig):
     pipeline_id = 0
     trigger_id = 0
     batch_size = 32
-    params_from_selector = {"replacement": False, "downsampling_ratio": 50}
+    params_from_selector = {"replacement": False, "downsampling_ratio": 50, "ratio_max": 100}
     per_sample_loss = None
     device = "cpu"
 
@@ -171,7 +171,7 @@ def test_multiple_epochs_without_replacement_leftover_data(dummy_system_config: 
     pipeline_id = 0
     trigger_id = 0
     batch_size = 32
-    params_from_selector = {"replacement": False, "downsampling_ratio": 40}
+    params_from_selector = {"replacement": False, "downsampling_ratio": 40, "ratio_max": 100}
     per_sample_loss = None
     device = "cpu"
 
@@ -207,7 +207,7 @@ def test_multiple_epochs_empty_without_replacement_leftover_data(dummy_system_co
     pipeline_id = 0
     trigger_id = 0
     batch_size = 32
-    params_from_selector = {"replacement": False, "downsampling_ratio": 40}
+    params_from_selector = {"replacement": False, "downsampling_ratio": 40, "ratio_max": 100}
     per_sample_loss = None
     device = "cpu"
 

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_submodular_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_submodular_downsampling_strategy.py
@@ -19,6 +19,7 @@ def get_sampler_config(modyn_config: ModynConfig, submodular: str = "GraphCut", 
         "submodular_function": submodular,
         "balance": balance,
         "selection_batch": 64,
+        "ratio_max": 100,
     }
     return 0, 0, 0, params_from_selector, modyn_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
 
@@ -124,6 +125,7 @@ def _get_selected_samples(
             "submodular_function": submodular,
             "balance": False,
             "selection_batch": 64,
+            "ratio_max": 100,
         },
         modyn_config.model_dump(by_alias=True),
         BCEWithLogitsLoss(reduction="none"),

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_uncertainty_downsampling_strategy.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_uncertainty_downsampling_strategy.py
@@ -18,6 +18,7 @@ def sampler_config(dummy_system_config: ModynConfig, request):
         "args": {},
         "balance": False,
         "score_metric": request.param,
+        "ratio_max": 100,
     }
     return 0, 0, 0, params_from_selector, dummy_system_config.model_dump(by_alias=True), per_sample_loss_fct, "cpu"
 

--- a/modyn/tests/trainer_server/internal/trainer/test_pytorch_trainer.py
+++ b/modyn/tests/trainer_server/internal/trainer/test_pytorch_trainer.py
@@ -291,6 +291,7 @@ def get_mock_trainer(
     batch_size: int = 32,
     downsampling_mode: DownsamplingMode = DownsamplingMode.DISABLED,
     downsampling_ratio: int = 25,
+    ratio_max: int = 100,
 ):
     model_dynamic_module_patch.return_value = MockModule(num_optimizers)
     lr_scheduler_dynamic_module_patch.return_value = MockLRSchedulerModule()
@@ -300,7 +301,7 @@ def get_mock_trainer(
         mock_selection_strategy.return_value = (
             True,
             "RemoteGradNormDownsampling",
-            {"downsampling_ratio": downsampling_ratio, "sample_then_batch": False},
+            {"downsampling_ratio": downsampling_ratio, "ratio_max": ratio_max, "sample_then_batch": False},
         )
     elif downsampling_mode == DownsamplingMode.SAMPLE_THEN_BATCH:
         raise NotImplementedError()
@@ -868,6 +869,7 @@ def test_create_trainer_with_exception(
         assert pathlib.Path(temp.name).exists()
 
 
+@pytest.mark.parametrize("downsampling_ratio, ratio_max", [(25, 100), (50, 100), (250, 1000), (125, 1000)])
 @patch("modyn.trainer_server.internal.trainer.pytorch_trainer.prepare_dataloaders", mock_get_dataloaders)
 @patch.object(BaseCallback, "on_train_begin", return_value=None)
 @patch.object(BaseCallback, "on_train_end", return_value=None)
@@ -893,10 +895,11 @@ def test_train_batch_then_sample_accumulation(
     test_on_train_end,
     test_on_train_begin,
     dummy_system_config: ModynConfig,
+    downsampling_ratio,
+    ratio_max,
 ):
     num_batches = 100  # hardcoded into mock dataloader
     batch_size = 32
-    downsampling_ratio = 25
 
     query_status_queue = mp.Queue()
     status_queue = mp.Queue()
@@ -913,11 +916,12 @@ def test_train_batch_then_sample_accumulation(
         batch_size=batch_size,
         downsampling_mode=DownsamplingMode.BATCH_THEN_SAMPLE,
         downsampling_ratio=downsampling_ratio,
+        ratio_max=ratio_max,
     )
     assert trainer._downsampling_mode == DownsamplingMode.BATCH_THEN_SAMPLE
 
     # Mock the downsample_batch method to return batches of the expected size
-    expected_bts_size = int(batch_size * (downsampling_ratio / 100.0))
+    expected_bts_size = int(batch_size * (downsampling_ratio / ratio_max))
     bts_accumulate_period = batch_size // expected_bts_size
 
     def mock_downsample_batch(data, sample_ids, target):
@@ -945,7 +949,8 @@ def test_train_batch_then_sample_accumulation(
 
     assert trainer._num_samples == batch_size * num_batches
     assert trainer._log["num_samples"] == batch_size * num_batches
-    assert trainer._log["num_samples_trained"] == expected_bts_size * num_batches
+    # We only train on whole batches, hence we have to scale by batch size
+    assert trainer._log["num_samples_trained"] == ((expected_bts_size * num_batches) // batch_size) * batch_size
     assert test_on_batch_begin.call_count == len(trainer._callbacks) * num_batches
     assert test_on_batch_end.call_count == len(trainer._callbacks) * num_batches
     assert test_downsample_batch.call_count == num_batches

--- a/modyn/tests/utils/test_utils.py
+++ b/modyn/tests/utils/test_utils.py
@@ -189,7 +189,7 @@ def test_instantiate_class_existing(dummy_system_config: ModynConfig):
         10,
         11,
         64,
-        {"downsampling_ratio": 67},
+        {"downsampling_ratio": 67, "ratio_max": 100},
         dummy_system_config.model_dump(by_alias=True),
         {},
         "cpu",

--- a/modyn/trainer_server/internal/trainer/pytorch_trainer.py
+++ b/modyn/trainer_server/internal/trainer/pytorch_trainer.py
@@ -223,7 +223,9 @@ class PytorchTrainer:
             # assertion since model validation by pydantic should catch this.
             assert self._downsampler.supports_bts, "The downsampler does not support batch then sample"
             # We cannot pass the target size from the trainer server since that depends on StB vs BtS.
-            post_downsampling_size = max((self._downsampler.downsampling_ratio * self._batch_size) // 100, 1)
+            post_downsampling_size = max(
+                (self._downsampler.downsampling_ratio * self._batch_size) // self._downsampling_ratio_max, 1
+            )
             assert post_downsampling_size < self._batch_size
             if self._batch_size % post_downsampling_size != 0:
                 raise ValueError(
@@ -727,6 +729,7 @@ class PytorchTrainer:
         self._downsampler = self._instantiate_downsampler(
             strategy_name, downsampler_config, modyn_config, self._criterion_nored
         )
+        self._downsampling_ratio_max = downsampler_config["ratio_max"]
         assert "sample_then_batch" in downsampler_config
         self._log["received_downsampler_config"] = downsampler_config
         if downsampler_config["sample_then_batch"]:
@@ -833,7 +836,9 @@ class PytorchTrainer:
         )  # scale up again to multiples of batch size
 
         if downsampling_enabled:
-            num_samples_per_epoch = max((self._downsampler.downsampling_ratio * num_samples_per_epoch) // 100, 1)
+            num_samples_per_epoch = max(
+                (self._downsampler.downsampling_ratio * num_samples_per_epoch) // self._downsampling_ratio_max, 1
+            )
 
         self._expected_num_batches = (num_samples_per_epoch // self._batch_size) * self.epochs_per_trigger
         self._expected_num_epochs = self.epochs_per_trigger

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_matrix_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_matrix_downsampling_strategy.py
@@ -110,7 +110,7 @@ class AbstractMatrixDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingStrat
     def _select_from_matrix(self) -> tuple[list[int], torch.Tensor]:
         matrix = np.concatenate(self.matrix_elements)
         number_of_samples = len(matrix)
-        target_size = max(int(self.downsampling_ratio * number_of_samples / 100), 1)
+        target_size = max(int(self.downsampling_ratio * number_of_samples / self.ratio_max), 1)
         selected_indices, weights = self._select_indexes_from_matrix(matrix, target_size)
         selected_ids = [self.index_sampleid_map[index] for index in selected_indices]
         return selected_ids, weights

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_remote_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_remote_downsampling_strategy.py
@@ -49,6 +49,7 @@ class AbstractRemoteDownsamplingStrategy(ABC):
 
         assert "downsampling_ratio" in params_from_selector
         self.downsampling_ratio = params_from_selector["downsampling_ratio"]
+        self.ratio_max = params_from_selector["ratio_max"]
 
         # The next variable is used to keep a mapping index <-> sample_id
         # This is needed since the data selection policy works on indexes (the policy does not care what the sample_id

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_craig_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_craig_downsampling.py
@@ -178,7 +178,7 @@ class RemoteCraigDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingStrategy
 
     def _select_points_from_distance_matrix(self) -> tuple[list[int], torch.Tensor]:
         number_of_samples = self.distance_matrix.shape[0]
-        target_size = max(int(self.downsampling_ratio * number_of_samples / 100), 1)
+        target_size = max(int(self.downsampling_ratio * number_of_samples / self.ratio_max), 1)
 
         all_index = np.arange(number_of_samples)
         submod_function = FacilityLocation(index=all_index, similarity_matrix=self.distance_matrix)

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_gradnorm_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_gradnorm_downsampling.py
@@ -79,7 +79,7 @@ class RemoteGradNormDownsampling(AbstractRemoteDownsamplingStrategy):
             return [], torch.Tensor([])
 
         # select always at least 1 point
-        target_size = max(int(self.downsampling_ratio * self.number_of_points_seen / 100), 1)
+        target_size = max(int(self.downsampling_ratio * self.number_of_points_seen / self.ratio_max), 1)
 
         probabilities = torch.cat(self.probabilities, dim=0)
         probabilities = probabilities / probabilities.sum()

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_loss_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_loss_downsampling.py
@@ -61,7 +61,7 @@ class RemoteLossDownsampling(AbstractRemoteDownsamplingStrategy):
             return [], torch.Tensor([])
 
         # select always at least 1 point
-        target_size = max(int(self.downsampling_ratio * self.number_of_points_seen / 100), 1)
+        target_size = max(int(self.downsampling_ratio * self.number_of_points_seen / self.ratio_max), 1)
 
         probabilities = torch.cat(self.probabilities, dim=0)
         probabilities = probabilities / probabilities.sum()

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rho_loss_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rho_loss_downsampling.py
@@ -58,7 +58,7 @@ class RemoteRHOLossDownsampling(AbstractRemoteDownsamplingStrategy):
         self.number_of_points_seen += forward_output.shape[0]
 
     def select_points(self) -> tuple[list[int], torch.Tensor]:
-        target_size = max(int(self.downsampling_ratio * self.number_of_points_seen / 100), 1)
+        target_size = max(int(self.downsampling_ratio * self.number_of_points_seen / self.ratio_max), 1)
         # find the indices of maximal "target_size" elements in the list of rho_loss
         selected_indices = torch.topk(self.rho_loss, target_size).indices
         # use sorted() because we keep the relative order of the selected samples

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rs2_downsampling.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_rs2_downsampling.py
@@ -71,7 +71,7 @@ class RemoteRS2Downsampling(AbstractRemoteDownsamplingStrategy):
             self._subsets = [self._all_sample_ids[i * target_size : (i + 1) * target_size] for i in range(max_subset)]
 
     def _epoch_step(self) -> None:
-        target_size = max(int(self.downsampling_ratio * len(self._all_sample_ids) / 100), 1)
+        target_size = max(int(self.downsampling_ratio * len(self._all_sample_ids) / self.ratio_max), 1)
 
         if self._with_replacement:
             self._epoch_step_wr(target_size)

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_uncertainty_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/remote_uncertainty_downsampling_strategy.py
@@ -119,7 +119,7 @@ class RemoteUncertaintyDownsamplingStrategy(AbstractPerLabelRemoteDownsamplingSt
 
     def _select_from_scores(self) -> tuple[list[int], torch.Tensor]:
         number_of_samples = len(self.scores)
-        target_size = max(int(self.downsampling_ratio * number_of_samples / 100), 1)
+        target_size = max(int(self.downsampling_ratio * number_of_samples / self.ratio_max), 1)
         selected_indices, weights = self._select_indexes_from_scores(target_size)
         selected_ids = [self.index_sampleid_map[index] for index in selected_indices]
         return selected_ids, weights


### PR DESCRIPTION
Before, we only were able to enter ratios from 0-100 as percentages for downsamplers. With this PR, we allow scaling by a ratio_max factor.