### PR TITLE
feat: Create `DriftDetector` abstraction and introduce alibi-detect

### DIFF
--- a/analytics/app/pages/plots/eval_heatmap.py
+++ b/analytics/app/pages/plots/eval_heatmap.py
@@ -86,7 +86,7 @@ def gen_figure(
         label_map = {v: full_refs[k] for k, v in mapping[()].items()}
 
     else:
-        assert df_adjusted["pipeline_ref"].nunique() == 1
+        assert df_adjusted["pipeline_ref"].nunique() <= 1
         # add the pipeline time series which is the performance of different models stitched together dep.
         # w.r.t which model was active
         pipeline_composite_model = df_adjusted[df_adjusted[composite_model_variant]]

--- a/analytics/app/pages/plots/num_triggers_eval_metric.py
+++ b/analytics/app/pages/plots/num_triggers_eval_metric.py
@@ -93,11 +93,7 @@ def gen_fig_scatter_num_triggers(
             aggregate_func="time_weighted_avg" if time_weighted else "mean",
         )
         merged = num_triggers.merge(mean_accuracies, on="pipeline_ref").rename(columns=col_map, inplace=False)
-        assert (
-            mean_accuracies.shape[0]
-            == merged.shape[0]
-            == num_triggers.shape[0] * len(mean_accuracies["metric"].unique())
-        )
+        assert mean_accuracies.shape[0] == merged.shape[0]
         fig = px.scatter(
             merged,
             x="num_triggers",

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/arxiv_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/arxiv_datadrift.yaml
@@ -39,11 +39,16 @@ data:
     def bytes_parser_function(data: bytes) -> str:
       return str(data, "utf8")
   tokenizer: DistilBertTokenizerTransform
-
 trigger:
   id: DataDriftTrigger
   detection_interval_data_points: 100000
   sample_size: 5000
+  metrics:
+    ev_mmd:
+      id: EvidentlyModelDriftMetric
+      threshold: 0.7
+  aggregation_strategy:
+    id: MajorityVote
 selection_strategy:
   name: NewDataStrategy
   maximum_keys_in_memory: 10000

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
@@ -43,9 +43,12 @@ data:
 trigger:
   id: DataDriftTrigger
   detection_interval_data_points: 5000
-  metric: mmd
-  metric_config:
-    bootstrap: False
+  metrics:
+    ev_mmd:
+      id: EvidentlyMmdDriftMetric
+      bootstrap: false
+  aggregation_strategy:
+    id: MajorityVote
 selection_strategy:
   name: NewDataStrategy
   maximum_keys_in_memory: 1000

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/huffpost_datadrift.yaml
@@ -45,8 +45,7 @@ trigger:
   detection_interval_data_points: 5000
   metrics:
     ev_mmd:
-      id: EvidentlyMmdDriftMetric
-      bootstrap: false
+      id: AlibiDetectMmdDriftMetric
   aggregation_strategy:
     id: MajorityVote
 selection_strategy:

--- a/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/yearbook_datadrift.yaml
+++ b/benchmark/wildtime_benchmarks/example_pipelines/data_drift_trigger/yearbook_datadrift.yaml
@@ -45,9 +45,12 @@ data:
 trigger:
   id: DataDriftTrigger
   detection_interval_data_points: 1000
-  metric: model
-  metric_config:
-    threshold: 0.7
+  metrics:
+    ev_mmd:
+      id: EvidentlyModelDriftMetric
+      threshold: 0.7
+  aggregation_strategy:
+    id: MajorityVote
 selection_strategy:
   name: NewDataStrategy
   maximum_keys_in_memory: 1000

--- a/docs/pipeline/TRIGGERING.md
+++ b/docs/pipeline/TRIGGERING.md
@@ -3,7 +3,7 @@
 Alongside the simple triggers, Modyn also provides complex triggers that can be used to trigger the training of a model. 
 
 Despite the line being blurry, complex triggers are generally more sophisticated and require more information to be provided to the trigger - they most of the time cannot be pre-determined via a simple configuration entry but require
-reinjested information from the ongoing pipeline run.
+reingested information from the ongoing pipeline run.
 
 Some complex triggers can only make decisions in batched intervals as they are cannot be efficiently computed
 on a per-sample basis. Here we can find the `DataDrift` and `CostBased` (not yet implemented) based triggers.

--- a/experiments/arxiv/compare_trigger_policies/run.py
+++ b/experiments/arxiv/compare_trigger_policies/run.py
@@ -12,6 +12,8 @@ from modyn.config.schema.pipeline import (
 from modyn.config.schema.pipeline.evaluation.strategy.between_two_triggers import BetweenTwoTriggersEvalStrategyConfig
 from modyn.config.schema.pipeline.evaluation.strategy.periodic import PeriodicEvalStrategyConfig
 from modyn.config.schema.pipeline.trigger import DataDriftTriggerConfig
+from modyn.config.schema.pipeline.trigger.drift.aggregation import MajorityVoteDriftAggregationStrategy
+from modyn.config.schema.pipeline.trigger.drift.evidently import EvidentlyMmdDriftMetric
 from modynclient.config.schema.client_config import ModynClientConfig, Supervisor
 
 
@@ -65,14 +67,15 @@ def construct_pipelines() -> list[ModynPipelineConfig]:
         )
 
     for interval, threshold in [
-        (20_000, 0.5),
-        (100_000, 0.6),
-        (100_000, 0.7),
-        (100_000, 0.8),
-        (100_000, 0.9),
-        (250_000, 0.7),
-        (500_000, 0.7),
-        (1_000_000, 0.7),
+        (20_000, 0.15),
+        # (20_000, 0.5),
+        # (100_000, 0.6),
+        # (100_000, 0.7),
+        # (100_000, 0.8),
+        # (100_000, 0.9),
+        # (250_000, 0.7),
+        # (500_000, 0.7),
+        # (1_000_000, 0.7),
     ]:
         pipeline_configs.append(
             gen_pipeline_config(
@@ -80,8 +83,13 @@ def construct_pipelines() -> list[ModynPipelineConfig]:
                 trigger=DataDriftTriggerConfig(
                     detection_interval_data_points=interval,
                     sample_size=5000,
-                    metric="model",
-                    metric_config={"threshold": threshold},
+                    metrics={
+                        "ev_mmd": EvidentlyMmdDriftMetric(threshold=threshold),
+                        # "ev_model": EvidentlyMmdDriftMetric(threshold=threshold),
+                        # "ev_ratio": EvidentlyMmdDriftMetric(threshold=threshold),
+                        # "ev_distance": EvidentlyMmdDriftMetric(threshold=threshold),
+                    },
+                    aggregation_strategy=MajorityVoteDriftAggregationStrategy(),
                 ),
                 eval_handlers=eval_handlers,
             )

--- a/experiments/arxiv/compare_trigger_policies/run.py
+++ b/experiments/arxiv/compare_trigger_policies/run.py
@@ -13,7 +13,7 @@ from modyn.config.schema.pipeline.evaluation.strategy.between_two_triggers impor
 from modyn.config.schema.pipeline.evaluation.strategy.periodic import PeriodicEvalStrategyConfig
 from modyn.config.schema.pipeline.trigger import DataDriftTriggerConfig
 from modyn.config.schema.pipeline.trigger.drift.aggregation import MajorityVoteDriftAggregationStrategy
-from modyn.config.schema.pipeline.trigger.drift.evidently import EvidentlyMmdDriftMetric
+from modyn.config.schema.pipeline.trigger.drift.alibi_detect import AlibiDetectMmdDriftMetric
 from modynclient.config.schema.client_config import ModynClientConfig, Supervisor
 
 
@@ -66,8 +66,8 @@ def construct_pipelines() -> list[ModynPipelineConfig]:
             )
         )
 
-    for interval, threshold in [
-        (20_000, 0.15),
+    for interval in [
+        20_000,
         # (20_000, 0.5),
         # (100_000, 0.6),
         # (100_000, 0.7),
@@ -79,15 +79,15 @@ def construct_pipelines() -> list[ModynPipelineConfig]:
     ]:
         pipeline_configs.append(
             gen_pipeline_config(
-                name=f"datadrifttrigger_{interval}_{threshold}",
+                name=f"datadrifttrigger_{interval}",
                 trigger=DataDriftTriggerConfig(
                     detection_interval_data_points=interval,
                     sample_size=5000,
                     metrics={
-                        "ev_mmd": EvidentlyMmdDriftMetric(threshold=threshold),
-                        # "ev_model": EvidentlyMmdDriftMetric(threshold=threshold),
-                        # "ev_ratio": EvidentlyMmdDriftMetric(threshold=threshold),
-                        # "ev_distance": EvidentlyMmdDriftMetric(threshold=threshold),
+                        "ev_mmd": AlibiDetectMmdDriftMetric(),
+                        # "ev_model": AlibiDetectMmdDriftMetric(),
+                        # "ev_ratio": AlibiDetectMmdDriftMetric(),
+                        # "ev_distance": AlibiDetectMmdDriftMetric(),
                     },
                     aggregation_strategy=MajorityVoteDriftAggregationStrategy(),
                 ),

--- a/experiments/yearbook/compare_trigger_policies/run.py
+++ b/experiments/yearbook/compare_trigger_policies/run.py
@@ -7,11 +7,13 @@ from modyn.config.schema.pipeline.evaluation.handler import EvalHandlerConfig
 from modyn.config.schema.pipeline.evaluation.strategy.between_two_triggers import BetweenTwoTriggersEvalStrategyConfig
 from modyn.config.schema.pipeline.evaluation.strategy.periodic import PeriodicEvalStrategyConfig
 from modyn.config.schema.pipeline.trigger import DataDriftTriggerConfig
+from modyn.config.schema.pipeline.trigger.drift.aggregation import MajorityVoteDriftAggregationStrategy
+from modyn.config.schema.pipeline.trigger.drift.evidently import EvidentlyMmdDriftMetric
 from modyn.utils.utils import SECONDS_PER_UNIT
 from modynclient.config.schema.client_config import ModynClientConfig, Supervisor
 
 
-def construct_pipelines() -> None:
+def construct_pipelines() -> list[ModynPipelineConfig]:
     pipeline_configs: list[ModynPipelineConfig] = []
     first_timestamp = 0
     last_timestamp = SECONDS_PER_UNIT["d"] * (2015 - 1930)
@@ -76,8 +78,13 @@ def construct_pipelines() -> None:
                 trigger=DataDriftTriggerConfig(
                     detection_interval_data_points=interval,
                     sample_size=None,
-                    metric="model",
-                    metric_config={"threshold": threshold},
+                    metrics={
+                        "ev_mmd": EvidentlyMmdDriftMetric(threshold=threshold),
+                        # "ev_model": EvidentlyMmdDriftMetric(threshold=threshold),
+                        # "ev_ratio": EvidentlyMmdDriftMetric(threshold=threshold),
+                        # "ev_distance": EvidentlyMmdDriftMetric(threshold=threshold),
+                    },
+                    aggregation_strategy=MajorityVoteDriftAggregationStrategy(),
                 ),
                 eval_handlers=eval_handlers,
             )

--- a/experiments/yearbook/compare_trigger_policies/run.py
+++ b/experiments/yearbook/compare_trigger_policies/run.py
@@ -8,7 +8,7 @@ from modyn.config.schema.pipeline.evaluation.strategy.between_two_triggers impor
 from modyn.config.schema.pipeline.evaluation.strategy.periodic import PeriodicEvalStrategyConfig
 from modyn.config.schema.pipeline.trigger import DataDriftTriggerConfig
 from modyn.config.schema.pipeline.trigger.drift.aggregation import MajorityVoteDriftAggregationStrategy
-from modyn.config.schema.pipeline.trigger.drift.evidently import EvidentlyMmdDriftMetric
+from modyn.config.schema.pipeline.trigger.drift.alibi_detect import AlibiDetectMmdDriftMetric
 from modyn.utils.utils import SECONDS_PER_UNIT
 from modynclient.config.schema.client_config import ModynClientConfig, Supervisor
 
@@ -79,10 +79,10 @@ def construct_pipelines() -> list[ModynPipelineConfig]:
                     detection_interval_data_points=interval,
                     sample_size=None,
                     metrics={
-                        "ev_mmd": EvidentlyMmdDriftMetric(threshold=threshold),
-                        # "ev_model": EvidentlyMmdDriftMetric(threshold=threshold),
-                        # "ev_ratio": EvidentlyMmdDriftMetric(threshold=threshold),
-                        # "ev_distance": EvidentlyMmdDriftMetric(threshold=threshold),
+                        "ev_mmd": AlibiDetectMmdDriftMetric(threshold=threshold),
+                        # "ev_model": AlibiDetectMmdDriftMetric(threshold=threshold),
+                        # "ev_ratio": AlibiDetectMmdDriftMetric(threshold=threshold),
+                        # "ev_distance": AlibiDetectMmdDriftMetric(threshold=threshold),
                     },
                     aggregation_strategy=MajorityVoteDriftAggregationStrategy(),
                 ),

--- a/modyn/config/__init__.py
+++ b/modyn/config/__init__.py
@@ -12,7 +12,7 @@ def read_modyn_config(path: Path) -> ModynConfig:
     Args:
         path: Path to the configuration file.
 
-    Returns:
+    Returns: e
         The validated Modyn config as a pydantic model.
     """
     with open(path, "r", encoding="utf-8") as config_file:

--- a/modyn/config/schema/pipeline/trigger/drift/__init__.py
+++ b/modyn/config/schema/pipeline/trigger/drift/__init__.py
@@ -1,0 +1,5 @@
+from .aggregation import *  # noqa
+from .alibi_detect import *  # noqa
+from .config import *  # noqa
+from .evidently import *  # noqa
+from .result import *  # noqa

--- a/modyn/config/schema/pipeline/trigger/drift/aggregation.py
+++ b/modyn/config/schema/pipeline/trigger/drift/aggregation.py
@@ -1,0 +1,35 @@
+"""Support the aggregation of the decisions of multiple drift metrics."""
+
+from typing import Annotated, Callable, Literal, Union
+
+from modyn.config.schema.base_model import ModynBaseModel
+from pydantic import Field
+
+from .result import MetricResult
+
+
+class MajorityVoteDriftAggregationStrategy(ModynBaseModel):
+    id: Literal["MajorityVote"] = Field("MajorityVote")
+
+    @property
+    def aggregate_decision_func(self) -> Callable[[dict[str, MetricResult]], bool]:
+        return lambda decisions: sum((decision.is_drift for decision in decisions.values())) > len(decisions) / 2
+
+
+class AtLeastNDriftAggregationStrategy(ModynBaseModel):
+    id: Literal["AtLeastN"] = Field("AtLeastN")
+
+    n: int = Field(description="The minimum number of triggers that need to trigger for the ensemble to trigger.", ge=1)
+
+    @property
+    def aggregate_decision_func(self) -> Callable[[dict[str, MetricResult]], bool]:
+        return lambda decisions: sum(decision.is_drift for decision in decisions.values()) >= self.n
+
+
+DriftAggregationStrategy = Annotated[
+    Union[
+        MajorityVoteDriftAggregationStrategy,
+        AtLeastNDriftAggregationStrategy,
+    ],
+    Field(discriminator="id"),
+]

--- a/modyn/config/schema/pipeline/trigger/drift/alibi_detect.py
+++ b/modyn/config/schema/pipeline/trigger/drift/alibi_detect.py
@@ -1,0 +1,34 @@
+from typing import Annotated, Literal, Union
+
+from modyn.config.schema.base_model import ModynBaseModel
+from pydantic import Field
+
+
+class _AlibiDetectBaseDriftMetric(ModynBaseModel):
+    p_val: float = Field(0.05, description="The p-value threshold for the drift detection.")
+    kernel: str  # TODO;
+    # x_ref_preprocessed
+    # configure_kernel_from_x_ref
+    device: str | None = Field(
+        None,
+        description="The device used for the drift detection.",
+        pattern="^(cpu|gpu|cuda:?[0-9]*)$",
+    )
+
+
+class AlibiDetectMmdDriftMetric(_AlibiDetectBaseDriftMetric):
+    id: Literal["AlibiDetectMmdDriftMetric"] = Field("AlibiDetectMmdDriftMetric")
+    n_permutations: bool = Field(
+        100,
+        description=("The number of permutations used in the MMD calculation. " "100 is the alibi-detect default."),
+    )
+
+
+class AlibiDetectTODODriftMetric(_AlibiDetectBaseDriftMetric):
+    id: Literal["AlibiDetectTODODriftMetric"] = Field("AlibiDetectTODODriftMetric")
+
+
+AlibiDetectDriftMetric = Annotated[
+    Union[AlibiDetectMmdDriftMetric, AlibiDetectTODODriftMetric],
+    Field(discriminator="id"),
+]

--- a/modyn/config/schema/pipeline/trigger/drift/alibi_detect.py
+++ b/modyn/config/schema/pipeline/trigger/drift/alibi_detect.py
@@ -6,9 +6,15 @@ from pydantic import Field
 
 class _AlibiDetectBaseDriftMetric(ModynBaseModel):
     p_val: float = Field(0.05, description="The p-value threshold for the drift detection.")
-    kernel: str  # TODO;
+
+    # to be added in the future:
+
     # x_ref_preprocessed
+    # preprocess_at_init
     # configure_kernel_from_x_ref
+
+
+class AlibiDetectDeviceMixin(ModynBaseModel):
     device: str | None = Field(
         None,
         description="The device used for the drift detection.",
@@ -16,19 +22,36 @@ class _AlibiDetectBaseDriftMetric(ModynBaseModel):
     )
 
 
-class AlibiDetectMmdDriftMetric(_AlibiDetectBaseDriftMetric):
+class _AlibiDetectCorrectionMixin(ModynBaseModel):
+    correction: Literal["bonferroni", "fdr"] = Field("bonferroni")
+
+
+class _AlibiDetectAlternativeMixin(ModynBaseModel):
+    alternative_hypothesis: Literal["two-sided", "less", "greater"] = Field("two-sided")
+
+
+class AlibiDetectMmdDriftMetric(_AlibiDetectBaseDriftMetric, AlibiDetectDeviceMixin):
     id: Literal["AlibiDetectMmdDriftMetric"] = Field("AlibiDetectMmdDriftMetric")
-    n_permutations: bool = Field(
+    num_permutations: int = Field(
         100,
-        description=("The number of permutations used in the MMD calculation. " "100 is the alibi-detect default."),
+        description=(
+            "The number of permutations used in the MMD hypothesis permutation test. 100 is the alibi-detect default."
+        ),
+    )
+    kernel: str = Field(
+        "GaussianRBF", description="The kernel used for distance calculation imported from alibi_detect.utils.pytorch"
     )
 
 
-class AlibiDetectTODODriftMetric(_AlibiDetectBaseDriftMetric):
-    id: Literal["AlibiDetectTODODriftMetric"] = Field("AlibiDetectTODODriftMetric")
+class AlibiDetectKSDriftMetric(_AlibiDetectBaseDriftMetric, _AlibiDetectAlternativeMixin, _AlibiDetectCorrectionMixin):
+    id: Literal["AlibiDetectKSDriftMetric"] = Field("AlibiDetectKSDriftMetric")
+
+
+class AlibiDetectCVMDriftMetric(_AlibiDetectBaseDriftMetric, _AlibiDetectCorrectionMixin):
+    id: Literal["AlibiDetectCVMDriftMetric"] = Field("AlibiDetectCVMDriftMetric")
 
 
 AlibiDetectDriftMetric = Annotated[
-    Union[AlibiDetectMmdDriftMetric, AlibiDetectTODODriftMetric],
+    Union[AlibiDetectMmdDriftMetric, AlibiDetectKSDriftMetric, AlibiDetectCVMDriftMetric],
     Field(discriminator="id"),
 ]

--- a/modyn/config/schema/pipeline/trigger/drift/evidently.py
+++ b/modyn/config/schema/pipeline/trigger/drift/evidently.py
@@ -8,13 +8,6 @@ class _EvidentlyBaseDriftMetric(ModynBaseModel):
     num_pca_component: int | None = Field(None)
 
 
-class EvidentlyMmdDriftMetric(_EvidentlyBaseDriftMetric):
-    id: Literal["EvidentlyMmdDriftMetric"] = Field("EvidentlyMmdDriftMetric")
-    bootstrap: bool = Field(False)
-    quantile_probability: float = 0.05
-    threshold: float = Field(0.15)
-
-
 class EvidentlyModelDriftMetric(_EvidentlyBaseDriftMetric):
     id: Literal["EvidentlyModelDriftMetric"] = Field("EvidentlyModelDriftMetric")
     bootstrap: bool = Field(False)
@@ -39,7 +32,6 @@ class EvidentlySimpleDistanceDriftMetric(_EvidentlyBaseDriftMetric):
 
 EvidentlyDriftMetric = Annotated[
     Union[
-        EvidentlyMmdDriftMetric,
         EvidentlyModelDriftMetric,
         EvidentlyRatioDriftMetric,
         EvidentlySimpleDistanceDriftMetric,

--- a/modyn/config/schema/pipeline/trigger/drift/evidently.py
+++ b/modyn/config/schema/pipeline/trigger/drift/evidently.py
@@ -1,0 +1,48 @@
+from typing import Annotated, Literal, Union
+
+from modyn.config.schema.base_model import ModynBaseModel
+from pydantic import Field
+
+
+class _EvidentlyBaseDriftMetric(ModynBaseModel):
+    num_pca_component: int | None = Field(None)
+
+
+class EvidentlyMmdDriftMetric(_EvidentlyBaseDriftMetric):
+    id: Literal["EvidentlyMmdDriftMetric"] = Field("EvidentlyMmdDriftMetric")
+    bootstrap: bool = Field(False)
+    quantile_probability: float = 0.05
+    threshold: float = Field(0.15)
+
+
+class EvidentlyModelDriftMetric(_EvidentlyBaseDriftMetric):
+    id: Literal["EvidentlyModelDriftMetric"] = Field("EvidentlyModelDriftMetric")
+    bootstrap: bool = Field(False)
+    quantile_probability: float = 0.95
+    threshold: float = Field(0.55)
+
+
+class EvidentlyRatioDriftMetric(_EvidentlyBaseDriftMetric):
+    id: Literal["EvidentlyRatioDriftMetric"] = Field("EvidentlyRatioDriftMetric")
+    component_stattest: str = Field("wasserstein", description="The statistical test used to compare the components.")
+    component_stattest_threshold: float = Field(0.1)
+    threshold: float = Field(0.2)
+
+
+class EvidentlySimpleDistanceDriftMetric(_EvidentlyBaseDriftMetric):
+    id: Literal["EvidentlySimpleDistanceDriftMetric"] = Field("EvidentlySimpleDistanceDriftMetric")
+    distance_metric: str = Field("euclidean", description="The distance metric used for the distance calculation.")
+    bootstrap: bool = Field(False)
+    quantile_probability: float = 0.95
+    threshold: float = Field(0.2)
+
+
+EvidentlyDriftMetric = Annotated[
+    Union[
+        EvidentlyMmdDriftMetric,
+        EvidentlyModelDriftMetric,
+        EvidentlyRatioDriftMetric,
+        EvidentlySimpleDistanceDriftMetric,
+    ],
+    Field(discriminator="id"),
+]

--- a/modyn/config/schema/pipeline/trigger/drift/modyn.py
+++ b/modyn/config/schema/pipeline/trigger/drift/modyn.py
@@ -1,0 +1,20 @@
+from typing import Annotated, Literal, Union
+
+from modyn.config.schema.base_model import ModynBaseModel
+from pydantic import Field
+
+
+class ModynMmdDriftMetric(ModynBaseModel):
+    id: Literal["ModynMmdDriftMetric"] = Field("ModynMmdDriftMetric")
+    bootstrap: bool = Field(False)
+    quantile_probability: float = 0.05
+    num_bootstraps: int = Field(100)
+    num_pca_component: int | None = Field(None)
+    device: str = Field("cpu", description="Pytorch device to use for computation")
+    num_workers: int = Field(1, description="Number of workers to use for computation")
+
+
+ModynDriftMetric = Annotated[
+    Union[ModynMmdDriftMetric],
+    Field(discriminator="id"),
+]

--- a/modyn/config/schema/pipeline/trigger/drift/result.py
+++ b/modyn/config/schema/pipeline/trigger/drift/result.py
@@ -1,0 +1,10 @@
+from modyn.config.schema.base_model import ModynBaseModel
+from pydantic import Field
+
+
+class MetricResult(ModynBaseModel):
+    metric_id: str = Field(description="The id of the metric used for drift detection.")
+    is_drift: bool
+    p_val: float | None = None
+    distance: float
+    threshold: float | None = None

--- a/modyn/config/schema/pipeline/trigger/drift/result.py
+++ b/modyn/config/schema/pipeline/trigger/drift/result.py
@@ -5,6 +5,6 @@ from pydantic import Field
 class MetricResult(ModynBaseModel):
     metric_id: str = Field(description="The id of the metric used for drift detection.")
     is_drift: bool
-    p_val: float | None = None
-    distance: float
+    p_val: float | list[float] | None = None
+    distance: float | list[float]
     threshold: float | None = None

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -163,6 +163,7 @@ class GRPCHandler(TrainerServerGRPCHandlerMixin):
         if not self.connected_to_storage:
             raise ConnectionError("Tried to fetch data from storage, but no connection was made.")
 
+        # pylint: disable=c-extension-no-member
         response: GetCurrentTimestampResponse = self.storage.GetCurrentTimestamp(
             storage_pb2.google_dot_protobuf_dot_empty__pb2.Empty()  # type: ignore
         )

--- a/modyn/supervisor/internal/pipeline_executor/models.py
+++ b/modyn/supervisor/internal/pipeline_executor/models.py
@@ -16,6 +16,7 @@ from modyn.config.schema.pipeline import ModynPipelineConfig
 from modyn.config.schema.system.config import ModynConfig
 from modyn.supervisor.internal.eval.handler import EvalRequest
 from modyn.supervisor.internal.grpc.enums import PipelineStage
+from modyn.supervisor.internal.triggers.models import TriggerPolicyEvaluationLog
 from modyn.supervisor.internal.utils.evaluation_status_reporter import EvaluationStatusReporter
 from modyn.supervisor.internal.utils.git_utils import get_head_sha
 from pydantic import BaseModel, Field, model_serializer, model_validator
@@ -201,6 +202,8 @@ class EvaluateTriggerInfo(StageInfo):
     trigger_indexes: list[int] = Field(default_factory=list)
     trigger_eval_times: list[int] = Field(default_factory=list)
     """Time in milliseconds that every next(...) call of the trigger.inform(...) generator took."""
+
+    trigger_evaluation_log: TriggerPolicyEvaluationLog = Field(default_factory=TriggerPolicyEvaluationLog)
 
     def df_columns(self) -> list[str]:
         """Provide the column names of the DataFrame representation of the data."""

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -457,7 +457,7 @@ class PipelineExecutor:
             log.info = EvaluateTriggerInfo(batch_size=len(batch))
 
             # Evaluate trigger policy
-            for trigger_index, t_micros in timed_generator(self.trigger.inform(batch)):
+            for trigger_index, t_micros in timed_generator(self.trigger.inform(batch, log.info.trigger_evaluation_log)):
                 log.info.trigger_indexes.append(trigger_index)
                 log.info.trigger_eval_times.append(int(t_micros))
                 yield trigger_index

--- a/modyn/supervisor/internal/triggers/amounttrigger.py
+++ b/modyn/supervisor/internal/triggers/amounttrigger.py
@@ -1,6 +1,7 @@
 from typing import Generator
 
 from modyn.config.schema.pipeline import DataAmountTriggerConfig
+from modyn.supervisor.internal.triggers.models import TriggerPolicyEvaluationLog
 from modyn.supervisor.internal.triggers.trigger import Trigger
 
 
@@ -15,7 +16,9 @@ class DataAmountTrigger(Trigger):
 
         super().__init__()
 
-    def inform(self, new_data: list[tuple[int, int, int]]) -> Generator[int, None, None]:
+    def inform(
+        self, new_data: list[tuple[int, int, int]], log: TriggerPolicyEvaluationLog | None = None
+    ) -> Generator[int, None, None]:
         assert self.remaining_data_points < self.data_points_for_trigger, "Inconsistent remaining datapoints"
 
         first_idx = self.data_points_for_trigger - self.remaining_data_points - 1

--- a/modyn/supervisor/internal/triggers/datadrifttrigger.py
+++ b/modyn/supervisor/internal/triggers/datadrifttrigger.py
@@ -7,6 +7,7 @@ from modyn.config.schema.pipeline import DataDriftTriggerConfig
 from modyn.config.schema.pipeline.trigger.drift.result import MetricResult
 from modyn.supervisor.internal.triggers.drift.alibi_detector import AlibiDriftDetector
 from modyn.supervisor.internal.triggers.drift.evidently_detector import EvidentlyDriftDetector
+from modyn.supervisor.internal.triggers.drift.modyn_detector import ModynDriftDetector
 from modyn.supervisor.internal.triggers.embedding_encoder_utils import EmbeddingEncoder, EmbeddingEncoderDownloader
 
 # pylint: disable-next=no-name-in-module
@@ -44,6 +45,7 @@ class DataDriftTrigger(Trigger):
 
         self.evidently_detector = EvidentlyDriftDetector(config.metrics)
         self.alibi_detector = AlibiDriftDetector(config.metrics)
+        self.modyn_detector = ModynDriftDetector(config.metrics)
 
     def init_trigger(self, context: TriggerContext) -> None:
         self.context = context

--- a/modyn/supervisor/internal/triggers/datadrifttrigger.py
+++ b/modyn/supervisor/internal/triggers/datadrifttrigger.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import logging
 from typing import Generator, Optional
 
-import pandas as pd
-from evidently import ColumnMapping
-from evidently.metrics import EmbeddingsDriftMetric
-from evidently.metrics.data_drift import embedding_drift_methods
-from evidently.report import Report
 from modyn.config.schema.pipeline import DataDriftTriggerConfig
+from modyn.config.schema.pipeline.trigger.drift.result import MetricResult
+from modyn.supervisor.internal.triggers.drift.alibi_detector import AlibiDriftDetector
+from modyn.supervisor.internal.triggers.drift.evidently_detector import EvidentlyDriftDetector
 from modyn.supervisor.internal.triggers.embedding_encoder_utils import EmbeddingEncoder, EmbeddingEncoderDownloader
 
 # pylint: disable-next=no-name-in-module
+from modyn.supervisor.internal.triggers.models import DriftTriggerEvalLog, TriggerPolicyEvaluationLog
 from modyn.supervisor.internal.triggers.trigger import Trigger, TriggerContext
 from modyn.supervisor.internal.triggers.trigger_datasets import DataLoaderInfo
 from modyn.supervisor.internal.triggers.utils import (
@@ -40,44 +39,105 @@ class DataDriftTrigger(Trigger):
         self.encoder_downloader: Optional[EmbeddingEncoderDownloader] = None
         self.embedding_encoder: Optional[EmbeddingEncoder] = None
 
-        self.evidently_column_mapping_name = "data"
-        self.metrics = self._get_evidently_metrics(self.evidently_column_mapping_name, config)
-
         self.data_cache: list[tuple[int, int, int]] = []
         self.leftover_data_points = 0
+
+        self.evidently_detector = EvidentlyDriftDetector(config.metrics)
+        self.alibi_detector = AlibiDriftDetector(config.metrics)
 
     def init_trigger(self, context: TriggerContext) -> None:
         self.context = context
         self._init_dataloader_info()
         self._init_encoder_downloader()
 
-    def run_detection(self, reference_embeddings_df: pd.DataFrame, current_embeddings_df: pd.DataFrame) -> bool:
-        assert self.dataloader_info is not None
+    def inform(
+        self, new_data: list[tuple[int, int, int]], log: TriggerPolicyEvaluationLog | None = None
+    ) -> Generator[int, None, None]:
+        """Decides whether to trigger retraining on a batch of new data based on data drift.
 
-        # Run Evidently detection
-        # ColumnMapping is {mapping name: column indices},
-        # an Evidently way of identifying (sub)columns to use in the detection.
-        # e.g. {"even columns": [0,2,4]}.
-        column_mapping = ColumnMapping(embeddings={self.evidently_column_mapping_name: reference_embeddings_df.columns})
+        New data is stored in data_cache and iterated over via a sliding window of current data for drift detection.
 
-        # https://docs.evidentlyai.com/user-guide/customization/embeddings-drift-parameters
-        report = Report(metrics=self.metrics)
-        report.run(
-            reference_data=reference_embeddings_df, current_data=current_embeddings_df, column_mapping=column_mapping
-        )
-        result = report.as_dict()
-        result_print = [
-            (x["result"]["drift_score"], x["result"]["method_name"], x["result"]["drift_detected"])
-            for x in result["metrics"]
-        ]
-        logger.info(
-            f"[DataDriftDetector][Prev Trigger {self.previous_trigger_id}][Dataset {self.dataloader_info.dataset_id}]"
-            + f"[Result] {result_print}"
-        )
+        The sliding window is determined by two pointers: detection_idx_start and detection_idx_end.
+        We hold the start pointer constant and advance the end pointer by detection_interval in every iteration.
+        In every iteration we run data drift detection on the sliding window of current data.
 
-        return result["metrics"][0]["result"]["drift_detected"]
+        Note: When having remaining untriggered data from the previous batch of new data,
+        we include all of them in the first drift detection.
 
-    def detect_drift(self, idx_start: int, idx_end: int) -> bool:
+        The remaining untriggered data has been processed in the previous new data batch,
+        so there's no need to run detection only on remaining data in this batch.
+        If a retraining is triggered, all data in the sliding window becomes triggering data.
+        Advance the start ptr after traversing the data_cache, we remove all the triggered data from the cache
+        and record the number of remaining untriggered samples.
+
+        Args:
+            new_data: List of new data (keys, timestamps, labels)
+            log: The log to store the trigger policy evaluation results to be able to verify trigger decisions
+
+        Returns:
+            a generator here that waits for the previous trigger to finish and get the model.
+        """
+        # add new data to data_cache
+        self.data_cache.extend(new_data)
+
+        unvisited_data_points = len(self.data_cache)
+        untriggered_data_points = unvisited_data_points
+
+        # the sliding window of data points for detection
+        detection_idx_start = 0
+        detection_idx_end = 0
+
+        while unvisited_data_points >= self.config.detection_interval_data_points:
+            unvisited_data_points -= self.config.detection_interval_data_points
+            detection_idx_end += self.config.detection_interval_data_points
+            if detection_idx_end <= self.leftover_data_points:
+                continue
+
+            if self.previous_trigger_id is None:
+                triggered = True  # if no previous trigger exists, always trigger retraining
+                drift_results: dict[str, MetricResult] = {}
+            else:
+                # if exist previous trigger, detect drift
+                triggered, drift_results = self._run_detection(detection_idx_start, detection_idx_end)
+
+            drift_eval_log = DriftTriggerEvalLog(
+                detection_idx_start=detection_idx_start,
+                detection_idx_end=detection_idx_end,
+                triggered=triggered,
+                trigger_index=-1,
+                drift_results=drift_results,
+            )
+
+            if triggered:
+                trigger_data_points = detection_idx_end - detection_idx_start
+                # Index of the last sample of the trigger. Index is relative to the new_data list.
+                trigger_idx = len(new_data) - (untriggered_data_points - trigger_data_points) - 1
+
+                # log
+                drift_eval_log.data_points = trigger_data_points
+                if log:
+                    log.evaluations.append(drift_eval_log)
+
+                # update bookkeeping and sliding window
+                untriggered_data_points -= trigger_data_points
+                detection_idx_start = detection_idx_end
+                yield trigger_idx
+
+        # remove triggered data from cache
+        del self.data_cache[:detection_idx_start]
+        self.leftover_data_points = detection_idx_end - detection_idx_start
+
+    def inform_previous_trigger_and_data_points(self, previous_trigger_id: int, data_points: int) -> None:
+        self.previous_trigger_id = previous_trigger_id
+        self.previous_data_points = data_points
+
+    def inform_previous_model(self, previous_model_id: int) -> None:
+        self.previous_model_id = previous_model_id
+        self.model_updated = True
+
+    # --------------------------------------------------- INTERNAL --------------------------------------------------- #
+
+    def _run_detection(self, idx_start: int, idx_end: int) -> tuple[bool, dict[str, MetricResult]]:
         """Compare current data against reference data.
         current data: all untriggered samples in the sliding window in inform().
         reference data: the training samples of the previous trigger.
@@ -121,87 +181,19 @@ class DataDriftTrigger(Trigger):
         reference_embeddings_df = convert_tensor_to_df(reference_embeddings, "col_")
         current_embeddings_df = convert_tensor_to_df(current_embeddings, "col_")
 
-        drift_detected = self.run_detection(reference_embeddings_df, current_embeddings_df)
+        drift_results = {
+            **self.evidently_detector.detect_drift(reference_embeddings_df, current_embeddings_df),
+            **self.alibi_detector.detect_drift(reference_embeddings, current_embeddings),
+        }
+        logger.info(
+            f"[DataDriftDetector][Prev Trigger {self.previous_trigger_id}][Dataset {self.dataloader_info.dataset_id}]"
+            + f"[Result] {drift_results}"
+        )
 
-        return drift_detected
+        # aggregate the different drift detection results
+        drift_detected = self.config.aggregation_strategy.aggregate_decision_func(drift_results)
 
-    def inform(self, new_data: list[tuple[int, int, int]]) -> Generator[int, None, None]:
-        """The DataDriftTrigger takes a batch of new data as input. It adds the new data to its data_cache.
-        Then, it iterates through the data_cache with a sliding window of current data for drift detection.
-        The sliding window is determined by two pointers: detection_idx_start and detection_idx_end.
-        We fix the start pointer and advance the end pointer by detection_interval in every iteration.
-        In every iteration we run data drift detection on the sliding window of current data.
-        Note, if we have remaining untriggered data from the previous batch of new data,
-        we include all of them in the first drift detection.
-        The remaining untriggered data has been processed in the previous new data batch,
-        so there's no need to run detection only on remaining data in this batch.
-        If a retraining is triggered, all data in the sliding window becomes triggering data. Advance the start ptr.
-        After traversing the data_cache, we remove all the triggered data from the cache
-        and record the number of remaining untriggered samples.
-        Use Generator here because this data drift trigger
-        needs to wait for the previous trigger to finish and get the model.
-        """
-        # add new data to data_cache
-        self.data_cache.extend(new_data)
-
-        unvisited_data_points = len(self.data_cache)
-        untriggered_data_points = unvisited_data_points
-        # the sliding window of data points for detection
-        detection_idx_start = 0
-        detection_idx_end = 0
-
-        while unvisited_data_points >= self.config.detection_interval_data_points:
-            unvisited_data_points -= self.config.detection_interval_data_points
-            detection_idx_end += self.config.detection_interval_data_points
-            if detection_idx_end <= self.leftover_data_points:
-                continue
-
-            # trigger_id doesn't always start from 0
-            if self.previous_trigger_id is None:
-                # if no previous trigger exists, always trigger retraining
-                triggered = True
-            else:
-                # if exist previous trigger, detect drift
-                triggered = self.detect_drift(detection_idx_start, detection_idx_end)
-
-            if triggered:
-                trigger_data_points = detection_idx_end - detection_idx_start
-                # Index of the last sample of the trigger. Index is relative to the new_data list.
-                trigger_idx = len(new_data) - (untriggered_data_points - trigger_data_points) - 1
-
-                # update bookkeeping and sliding window
-                untriggered_data_points -= trigger_data_points
-                detection_idx_start = detection_idx_end
-                yield trigger_idx
-
-        # remove triggered data from cache
-        del self.data_cache[:detection_idx_start]
-        self.leftover_data_points = detection_idx_end - detection_idx_start
-
-    def inform_previous_trigger_and_data_points(self, previous_trigger_id: int, data_points: int) -> None:
-        self.previous_trigger_id = previous_trigger_id
-        self.previous_data_points = data_points
-
-    def inform_previous_model(self, previous_model_id: int) -> None:
-        self.previous_model_id = previous_model_id
-        self.model_updated = True
-
-    # --------------------------------------------------- INTERNAL --------------------------------------------------- #
-
-    def _get_evidently_metrics(
-        self, column_mapping_name: str, config: DataDriftTriggerConfig
-    ) -> list[EmbeddingsDriftMetric]:
-        """This function instantiates an Evidently metric given metric configuration.
-        If we want to support multiple metrics in the future, we can loop through the configurations.
-
-        Evidently metric configurations follow exactly the four DriftMethods defined in embedding_drift_methods:
-        model, distance, mmd, ratio
-        If metric_name not given, we use the default 'model' metric.
-        Otherwise, we use the metric given by metric_name, with optional metric configuration specific to the metric.
-        """
-        metric = getattr(embedding_drift_methods, config.metric)(**config.metric_config)
-        metrics = [EmbeddingsDriftMetric(column_mapping_name, drift_method=metric)]
-        return metrics
+        return drift_detected, drift_results
 
     def _init_dataloader_info(self) -> None:
         assert self.context

--- a/modyn/supervisor/internal/triggers/drift/alibi_detector.py
+++ b/modyn/supervisor/internal/triggers/drift/alibi_detector.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import torch
+from modyn.config.schema.pipeline.trigger.drift.alibi_detect import AlibiDetectDriftMetric
+from modyn.config.schema.pipeline.trigger.drift.result import MetricResult
+from typing_extensions import override
+
+from .drift_detector import DriftDetector
+
+
+class AlibiDriftDetector(DriftDetector):
+    def __init__(self, metrics_config: dict[str, AlibiDetectDriftMetric]):
+        super().__init__(metrics_config)
+
+    @override
+    def init_detector(self) -> None:
+        pass
+
+    @override
+    def detect_drift(
+        self,
+        embeddings_ref: pd.DataFrame | np.ndarray | torch.Tensor,
+        embeddings_cur: pd.DataFrame | np.ndarray | torch.Tensor,
+    ) -> dict[str, MetricResult]:
+        for metric_id, metric_config in self.metrics_config.items():
+            assert metric_id
+            assert metric_config
+            raise NotImplementedError()
+        assert self.metrics_config, "No metrics configured for drift detection"
+        return {}

--- a/modyn/supervisor/internal/triggers/drift/drift_detector.py
+++ b/modyn/supervisor/internal/triggers/drift/drift_detector.py
@@ -1,0 +1,22 @@
+from abc import ABC
+
+import numpy as np
+import pandas as pd
+import torch
+from modyn.config.schema.pipeline.trigger.drift.config import DriftMetric
+from modyn.config.schema.pipeline.trigger.drift.result import MetricResult
+
+
+class DriftDetector(ABC):
+    def __init__(self, metrics_config: dict[str, DriftMetric]):
+        self.metrics_config = metrics_config
+
+    def init_detector(self) -> None:
+        pass
+
+    def detect_drift(
+        self,
+        embeddings_ref: pd.DataFrame | np.ndarray | torch.Tensor,
+        embeddings_cur: pd.DataFrame | np.ndarray | torch.Tensor,
+    ) -> dict[str, MetricResult]:
+        raise NotImplementedError()

--- a/modyn/supervisor/internal/triggers/drift/drift_detector.py
+++ b/modyn/supervisor/internal/triggers/drift/drift_detector.py
@@ -8,6 +8,8 @@ from modyn.config.schema.pipeline.trigger.drift.result import MetricResult
 
 
 class DriftDetector(ABC):
+    # to do: multiple strategies to select reference data
+
     def __init__(self, metrics_config: dict[str, DriftMetric]):
         self.metrics_config = metrics_config
 

--- a/modyn/supervisor/internal/triggers/drift/evidently_detector.py
+++ b/modyn/supervisor/internal/triggers/drift/evidently_detector.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+import torch
+from evidently import ColumnMapping
+from evidently.metrics import EmbeddingsDriftMetric
+from evidently.metrics.data_drift import embedding_drift_methods
+from evidently.report import Report
+from modyn.config.schema.pipeline import EvidentlyDriftMetric, MetricResult
+from typing_extensions import override
+
+from .drift_detector import DriftDetector
+
+logger = logging.getLogger(__name__)
+
+EVIDENTLY_COLUMN_MAPPING_NAME = "data"
+
+
+class EvidentlyDriftDetector(DriftDetector):
+    def __init__(self, metrics_config: dict[str, EvidentlyDriftMetric]):
+        super().__init__(metrics_config)
+        self.evidently_metrics = _get_evidently_metrics(metrics_config)
+
+    @override
+    def init_detector(self) -> None:
+        pass
+
+    @override
+    def detect_drift(
+        self,
+        embeddings_ref: pd.DataFrame | np.ndarray | torch.Tensor,
+        embeddings_cur: pd.DataFrame | np.ndarray | torch.Tensor,
+    ) -> dict[str, MetricResult]:
+        assert isinstance(embeddings_ref, pd.DataFrame)
+        assert isinstance(embeddings_cur, pd.DataFrame)
+
+        # Run Evidently detection
+        # ColumnMapping is {mapping name: column indices},
+        # an Evidently way of identifying (sub)columns to use in the detection.
+        # e.g. {"even columns": [0,2,4]}.
+        column_mapping = ColumnMapping(embeddings={EVIDENTLY_COLUMN_MAPPING_NAME: embeddings_ref.columns})
+
+        # https://docs.evidentlyai.com/user-guide/customization/embeddings-drift-parameters
+        report = Report(metrics=self.evidently_metrics)
+        report.run(reference_data=embeddings_ref, current_data=embeddings_cur, column_mapping=column_mapping)
+        results_raw = report.as_dict()
+
+        results = {
+            metric: MetricResult(
+                metric_id=metric,
+                is_drift=metric_result["result"]["drift_detected"],
+                distance=metric_result["result"]["drift_score"],
+            )
+            for metric, metric_result in results_raw["metrics"].items()
+        }
+        return results
+
+
+# -------------------------------------------------------------------------------------------------------------------- #
+#                                                       Internal                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+
+def _get_evidently_metrics(metrics_config: dict[str, EvidentlyDriftMetric]) -> dict[str, EmbeddingsDriftMetric]:
+    """This function instantiates an Evidently metric given metric configuration.
+    If we want to support multiple metrics in the future, we can loop through the configurations.
+
+    Evidently metric configurations follow exactly the four DriftMethods defined in embedding_drift_methods:
+    model, distance, mmd, ratio
+    If metric_name not given, we use the default 'model' metric.
+    Otherwise, we use the metric given by metric_name, with optional metric configuration specific to the metric.
+    """
+    metrics = {
+        metric_ref: EmbeddingsDriftMetric(EVIDENTLY_COLUMN_MAPPING_NAME, _evidently_metric_factory(config))
+        for metric_ref, config in metrics_config.items()
+    }
+    return metrics
+
+
+def _evidently_metric_factory(config: EvidentlyDriftMetric) -> EmbeddingsDriftMetric:
+    if config.id == "EvidentlyMmdDriftMetric":
+        return embedding_drift_methods.mmd(
+            threshold=config.threshold,
+            bootstrap=config.bootstrap,
+            quantile_probability=config.quantile_probability,
+            pca_components=config.num_pca_component,
+        )
+    if config.id == "EvidentlyModelDriftMetric":
+        return embedding_drift_methods.model(
+            threshold=config.threshold,
+            bootstrap=config.bootstrap,
+            quantile_probability=config.quantile_probability,
+            pca_components=config.num_pca_component,
+        )
+    if config.id == "EvidentlyRatioDriftMetric":
+        return embedding_drift_methods.ratio(
+            component_stattest=config.component_stattest,
+            component_stattest_threshold=config.component_stattest_threshold,
+            threshold=config.threshold,
+            pca_components=config.num_pca_component,
+        )
+    if config.id == "EvidentlySimpleDistanceDriftMetric":
+        return embedding_drift_methods.distance(
+            dist=config.distance_metric,
+            threshold=config.threshold,
+            bootstrap=config.bootstrap,
+            pca_components=config.num_pca_component,
+            quantile_probability=config.quantile_probability,
+        )
+
+    raise NotImplementedError(f"Metric {config.id} is not supported in EvidentlyDriftMetric.")

--- a/modyn/supervisor/internal/triggers/drift/evidently_detector.py
+++ b/modyn/supervisor/internal/triggers/drift/evidently_detector.py
@@ -44,17 +44,18 @@ class EvidentlyDriftDetector(DriftDetector):
         column_mapping = ColumnMapping(embeddings={EVIDENTLY_COLUMN_MAPPING_NAME: embeddings_ref.columns})
 
         # https://docs.evidentlyai.com/user-guide/customization/embeddings-drift-parameters
-        report = Report(metrics=self.evidently_metrics)
+        report = Report(metrics=[self.evidently_metrics[name] for name in self.evidently_metrics])
         report.run(reference_data=embeddings_ref, current_data=embeddings_cur, column_mapping=column_mapping)
         results_raw = report.as_dict()
 
+        metric_names = list(self.metrics_config)
         results = {
-            metric: MetricResult(
-                metric_id=metric,
+            metric_names[metric_idx]: MetricResult(
+                metric_id=metric_result["metric"],
                 is_drift=metric_result["result"]["drift_detected"],
                 distance=metric_result["result"]["drift_score"],
             )
-            for metric, metric_result in results_raw["metrics"].items()
+            for metric_idx, metric_result in enumerate(results_raw["metrics"])
         }
         return results
 

--- a/modyn/supervisor/internal/triggers/drift/metrics/mmd.py
+++ b/modyn/supervisor/internal/triggers/drift/metrics/mmd.py
@@ -1,0 +1,146 @@
+from functools import partial
+from multiprocessing import Pool
+
+import numpy as np
+import torch
+from modyn.config.schema.pipeline.trigger.drift.result import MetricResult
+from sklearn.decomposition import PCA
+from sklearn.kernel_approximation import pairwise_kernels
+from sklearn.metrics import pairwise_distances
+
+# ------------------------------------------------- unbiased estimate ------------------------------------------------ #
+# has quadratic time [O((m+n)^2)] complexity see https://www.jmlr.org/papers/volume13/gretton12a/gretton12a.pdf
+
+
+def _mmd2_u(kernel_matrix: torch.Tensor, m: int, n: int) -> float:
+    """The MMD^2_u unbiased statistic. c_i account for the imbalance in the number of samples in X and Y."""
+    kernel_matrix_xx = kernel_matrix[:m, :m]
+    kernel_matrix_yy = kernel_matrix[m:, m:]
+    kernel_matrix_xy = kernel_matrix[:m, m:]
+
+    c1 = 1 / (m * (m - 1))
+    sum_x = torch.sum(kernel_matrix_xx - torch.diag(torch.diagonal(kernel_matrix_xx)))
+
+    c2 = 1 / (n * (n - 1))
+    sum_y = torch.sum(kernel_matrix_yy - torch.diag(torch.diagonal(kernel_matrix_yy)))
+
+    sum_xy = torch.mean(kernel_matrix_xy)
+
+    # unbiased estimate for MMD
+    return float(c1 * sum_x + c2 * sum_y - 2 * sum_xy)
+
+
+def _mmd2_u_bstrp(kernel_matrix: torch.Tensor, m: int, n: int, x_y_idxs: tuple[np.ndarray, np.ndarray]) -> float:
+    """The MMD^2_u unbiased statistic for bootstrap subsample."""
+    x_idx, y_idx = x_y_idxs
+
+    kernel_matrix_xx = kernel_matrix[[[idx] for idx in x_idx], x_idx]
+    kernel_matrix_yy = kernel_matrix[[[idx] for idx in y_idx], y_idx]
+    kernel_matrix_xy = kernel_matrix[[[idx] for idx in x_idx], y_idx]
+
+    c1 = 1 / (m * (m - 1))
+    sum_x = torch.sum(kernel_matrix_xx - torch.diag(torch.diagonal(kernel_matrix_xx)))
+
+    c2 = 1 / (n * (n - 1))
+    sum_y = torch.sum(kernel_matrix_yy - torch.diag(torch.diagonal(kernel_matrix_yy)))
+
+    sum_xy = torch.mean(kernel_matrix_xy)
+
+    # unbiased estimate for MMD
+    return c1 * sum_x + c2 * sum_y - 2 * sum_xy
+
+
+def _mm2_u_null_distrib_bootstrap(
+    kernel_matrix: torch.Tensor, m: int, n: int, num_bootstraps: int, num_workers: int
+) -> np.ndarray:
+    """Compute the bootstrapped null-distribution of MMD2u and run a two-sample test via bootstrapping.
+
+    Assume that the null hypothesis is true, i.e., the samples are drawn from the same distribution.
+    We compute the null-distribution by bootstrapping samples from the sample pool of X and Y, and compute MMD2u
+    on these samples. We later compute a p-value by comparing the observed MMD2u to the null-distribution.
+
+    p-values are defined as the proportion of bootstrapped MMD2u that are at least as extreme as the observed MMD2u.
+    If our H0 does not hold and X and Y are drawn from different distributions, the the bootstrapped MMD2u values
+    will be smaller as the sets contain samples from both distributions averaging the distances out.
+    Hence the proportion of bootstrapped MMD2u values that are at least as extreme as the observed MMD2u will be
+    smaller making the p-value smaller.
+
+    We reject the null hypothesis if the p-value is smaller than the significance level.
+    """
+
+    # our quadratic unbiased estimator can deal with n != m, therefore we sample m values from X and n values from Y.
+    # Bootstrapping uses sampling with replacement.
+
+    x_size = max(int(m * m / (m + n)), 1)
+    y_size = max(int(m * n / (m + n)), 1)
+
+    sample_ids = [
+        (np.random.choice(m, x_size, replace=True), np.random.choice(n, y_size, replace=True))
+        for _ in range(num_bootstraps)
+    ]
+
+    _bootstrap_job = partial(_mmd2_u_bstrp, kernel_matrix, x_size, y_size)
+    if num_workers > 1:
+        with Pool(num_workers) as pool:
+            null_distrib = np.array(pool.map(_bootstrap_job, sample_ids))
+    else:
+        null_distrib = np.zeros(num_bootstraps)
+        for i, idxs in enumerate(sample_ids):
+            null_distrib[i] = _bootstrap_job(idxs)
+
+    return null_distrib
+
+
+# -------------------------------------------------- hypothesis test ------------------------------------------------- #
+
+
+def mmd2_two_sample_test(
+    reference_emb: torch.Tensor | np.ndarray,
+    current_emb: torch.Tensor | np.ndarray,
+    num_bootstraps: int = 1000,
+    quantile_probability: float = 0.05,
+    pca_components: int | None = None,
+    device: str = "cpu",
+    num_workers: int = 1,
+) -> MetricResult:
+    """Compute the MMD^2 two-sample test statistic and the p-value.
+
+    The MMD^2 two-sample test statistic is computed using the unbiased estimator for small sample sizes
+    (m, n < 1000) and the linear approximation estimator for large sample sizes (m, n >= 1000).
+
+    The p-value is computed by bootstrapping the null-distribution of MMD^2 and comparing the observed MMD^2
+    to the null-distribution.
+
+    Args:
+        x: The first sample.
+        y: The second sample.
+        num_bootstraps: The number of bootstraps to compute the null-distribution.
+
+    Returns:
+        The MMD^2 two-sample test statistic and a boolean indicating whether the null hypothesis is rejected.
+    """
+    # pylint: disable=too-many-locals
+    if pca_components:
+        pca = PCA(n_components=pca_components, random_state=0)
+        reference_emb = pca.fit_transform(reference_emb)
+        current_emb = pca.fit_transform(current_emb)
+
+    x = torch.from_numpy(reference_emb).to(device)
+    y = torch.from_numpy(current_emb).to(device)
+    m = len(x)
+    n = len(y)
+
+    xy = torch.vstack([x, y])
+    kernel_matrix = torch.from_numpy(
+        pairwise_kernels(xy, metric="rbf", gamma=1.0 / np.median(pairwise_distances(xy, metric="euclidean")) ** 2)
+    )
+    statistic = _mmd2_u(kernel_matrix, m, n)
+    null_distrib = _mm2_u_null_distrib_bootstrap(kernel_matrix, m, n, num_bootstraps, num_workers)
+
+    p_value = max(float(np.mean(null_distrib > statistic)), 1 / num_bootstraps)
+    return MetricResult(
+        metric_id="mmd",
+        distance=statistic,
+        p_val=p_value,
+        is_drift=p_value <= quantile_probability,
+    )

--- a/modyn/supervisor/internal/triggers/drift/modyn_detector.py
+++ b/modyn/supervisor/internal/triggers/drift/modyn_detector.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import torch
+from modyn.config.schema.pipeline import MetricResult
+from modyn.config.schema.pipeline.trigger.drift.modyn import ModynDriftMetric, ModynMmdDriftMetric
+from modyn.supervisor.internal.triggers.drift.metrics.mmd import mmd2_two_sample_test
+
+from .drift_detector import DriftDetector
+
+
+class ModynDriftDetector(DriftDetector):
+    def __init__(self, metrics_config: dict[str, ModynDriftMetric]):
+        modyn_metrics_config = {
+            metric_ref: config for metric_ref, config in metrics_config.items() if config.id.startswith("Modyn")
+        }
+        super().__init__(modyn_metrics_config)
+
+    def init_detector(self) -> None:
+        pass
+
+    def detect_drift(
+        self,
+        embeddings_ref: pd.DataFrame | np.ndarray | torch.Tensor,
+        embeddings_cur: pd.DataFrame | np.ndarray | torch.Tensor,
+    ) -> dict[str, MetricResult]:
+        assert isinstance(embeddings_ref, np.ndarray)
+        assert isinstance(embeddings_cur, np.ndarray)
+
+        results: dict[str, MetricResult] = {}
+
+        for metric_ref, config in self.metrics_config.items():
+            if isinstance(config, ModynMmdDriftMetric):
+                results[metric_ref] = mmd2_two_sample_test(
+                    reference_emb=embeddings_ref,
+                    current_emb=embeddings_ref,
+                    num_bootstraps=config.num_bootstraps,
+                    pca_components=config.num_pca_component,
+                    quantile_probability=config.quantile_probability,
+                    device=config.device,
+                    num_workers=config.num_workers,
+                )
+
+            raise NotImplementedError(f"Metric {config.id} is not supported in ModynDetectDriftMetric.")
+
+        return results

--- a/modyn/supervisor/internal/triggers/models.py
+++ b/modyn/supervisor/internal/triggers/models.py
@@ -1,0 +1,24 @@
+from typing import Annotated, Literal, Union
+
+from modyn.config.schema.base_model import ModynBaseModel
+from modyn.config.schema.pipeline.trigger.drift.result import MetricResult
+from pydantic import Field
+
+
+class DriftTriggerEvalLog(ModynBaseModel):
+    type: Literal["drift"] = Field("drift")
+    detection_idx_start: int
+    detection_idx_end: int
+    triggered: bool
+    trigger_index: int | None = Field(None)
+    data_points: int = Field(0)
+    drift_results: dict[str, MetricResult] = Field(default_factory=dict)
+
+
+TriggerEvalLog = Annotated[Union[DriftTriggerEvalLog], Field(discriminator="type")]
+
+
+class TriggerPolicyEvaluationLog(ModynBaseModel):
+    evaluations: list[TriggerEvalLog] = Field(
+        default_factory=list, description="The results of the trigger policy evaluation."
+    )

--- a/modyn/supervisor/internal/triggers/timetrigger.py
+++ b/modyn/supervisor/internal/triggers/timetrigger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Generator
 
 from modyn.config.schema.pipeline import TimeTriggerConfig
+from modyn.supervisor.internal.triggers.models import TriggerPolicyEvaluationLog
 from modyn.supervisor.internal.triggers.trigger import Trigger
 
 
@@ -20,7 +21,9 @@ class TimeTrigger(Trigger):
 
         super().__init__()
 
-    def inform(self, new_data: list[tuple[int, int, int]]) -> Generator[int, None, None]:
+    def inform(
+        self, new_data: list[tuple[int, int, int]], log: TriggerPolicyEvaluationLog | None = None
+    ) -> Generator[int, None, None]:
         if self.next_trigger_at is None:
             if self.config.start_timestamp is not None:
                 self.next_trigger_at = self.config.start_timestamp + self.config.every_seconds

--- a/modyn/supervisor/internal/triggers/trigger.py
+++ b/modyn/supervisor/internal/triggers/trigger.py
@@ -5,6 +5,7 @@ from typing import Generator
 
 from modyn.config.schema.pipeline import ModynPipelineConfig
 from modyn.config.schema.system.config import ModynConfig
+from modyn.supervisor.internal.triggers.models import TriggerPolicyEvaluationLog
 
 
 @dataclass
@@ -24,17 +25,20 @@ class Trigger(ABC):
         pass
 
     @abstractmethod
-    def inform(self, new_data: list[tuple[int, int, int]]) -> Generator[int, None, None]:
+    def inform(
+        self, new_data: list[tuple[int, int, int]], log: TriggerPolicyEvaluationLog | None = None
+    ) -> Generator[int, None, None]:
         """The supervisor informs the Trigger about new data.
         In case the concrete Trigger implementation decides to trigger, we return a list of _indices into new_data_.
         This list contains the indices of all data points that cause a trigger.
         The list might be empty or only contain a single element, which concrete Triggers need to respect.
 
-             Parameters:
-                     new_data (list[tuple[str, int, int]]): List of new data (keys, timestamps, labels). Can be empty.
+        Args:
+            new_data: List of new data (keys, timestamps, labels)
+            log: The log to store the trigger policy evaluation results to be able to verify trigger decisions
 
-             Returns:
-                     triggering_indices (list[int]): List of all indices that trigger training
+        Returns:
+            triggering_indices: List of all indices that trigger training
         """
 
     # pylint: disable=unnecessary-pass

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_pipeline_executor.py
@@ -355,13 +355,14 @@ def test__process_new_data_batch_no_triggers(
 
     with patch.object(pe.trigger, "inform") as inform_mock:
 
-        def fake(self):
+        def fake(self, *args, **kwargs):
             yield from []
 
         inform_mock.side_effect = fake
         assert len(pe._process_new_data_batch(pe.state, pe.logs, batch)) == 0
 
-        inform_mock.assert_called_once_with(batch)
+        inform_mock.assert_called_once()
+        inform_mock.call_args_list == [call(batch, ANY)]
         test_inform_selector.assert_called_once_with(42, batch)
 
 

--- a/modyn/tests/supervisor/internal/triggers/drift/conftest.py
+++ b/modyn/tests/supervisor/internal/triggers/drift/conftest.py
@@ -1,0 +1,51 @@
+from typing import Iterator
+
+import numpy as np
+import pytest
+
+
+# back up seed before all tests
+@pytest.fixture(autouse=True, scope="package")
+def set_seed() -> Iterator[None]:
+    seed_backup = np.random.get_state()
+    np.random.seed(42)
+
+    yield
+
+    np.random.set_state(seed_backup)
+
+
+@pytest.fixture(scope="package")
+def data_ref() -> np.ndarray:
+    return np.stack(
+        [
+            (x, y)
+            for x, y in zip(
+                np.random.normal(loc=0.0, scale=1.0, size=5000), np.random.normal(loc=0.0, scale=1.0, size=5000)
+            )
+        ]
+    )
+
+
+@pytest.fixture(scope="package")
+def data_h0() -> np.ndarray:
+    return np.stack(
+        [
+            (x, y)
+            for x, y in zip(
+                np.random.normal(loc=0.0, scale=1.0, size=100), np.random.normal(loc=0.0, scale=1.0, size=100)
+            )
+        ]
+    )
+
+
+@pytest.fixture(scope="module")
+def data_cur() -> np.ndarray:
+    return np.stack(
+        [
+            (x, y)
+            for x, y in zip(
+                np.random.normal(loc=0.2, scale=1.0, size=120), np.random.normal(loc=-0.3, scale=1.0, size=120)
+            )
+        ]
+    )

--- a/modyn/tests/supervisor/internal/triggers/drift/test_alibi_detector.py
+++ b/modyn/tests/supervisor/internal/triggers/drift/test_alibi_detector.py
@@ -1,0 +1,84 @@
+import statistics
+
+import numpy as np
+import pytest
+from modyn.config.schema.pipeline import AlibiDetectCVMDriftMetric, AlibiDetectKSDriftMetric, AlibiDetectMmdDriftMetric
+from modyn.supervisor.internal.triggers.drift.alibi_detector import AlibiDriftDetector
+
+
+@pytest.fixture
+def mmd_drift_metric() -> AlibiDetectMmdDriftMetric:
+    return AlibiDetectMmdDriftMetric(
+        p_val=0.05,
+        device=None,
+        num_permutations=100,
+        kernel="GaussianRBF",
+    )
+
+
+@pytest.fixture
+def ks_drift_metric() -> AlibiDetectKSDriftMetric:
+    return AlibiDetectKSDriftMetric(
+        p_val=0.05,
+        correction="bonferroni",
+        alternative_hypothesis="two-sided",
+    )
+
+
+@pytest.fixture
+def cvm_drift_metric() -> AlibiDetectCVMDriftMetric:
+    return AlibiDetectCVMDriftMetric(
+        p_val=0.05,
+        correction="bonferroni",
+    )
+
+
+def test_alibi_detect_drift_metric(
+    mmd_drift_metric: AlibiDetectMmdDriftMetric,
+    ks_drift_metric: AlibiDetectKSDriftMetric,
+    cvm_drift_metric: AlibiDetectCVMDriftMetric,
+    data_ref: np.ndarray,
+    data_h0: np.ndarray,
+    data_cur: np.ndarray,
+) -> None:
+    detector = [
+        ("mmd", AlibiDriftDetector({"mmd": mmd_drift_metric})),
+        ("ks", AlibiDriftDetector({"ks": ks_drift_metric})),
+        ("cvm", AlibiDriftDetector({"cvm": cvm_drift_metric})),
+    ]
+    for name, ad in detector:
+        assert isinstance(ad, AlibiDriftDetector)
+
+        # on h0
+        results = ad.detect_drift(data_ref, data_h0)
+        assert not results[name].is_drift
+
+        # on current data
+        results = ad.detect_drift(data_ref, data_cur)
+        assert results[name].is_drift
+        assert (
+            0
+            <= statistics.mean(
+                [results[name].distance] if not isinstance(results[name].distance, list) else results[name].distance
+            )
+            < (1.0 if name == "cvm" else 0.2)
+        )
+        assert (
+            0
+            <= statistics.mean(
+                [results[name].p_val] if not isinstance(results[name].p_val, list) else results[name].p_val
+            )
+            < 0.015
+        )
+        assert results[name].threshold is not None
+        assert results[name].metric_id == name
+
+    ad = AlibiDriftDetector(
+        {
+            "mmd": mmd_drift_metric,
+            "ks": ks_drift_metric,
+            "cvm": cvm_drift_metric,
+        }
+    )
+    results = ad.detect_drift(data_ref, data_cur)
+    assert len(results) == 3

--- a/modyn/tests/supervisor/internal/triggers/drift/test_evidently_detector.py
+++ b/modyn/tests/supervisor/internal/triggers/drift/test_evidently_detector.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+
 from modyn.config.schema.pipeline import (
     EvidentlyMmdDriftMetric,
     EvidentlyModelDriftMetric,
@@ -84,7 +85,7 @@ def test_evidently_detect_drift_metric(
         if name != "model":
             # model makes the wrong decision here
             assert results[name].is_drift
-        assert 0 <= results[name].distance <= (1 if name == "ratio" else 0.5)
+        assert 0 <= results[name].distance <= (1 if name == "ratio" else 0.75)
         assert results[name].metric_id == "EmbeddingsDriftMetric"
 
     ad = EvidentlyDriftDetector(

--- a/modyn/tests/supervisor/internal/triggers/drift/test_evidently_detector.py
+++ b/modyn/tests/supervisor/internal/triggers/drift/test_evidently_detector.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pandas as pd
+import pytest
+from modyn.config.schema.pipeline import (
+    EvidentlyMmdDriftMetric,
+    EvidentlyModelDriftMetric,
+    EvidentlyRatioDriftMetric,
+    EvidentlySimpleDistanceDriftMetric,
+)
+from modyn.supervisor.internal.triggers.drift.evidently_detector import EvidentlyDriftDetector
+
+
+def _add_col_prefixes(df: pd.DataFrame, prefix: str) -> pd.DataFrame:
+    df.columns = [f"{prefix}{col}" for col in df.columns]
+    return df
+
+
+@pytest.fixture(scope="module")
+def df_data_ref(data_ref: np.ndarray) -> pd.DataFrame:
+    return _add_col_prefixes(pd.DataFrame(data_ref), "col_")
+
+
+@pytest.fixture(scope="module")
+def df_data_h0(data_h0: np.ndarray) -> pd.DataFrame:
+    return _add_col_prefixes(pd.DataFrame(data_h0), "col_")
+
+
+@pytest.fixture(scope="module")
+def df_data_cur(data_cur: np.ndarray) -> pd.DataFrame:
+    return _add_col_prefixes(pd.DataFrame(data_cur), "col_")
+
+
+@pytest.fixture
+def mmd_drift_metric() -> EvidentlyMmdDriftMetric:
+    return EvidentlyMmdDriftMetric(bootstrap=True)
+
+
+@pytest.fixture
+def model_drift_metric() -> EvidentlyModelDriftMetric:
+    return EvidentlyModelDriftMetric(bootstrap=True)
+
+
+@pytest.fixture
+def ratio_drift_metric() -> EvidentlyRatioDriftMetric:
+    return EvidentlyRatioDriftMetric()
+
+
+@pytest.fixture
+def simple_distance_drift_metric() -> EvidentlySimpleDistanceDriftMetric:
+    return EvidentlySimpleDistanceDriftMetric(
+        bootstrap=True,
+        distance_metric="euclidean",
+    )
+
+
+def test_evidently_detect_drift_metric(
+    mmd_drift_metric: EvidentlyMmdDriftMetric,
+    model_drift_metric: EvidentlyModelDriftMetric,
+    ratio_drift_metric: EvidentlyRatioDriftMetric,
+    simple_distance_drift_metric: EvidentlySimpleDistanceDriftMetric,
+    df_data_ref: np.ndarray,
+    df_data_h0: np.ndarray,
+    df_data_cur: np.ndarray,
+) -> None:
+    detector = [
+        ("mmd", EvidentlyDriftDetector({"mmd": mmd_drift_metric})),
+        ("model", EvidentlyDriftDetector({"model": model_drift_metric})),
+        ("ratio", EvidentlyDriftDetector({"ratio": ratio_drift_metric})),
+        ("simple_distance", EvidentlyDriftDetector({"simple_distance": simple_distance_drift_metric})),
+    ]
+    for name, ad in detector:
+        assert isinstance(ad, EvidentlyDriftDetector)
+
+        # on h0
+        results = ad.detect_drift(df_data_ref, df_data_h0)
+        # if name == "mmd":
+        #     # bug in evidently, always uses reference data to detect drift
+        #     pass
+        # else:
+        assert not results[name].is_drift
+
+        # on current data
+        results = ad.detect_drift(df_data_ref, df_data_cur)
+        if name != "model":
+            # model makes the wrong decision here
+            assert results[name].is_drift
+        assert 0 <= results[name].distance <= (1 if name == "ratio" else 0.5)
+        assert results[name].metric_id == "EmbeddingsDriftMetric"
+
+    ad = EvidentlyDriftDetector(
+        {
+            "mmd": mmd_drift_metric,
+            "model": model_drift_metric,
+            "ratio": ratio_drift_metric,
+            "simple_distance": simple_distance_drift_metric,
+        }
+    )
+    results = ad.detect_drift(df_data_ref, df_data_cur)
+    assert len(results) == 4

--- a/modyn/tests/supervisor/internal/triggers/drift/test_evidently_detector.py
+++ b/modyn/tests/supervisor/internal/triggers/drift/test_evidently_detector.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from modyn.config.schema.pipeline import (
-    EvidentlyMmdDriftMetric,
     EvidentlyModelDriftMetric,
     EvidentlyRatioDriftMetric,
     EvidentlySimpleDistanceDriftMetric,
@@ -32,11 +30,6 @@ def df_data_cur(data_cur: np.ndarray) -> pd.DataFrame:
 
 
 @pytest.fixture
-def mmd_drift_metric() -> EvidentlyMmdDriftMetric:
-    return EvidentlyMmdDriftMetric(bootstrap=True)
-
-
-@pytest.fixture
 def model_drift_metric() -> EvidentlyModelDriftMetric:
     return EvidentlyModelDriftMetric(bootstrap=True)
 
@@ -55,7 +48,6 @@ def simple_distance_drift_metric() -> EvidentlySimpleDistanceDriftMetric:
 
 
 def test_evidently_detect_drift_metric(
-    mmd_drift_metric: EvidentlyMmdDriftMetric,
     model_drift_metric: EvidentlyModelDriftMetric,
     ratio_drift_metric: EvidentlyRatioDriftMetric,
     simple_distance_drift_metric: EvidentlySimpleDistanceDriftMetric,
@@ -64,7 +56,6 @@ def test_evidently_detect_drift_metric(
     df_data_cur: np.ndarray,
 ) -> None:
     detector = [
-        ("mmd", EvidentlyDriftDetector({"mmd": mmd_drift_metric})),
         ("model", EvidentlyDriftDetector({"model": model_drift_metric})),
         ("ratio", EvidentlyDriftDetector({"ratio": ratio_drift_metric})),
         ("simple_distance", EvidentlyDriftDetector({"simple_distance": simple_distance_drift_metric})),
@@ -74,10 +65,6 @@ def test_evidently_detect_drift_metric(
 
         # on h0
         results = ad.detect_drift(df_data_ref, df_data_h0)
-        # if name == "mmd":
-        #     # bug in evidently, always uses reference data to detect drift
-        #     pass
-        # else:
         assert not results[name].is_drift
 
         # on current data
@@ -90,11 +77,10 @@ def test_evidently_detect_drift_metric(
 
     ad = EvidentlyDriftDetector(
         {
-            "mmd": mmd_drift_metric,
             "model": model_drift_metric,
             "ratio": ratio_drift_metric,
             "simple_distance": simple_distance_drift_metric,
         }
     )
     results = ad.detect_drift(df_data_ref, df_data_cur)
-    assert len(results) == 4
+    assert len(results) == 3

--- a/modyn/tests/supervisor/internal/triggers/drift/test_modyn_detector.py
+++ b/modyn/tests/supervisor/internal/triggers/drift/test_modyn_detector.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pandas as pd
+from modyn.supervisor.internal.triggers.drift.metrics.mmd import mmd2_two_sample_test
+
+
+def _add_col_prefixes(df: pd.DataFrame, prefix: str) -> pd.DataFrame:
+    df.columns = [f"{prefix}{col}" for col in df.columns]
+    return df
+
+
+def test_modyn_mmd_metric(data_ref: np.ndarray, data_h0: np.ndarray, data_cur: np.ndarray) -> None:
+    # on h0
+    results = mmd2_two_sample_test(
+        reference_emb=data_ref,
+        current_emb=data_h0,
+        num_bootstraps=200,
+        quantile_probability=0.05,
+        num_workers=4,
+    )
+    assert not results.is_drift
+    assert 0.94 <= results.p_val < 1
+
+    # on current data
+    results = mmd2_two_sample_test(
+        reference_emb=data_ref,
+        current_emb=data_cur,
+        num_bootstraps=200,
+        quantile_probability=0.05,
+        num_workers=4,
+    )
+    assert results.is_drift
+    assert 0 <= results.distance <= 0.3

--- a/modyn/tests/supervisor/internal/triggers/test_datadrifttrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_datadrifttrigger.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from modyn.config.schema.pipeline import DataDriftTriggerConfig, ModynPipelineConfig
 from modyn.config.schema.pipeline.trigger.drift.aggregation import MajorityVoteDriftAggregationStrategy
-from modyn.config.schema.pipeline.trigger.drift.evidently import EvidentlyMmdDriftMetric
+from modyn.config.schema.pipeline.trigger.drift.alibi_detect import AlibiDetectMmdDriftMetric
 from modyn.config.schema.system.config import ModynConfig
 from modyn.supervisor.internal.triggers import DataDriftTrigger
 from modyn.supervisor.internal.triggers.embedding_encoder_utils import EmbeddingEncoderDownloader
@@ -23,7 +23,7 @@ SAMPLE = (10, 1, 1)
 def drift_trigger_config() -> DataDriftTriggerConfig:
     return DataDriftTriggerConfig(
         detection_interval_data_points=42,
-        metrics={"model": EvidentlyMmdDriftMetric()},
+        metrics={"model": AlibiDetectMmdDriftMetric()},
         aggregation_strategy=MajorityVoteDriftAggregationStrategy(),
     )
 


### PR DESCRIPTION
# Motivation

We want to be able to use both evidently and alibi-detect as they support different drift detection metrics as well as differ in their runtime performance.

For that we need a clean abstraction that allows us to delegate drift detection to the respective library

# Changes

- add `alibi-detect` dependency
- adjust drift detection abstraction via the `DriftDetector` interface
- introduce pydantic configurations models for alibi detect and evidently
- allow the collection and aggregation of multiple drift metrics.
- add tests for our embedding drift detection setup

# Note:

As this is rather big already, I'd like to get this merged before trying to run drift detection pipelines, so we might need slight adjustments in a followup PR.