### PR TITLE
Add `ratio_max` for presampling strategies

### DIFF
--- a/modyn/config/schema/pipeline/sampling/config.py
+++ b/modyn/config/schema/pipeline/sampling/config.py
@@ -19,12 +19,29 @@ class PresamplingConfig(ModynBaseModel):
         "Only the prefix, i.e. without `PresamplingStrategy`, is needed."
     )
     ratio: int = Field(
-        description="Percentage of points on which the metric (loss, gradient norm,..) is computed.",
+        description=(
+            "Ratio of points on which the metric (loss, gradient norm,..) is computed."
+            "By default with ratio_max=100, this describes the selection ratio in percent."
+        ),
         min=0,
-        max=100,
+    )
+
+    ratio_max: int = Field(
+        description=(
+            "Reference maximum ratio value. Defaults to 100, which implies percent."
+            " If you set this to 1000, ratio describes promille instead."
+        ),
+        default=100,
+        min=1,
     )
     force_column_balancing: bool = Field(False)
     force_required_target_size: bool = Field(False)
+
+    @model_validator(mode="after")
+    def validate_ratio(self) -> Self:
+        if self.ratio > self.ratio_max:
+            raise ValueError("ratio cannot be greater than ratio_max.")
+        return self
 
 
 StorageBackend = Literal["database", "local"]

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/abstract_presampling_strategy.py
@@ -18,6 +18,7 @@ class AbstractPresamplingStrategy(ABC):
         self.pipeline_id = pipeline_id
         self._storage_backend = storage_backend
         self.presampling_ratio = presampling_config.ratio
+        self.ratio_max = presampling_config.ratio_max
         self.requires_trigger_dataset_size = False
 
     @abstractmethod
@@ -36,7 +37,7 @@ class AbstractPresamplingStrategy(ABC):
 
     def get_target_size(self, trigger_dataset_size: int, limit: Optional[int]) -> int:
         assert trigger_dataset_size >= 0
-        target_presampling = int(trigger_dataset_size * self.presampling_ratio / 100)
+        target_presampling = (trigger_dataset_size * self.presampling_ratio) // self.ratio_max
 
         if limit is not None:
             assert limit >= 0

--- a/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_random_presampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_random_presampling_strategy.py
@@ -164,3 +164,22 @@ def test_dataset_size_various_scenarios():
     strat.tail_triggers = 1
     trigger_size = strat._get_trigger_dataset_size()
     assert presampling_strat.get_target_size(trigger_size, None) == 22  # 75% of presampling
+
+
+def test_target_size_ratio_max():
+    config = get_config()
+    config.ratio_max = 1000
+    config.ratio = 125
+    strat = RandomPresamplingStrategy(
+        config,
+        get_minimal_modyn_config(),
+        10,
+        DatabaseStorageBackend(0, get_minimal_modyn_config(), 123),
+    )
+    assert strat.get_target_size(128, None) == 16
+    assert strat.get_target_size(100, None) == 12
+    assert strat.get_target_size(12, None) == 1
+    assert strat.get_target_size(0, None) == 0
+
+    with pytest.raises(AssertionError):
+        strat.get_target_size(-1, None)


### PR DESCRIPTION
I realized we also need to set `ratio_max` for presampling strategies, otherwise they cannot run 12.5% as well.