### PR TITLE
Add rho training log to the pipeline file

### DIFF
--- a/modyn/config/schema/pipeline/sampling/downsampling_config.py
+++ b/modyn/config/schema/pipeline/sampling/downsampling_config.py
@@ -147,6 +147,9 @@ class ILTrainingConfig(TrainingConfig):
     initial_model: Literal["random"] = "random"
     initial_model_id: Literal[None] = None
     checkpointing: NoCheckpointingConfig = Field(default=NoCheckpointingConfig())
+    drop_last_batch: bool = Field(
+        default=False, description="Whether to drop the last batch if it is smaller than the batch size."
+    )
 
 
 class RHOLossDownsamplingConfig(BaseDownsamplingConfig):

--- a/modyn/selector/internal/selector_strategies/coreset_strategy.py
+++ b/modyn/selector/internal/selector_strategies/coreset_strategy.py
@@ -70,8 +70,9 @@ class CoresetStrategy(AbstractSelectionStrategy):
         # self._next_trigger_id after the call to super().trigger() because later the remote downsampler on trainer
         # server needs to fetch configuration for the current trigger
 
-        self.downsampling_scheduler.inform_next_trigger(self._next_trigger_id, self._storage_backend)
-        trigger_id, total_keys_in_trigger, num_partitions, log = super().trigger()
+        downsampler_log = self.downsampling_scheduler.inform_next_trigger(self._next_trigger_id, self._storage_backend)
+        trigger_id, total_keys_in_trigger, num_partitions, tss_log = super().trigger()
+        log: dict[str, object] = {"downsampler_log": downsampler_log, "trigger_sample_storage_log": tss_log}
         return trigger_id, total_keys_in_trigger, num_partitions, log
 
     def _on_trigger(self) -> Iterable[tuple[list[tuple[int, float]], dict[str, object]]]:

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/abstract_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/abstract_downsampling_strategy.py
@@ -64,7 +64,9 @@ class AbstractDownsamplingStrategy(ABC):
         return config
 
     # pylint: disable=unused-argument
-    def inform_next_trigger(self, next_trigger_id: int, selector_storage_backend: AbstractStorageBackend) -> None:
+    def inform_next_trigger(
+        self, next_trigger_id: int, selector_storage_backend: AbstractStorageBackend
+    ) -> dict[str, object]:
         """
         This function is used to inform the downsampler that the next trigger is reached.
 
@@ -73,4 +75,4 @@ class AbstractDownsamplingStrategy(ABC):
         """
 
         # by default, no preparation is needed
-        return
+        return {}

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/downsampling_scheduler.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/downsampling_scheduler.py
@@ -72,12 +72,14 @@ class DownsamplingScheduler:
     def training_status_bar_scale(self) -> int:
         return self.current_downsampler.status_bar_scale
 
-    def inform_next_trigger(self, next_trigger_id: int, selector_storage_backend: AbstractStorageBackend) -> None:
+    def inform_next_trigger(
+        self, next_trigger_id: int, selector_storage_backend: AbstractStorageBackend
+    ) -> dict[str, object]:
         if self.next_threshold is not None and next_trigger_id - self._warmup_triggers >= self.next_threshold:
             self.downsampler_index += 1
             self.current_downsampler, self.next_threshold = self._get_next_downsampler_and_threshold()
 
-        self.current_downsampler.inform_next_trigger(next_trigger_id, selector_storage_backend)
+        return self.current_downsampler.inform_next_trigger(next_trigger_id, selector_storage_backend)
 
 
 def instantiate_scheduler(config: CoresetStrategyConfig, modyn_config: dict, pipeline_id: int) -> DownsamplingScheduler:

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/rho_loss_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/rho_loss_downsampling_strategy.py
@@ -70,12 +70,13 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
         else:
             previous_model_id = None
         model_id, trainer_log = self._train_il_model(next_rho_trigger_id, previous_model_id)
+        rho_log["main_trigger_id"] = next_trigger_id
         rho_log["rho_trigger_id"] = next_rho_trigger_id
         rho_log["il_model_id"] = model_id
         rho_log["trainer_log"] = trainer_log
         logger.info(
-            f"Trained IL model {model_id} for trigger {next_rho_trigger_id} in rho pipeline"
-            f"{self.rho_pipeline_id} with rho trigger id {next_trigger_id}."
+            f"Trained IL model {model_id} for main trigger {next_trigger_id} in rho pipeline"
+            f"{self.rho_pipeline_id} with rho trigger id {next_rho_trigger_id}."
         )
         if self.holdout_set_strategy == "Twin":
             second_next_trigger_id = next_rho_trigger_id + 1
@@ -86,8 +87,8 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
             rho_log["second_il_model_id"] = second_model_id
             rho_log["second_trainer_log"] = second_trainer_log
             logger.info(
-                f"Twin strategy: Trained second IL model for trigger {next_trigger_id} in rho pipeline "
-                f"{self.rho_pipeline_id} with rho trigger id {next_trigger_id}."
+                f"Twin strategy: Trained second IL model for main trigger {next_trigger_id} in rho pipeline "
+                f"{self.rho_pipeline_id} with rho trigger id {second_next_trigger_id}."
             )
         self._clean_tmp_version(self._pipeline_id, next_trigger_id, selector_storage_backend)
         return rho_log

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/rho_loss_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/rho_loss_downsampling_strategy.py
@@ -44,10 +44,13 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
         self.rho_pipeline_id: int = rho_pipeline_id
         self.data_config = data_config
 
-    def inform_next_trigger(self, next_trigger_id: int, selector_storage_backend: AbstractStorageBackend) -> None:
+    # pylint: disable-next=too-many-locals
+    def inform_next_trigger(
+        self, next_trigger_id: int, selector_storage_backend: AbstractStorageBackend
+    ) -> dict[str, object]:
         if not isinstance(selector_storage_backend, DatabaseStorageBackend):
             raise ValueError("RHOLossDownsamplingStrategy requires a DatabaseStorageBackend")
-
+        rho_log: dict[str, object] = {}
         probability = self.holdout_set_ratio / self.holdout_set_ratio_max
 
         query = self._get_sampling_query(self._pipeline_id, next_trigger_id, probability, selector_storage_backend)
@@ -66,8 +69,10 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
             previous_model_id = last_model_id
         else:
             previous_model_id = None
-
-        model_id = self._train_il_model(next_rho_trigger_id, previous_model_id)
+        model_id, trainer_log = self._train_il_model(next_rho_trigger_id, previous_model_id)
+        rho_log["rho_trigger_id"] = next_rho_trigger_id
+        rho_log["il_model_id"] = model_id
+        rho_log["trainer_log"] = trainer_log
         logger.info(
             f"Trained IL model {model_id} for trigger {next_rho_trigger_id} in rho pipeline"
             f"{self.rho_pipeline_id} with rho trigger id {next_trigger_id}."
@@ -76,12 +81,16 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
             second_next_trigger_id = next_rho_trigger_id + 1
             second_query = self._get_rest_data_query(self._pipeline_id, next_trigger_id)
             self._persist_holdout_set(second_query, second_next_trigger_id, selector_storage_backend)
-            self._train_il_model(second_next_trigger_id, model_id)
+            second_model_id, second_trainer_log = self._train_il_model(second_next_trigger_id, model_id)
+            rho_log["second_rho_trigger_id"] = second_next_trigger_id
+            rho_log["second_il_model_id"] = second_model_id
+            rho_log["second_trainer_log"] = second_trainer_log
             logger.info(
                 f"Twin strategy: Trained second IL model for trigger {next_trigger_id} in rho pipeline "
                 f"{self.rho_pipeline_id} with rho trigger id {next_trigger_id}."
             )
         self._clean_tmp_version(self._pipeline_id, next_trigger_id, selector_storage_backend)
+        return rho_log
 
     @staticmethod
     def _clean_tmp_version(
@@ -138,7 +147,7 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
             assert il_model_id is not None
         return max_trigger_id, il_model_id
 
-    def _train_il_model(self, trigger_id: int, previous_model_id: Optional[int]) -> int:
+    def _train_il_model(self, trigger_id: int, previous_model_id: Optional[int]) -> Tuple[int, dict[str, object]]:
         training_id = self.grpc.start_training(
             pipeline_id=self.rho_pipeline_id,
             trigger_id=trigger_id,
@@ -146,10 +155,10 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
             data_config=self.data_config,
             previous_model_id=previous_model_id,
         )
-        self.grpc.wait_for_training_completion(training_id)
+        trainer_log = self.grpc.wait_for_training_completion(training_id)
         model_id = self.grpc.store_trained_model(training_id)
         logger.info(f"Stored trained model {model_id} for trigger {trigger_id} in rho pipeline {self.rho_pipeline_id}")
-        return model_id
+        return model_id, trainer_log
 
     def _get_or_create_rho_pipeline_id_and_get_data_config(self) -> Tuple[int, DataConfig]:
 

--- a/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
@@ -410,7 +410,7 @@ def test_inform_next_trigger_simple(
     return_value=True,
 )
 @patch.object(RHOLossDownsamplingStrategy, "_get_latest_rho_state")
-@patch.object(RHOLossDownsamplingStrategy, "_train_il_model", return_value=(42, {}))
+@patch.object(RHOLossDownsamplingStrategy, "_train_il_model")
 @patch.object(RHOLossDownsamplingStrategy, "_get_sampling_query")
 @patch.object(RHOLossDownsamplingStrategy, "_persist_holdout_set")
 @patch.object(RHOLossDownsamplingStrategy, "_clean_tmp_version")
@@ -443,7 +443,7 @@ def test_inform_next_trigger_twin(
     mock__get_sampling_query.return_value = mock_query
     mock_second_query = MagicMock()
     mock__get_rest_data_query.return_value = mock_second_query
-    mock__train_il_model.side_effect = [1, 2]
+    mock__train_il_model.side_effect = [(1, {}), (2, {})]
     mock_get_latest_rho_state.return_value = rho_state
 
     strategy = RHOLossDownsamplingStrategy(downsampling_config, modyn_config, pipeline_id, maximum_keys_in_memory)

--- a/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
@@ -410,7 +410,7 @@ def test_inform_next_trigger_simple(
     return_value=True,
 )
 @patch.object(RHOLossDownsamplingStrategy, "_get_latest_rho_state")
-@patch.object(RHOLossDownsamplingStrategy, "_train_il_model", return_value=42)
+@patch.object(RHOLossDownsamplingStrategy, "_train_il_model", return_value=(42, {}))
 @patch.object(RHOLossDownsamplingStrategy, "_get_sampling_query")
 @patch.object(RHOLossDownsamplingStrategy, "_persist_holdout_set")
 @patch.object(RHOLossDownsamplingStrategy, "_clean_tmp_version")

--- a/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
@@ -355,7 +355,7 @@ def test__train_il_model(
     return_value=True,
 )
 @patch.object(RHOLossDownsamplingStrategy, "_get_latest_rho_state")
-@patch.object(RHOLossDownsamplingStrategy, "_train_il_model", return_value=42)
+@patch.object(RHOLossDownsamplingStrategy, "_train_il_model", return_value=(42, {}))
 @patch.object(RHOLossDownsamplingStrategy, "_get_sampling_query")
 @patch.object(RHOLossDownsamplingStrategy, "_persist_holdout_set")
 @patch.object(RHOLossDownsamplingStrategy, "_clean_tmp_version")

--- a/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/downsampling_strategies/test_rho_loss_downsampling_strategy.py
@@ -337,7 +337,7 @@ def test__train_il_model(
 
     strategy = RHOLossDownsamplingStrategy(downsampling_config, modyn_config, pipeline_id, maximum_keys_in_memory)
     trigger_id = 1
-    model_id = strategy._train_il_model(trigger_id, previous_model_id)
+    model_id, _ = strategy._train_il_model(trigger_id, previous_model_id)
     mock_start_training.assert_called_once_with(
         pipeline_id=strategy.rho_pipeline_id,
         trigger_id=trigger_id,

--- a/modyn/trainer_server/internal/trainer/pytorch_trainer.py
+++ b/modyn/trainer_server/internal/trainer/pytorch_trainer.py
@@ -331,7 +331,7 @@ class PytorchTrainer:
                 if self._record_loss_every > 0 and trained_batches % self._record_loss_every == 0:
                     training_loss.append(loss.item())
 
-                self._num_samples += self._batch_size
+                self._num_samples += len(sample_ids)
 
                 stopw.start("OnBatchEnd", resume=True)
                 for _, callback in self._callbacks.items():

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/rho_loss_utils/irreducible_loss_producer.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/rho_loss_utils/irreducible_loss_producer.py
@@ -27,6 +27,7 @@ class IrreducibleLossProducer:
         il_model_id: int,
         device: str,
     ) -> None:
+        logger.info(f"rho pipeline {rho_pipeline_id} loading irreducible loss model {il_model_id}")
         self.model = IrreducibleLossProducer._load_il_model(modyn_config, rho_pipeline_id, il_model_id)
         self.model.model.eval()
         # We probably will train the main model for multiple epochs.


### PR DESCRIPTION
Per the title, this PR actually adds the log of downsampling phase at selector to the selector log, hence further to the pipeline log. The intention here is to see how well the il model is trained with the `record_loss_every`.