### PR TITLE
feat!: Batch evaluations in evaluator

### DIFF
--- a/analytics/app/data/transform.py
+++ b/analytics/app/data/transform.py
@@ -134,7 +134,7 @@ def dfs_models_and_evals(
             run
             for run in logs.supervisor_logs.stage_runs
             if (
-                run.id == PipelineStage.EVALUATE_SINGLE.name
+                run.id == PipelineStage.EVALUATE_MULTI.name
                 and run.info.failure_reason is None
                 and run.info.eval_request
             )
@@ -146,9 +146,7 @@ def dfs_models_and_evals(
         (
             cast(SingleEvaluationInfo, run.info)
             for run in logs.supervisor_logs.stage_runs
-            if run.id == PipelineStage.EVALUATE_SINGLE.name
-            and run.info.failure_reason is None
-            and run.info.eval_request
+            if run.id == PipelineStage.EVALUATE_MULTI.name and run.info.failure_reason is None and run.info.eval_request
         )
     )
 

--- a/analytics/tools/aggregate_runs/core_aggregation.py
+++ b/analytics/tools/aggregate_runs/core_aggregation.py
@@ -108,7 +108,7 @@ def aggregate_eval_metrics(df_eval_single: pd.DataFrame, logs: list[PipelineLogs
 
     aggregated_logs = deepcopy(logs[0])
     for log in aggregated_logs.supervisor_logs.stage_runs:
-        if log.id == PipelineStage.EVALUATE_SINGLE.name:
+        if log.id == PipelineStage.EVALUATE_MULTI.name:
             assert isinstance(log.info, SingleEvaluationInfo)
             if not log.info.results:
                 continue

--- a/analytics/tools/aggregate_runs/pipeline_equivalence.py
+++ b/analytics/tools/aggregate_runs/pipeline_equivalence.py
@@ -16,8 +16,12 @@ def assert_pipeline_equivalence(logs: list[PipelineLogs]) -> None:
         candidate.config.pipeline.training.seed = candidates[0].config.pipeline.training.seed
         candidate.config.pipeline.training.device = candidates[0].config.pipeline.training.device
         candidate.config.pipeline.evaluation.device = candidates[0].config.pipeline.evaluation.device
-        candidate.config.pipeline.evaluation.after_pipeline_evaluation_workers = candidates[0].config.pipeline.evaluation.after_pipeline_evaluation_workers
-        candidate.config.pipeline.evaluation.after_training_evaluation_workers = candidates[0].config.pipeline.evaluation.after_training_evaluation_workers
+        candidate.config.pipeline.evaluation.after_pipeline_evaluation_workers = candidates[
+            0
+        ].config.pipeline.evaluation.after_pipeline_evaluation_workers
+        candidate.config.pipeline.evaluation.after_training_evaluation_workers = candidates[
+            0
+        ].config.pipeline.evaluation.after_training_evaluation_workers
 
         if isinstance(candidate.config.pipeline.selection_strategy, CoresetStrategyConfig) and isinstance(
             candidate.config.pipeline.selection_strategy.downsampling_config, RHOLossDownsamplingConfig

--- a/analytics/tools/patch_logfile.ipynb
+++ b/analytics/tools/patch_logfile.ipynb
@@ -126,7 +126,7 @@
    "outputs": [],
    "source": [
     "for eval_log in logs.supervisor_logs.stage_runs:\n",
-    "    if eval_log.id == PipelineStage.EVALUATE_SINGLE.name:\n",
+    "    if eval_log.id == PipelineStage.EVALUATE_MULTI.name:\n",
     "        # For a fixed interval the evaluation request of a certain model is the most recent, if the model training\n",
     "        # interval center lies within the evaluation interval.\n",
     "        # Note: this is not a generic solution, but works for the slicing case with fixed evaluation and trigger\n",
@@ -162,7 +162,7 @@
     "    df_models, eval_requests, evals_metrics = dfs_models_and_evals(logs, max_timestamp)\n",
     "\n",
     "    for eval_log in logs.supervisor_logs.stage_runs:\n",
-    "        if eval_log.id == PipelineStage.EVALUATE_SINGLE.name:\n",
+    "        if eval_log.id == PipelineStage.EVALUATE_MULTI.name:\n",
     "            # Let's throw away all information about the most recent model, let's rebuild it\n",
     "            eval_log.info.eval_request.currently_active_model = False\n",
     "\n",
@@ -306,7 +306,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.1.-1"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/integrationtests/evaluator/integrationtest_evaluator.py
+++ b/integrationtests/evaluator/integrationtest_evaluator.py
@@ -2,7 +2,7 @@ import json
 import pathlib
 import shutil
 import time
-from typing import Optional, Tuple
+from typing import Tuple
 
 import torch
 from integrationtests.utils import MODYN_MODELS_PATH, ImageDatasetHelper, connect_to_server, get_modyn_config

--- a/modyn/supervisor/internal/grpc/enums.py
+++ b/modyn/supervisor/internal/grpc/enums.py
@@ -63,7 +63,7 @@ class PipelineStage(StrEnum):
 
     # Evaluation
     EVALUATE = "Run evaluation"
-    EVALUATE_SINGLE = "Run single evaluation"
+    EVALUATE_MULTI = "Run multiple interval evaluations for one model"
     WAIT_FOR_EVALUATION_COMPLETION = "Wait for evaluation completion"
     POST_EVALUATION_CHECKPOINT = "Save pipeline metadata as checkpoint"
     POST_EVALUATION = "Post pipeline evaluation"

--- a/modyn/supervisor/internal/pipeline_executor/PIPELINE.md
+++ b/modyn/supervisor/internal/pipeline_executor/PIPELINE.md
@@ -41,8 +41,8 @@ stateDiagram-v2
                 }
                 state evaluation {
                     [*] --> EVALUATE
-                    EVALUATE --> EVALUATE_SINGLE
-                    EVALUATE_SINGLE -->  [*]
+                    EVALUATE --> EVALUATE_MULTI
+                    EVALUATE_MULTI -->  [*]
                 }
                 train_and_store_model --> evaluation
             }

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -268,11 +268,12 @@ class EvaluationExecutor:
                 sample_idx=parent_log.sample_idx,
                 sample_time=parent_log.sample_time,
                 trigger_idx=parent_log.trigger_idx,
-                info=MultiEvaluationInfo(
-                    dataset_id=dataset_id,
-                    model_id=model_id,
-                    interval_results=interval_result_infos,
-                ),
+                info=None,
+            )
+            single_log.info = MultiEvaluationInfo(
+                dataset_id=dataset_id,
+                id_model=model_id,
+                interval_results=interval_result_infos,
             )
             single_log.end = datetime.datetime.now()
             single_log.duration = datetime.timedelta(microseconds=current_time_micros() - epoch_micros_start)

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -8,10 +8,13 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Optional
+from typing import Any, cast
 
 import grpc
 import pandas as pd
+from pydantic import BaseModel
+from tenacity import Retrying, stop_after_attempt, wait_random_exponential
+
 from modyn.config.schema.pipeline import ModynPipelineConfig
 from modyn.config.schema.system import ModynConfig
 
@@ -22,14 +25,13 @@ from modyn.supervisor.internal.grpc.enums import PipelineStage
 from modyn.supervisor.internal.grpc_handler import GRPCHandler
 from modyn.supervisor.internal.pipeline_executor.models import (
     ConfigLogs,
+    MultiEvaluationInfo,
     PipelineLogs,
     SingleEvaluationInfo,
     StageLog,
     SupervisorLogs,
 )
 from modyn.utils.utils import current_time_micros, dynamic_module_import
-from pydantic import BaseModel
-from tenacity import Retrying, stop_after_attempt, wait_random_exponential
 
 eval_strategy_module = dynamic_module_import("modyn.supervisor.internal.eval.strategies")
 
@@ -186,6 +188,7 @@ class EvaluationExecutor:
 
         if len(eval_requests) == 0:
             return SupervisorLogs()
+
         # self.Eval_handlers is not an empty list if and only if self.pipeline.evaluation is not None
         assert self.pipeline.evaluation is not None
 
@@ -194,7 +197,7 @@ class EvaluationExecutor:
             # as we don't execute this during the training pipeline, we don't have a reference how
             # our current process is in terms of position in the dataset.
             parent_log=StageLog(
-                id=PipelineStage.EVALUATE_SINGLE.name,
+                id=PipelineStage.EVALUATE_MULTI.name,
                 id_seq_num=-1,
                 start=datetime.datetime.now(),
                 batch_idx=-1,
@@ -226,33 +229,60 @@ class EvaluationExecutor:
         tasks: list[Future[StageLog]] = []
         logs = SupervisorLogs()
 
-        def worker_func(eval_req: EvalRequest) -> StageLog:
+        # do batching by (dataset_id, model_id)
+        eval_requests_by_model: dict[tuple[str, int], list[EvalRequest]] = {}
+        for eval_req in eval_requests:
+            key_ = (eval_req.dataset_id, eval_req.id_model)
+            eval_requests_by_model[key_] = eval_requests_by_model.get(key_, []) + [eval_req]
+
+        def worker_func(model_eval_req: tuple[tuple[str, int], list[EvalRequest]]) -> StageLog:
+            """
+            Args:
+                model_eval_req: A tuple of model_id and a list of evaluation requests for that model.
+            """
+            dataset_id = model_eval_req[0][0]
+            model_id = model_eval_req[0][1]
+            eval_requests = model_eval_req[1]
+            intervals = [(eval_req.interval_start, eval_req.interval_end) for eval_req in eval_requests]
+
+            epoch_micros_start = current_time_micros()
+
+            # intervals and results are in the same order
+            results = self._single_batched_evaluation(intervals, model_id, dataset_id)
+
+            interval_result_infos: list[SingleEvaluationInfo] = []
+            intervals_and_results = zip(eval_requests, results)
+            for eval_req, (failure_reason, interval_res) in intervals_and_results:
+                interval_result_infos.append(
+                    SingleEvaluationInfo(
+                        eval_request=eval_req,
+                        failure_reason=failure_reason if failure_reason else None,
+                        results=interval_res if not failure_reason else {},
+                    )
+                )
+
             single_log = StageLog(
-                id=PipelineStage.EVALUATE_SINGLE.name,
+                id=PipelineStage.EVALUATE_MULTI.name,
                 id_seq_num=-1,  # evaluation don't need sequence numbers, their order is not important
                 start=datetime.datetime.now(),
                 batch_idx=parent_log.batch_idx,
                 sample_idx=parent_log.sample_idx,
                 sample_time=parent_log.sample_time,
                 trigger_idx=parent_log.trigger_idx,
+                info=MultiEvaluationInfo(
+                    dataset_id=dataset_id,
+                    model_id=model_id,
+                    interval_results=interval_result_infos,
+                ),
             )
-            epoch_micros_start = current_time_micros()
-            single_log.info = SingleEvaluationInfo(eval_request=eval_req)
-            optional_failure_reason, results = self._single_batched_evaluation(
-                eval_req.interval_start, eval_req.interval_end, eval_req.id_model, eval_req.dataset_id
-            )
-            if optional_failure_reason:
-                single_log.info.failure_reason = optional_failure_reason
-            else:
-                single_log.info.results = results
             single_log.end = datetime.datetime.now()
             single_log.duration = datetime.timedelta(microseconds=current_time_micros() - epoch_micros_start)
             return single_log
 
         # As we are io bound by the evaluator server, GIL locking isn't a concern, so we can use multithreading.
         with ThreadPoolExecutor(max_workers=num_workers) as pool:
-            for eval_req in eval_requests:
-                task = partial(worker_func, eval_req)
+            for r in eval_requests_by_model.items():
+                task = partial(worker_func, r)
                 tasks.append(pool.submit(task))
 
             # join threads
@@ -264,16 +294,20 @@ class EvaluationExecutor:
     # pylint: disable-next=too-many-locals
     def _single_batched_evaluation(
         self,
-        interval_start: int,
-        interval_end: Optional[int],
+        intervals: list[tuple[int, int | None]],
         model_id_to_eval: int,
         dataset_id: str,
-    ) -> tuple[Optional[str], dict]:
+    ) -> list[tuple[str | None, dict]]:
+        """Takes a list of intervals to be evaluated for a certain model and dataset.
+
+        Returns:
+            A list of tuples, where the first element is the failure reason (if any) and the second element is the
+            evaluation results. The order of the tuples corresponds to the order of the intervals.
+        """
         assert self.grpc.evaluator is not None, "Evaluator not initialized."
         assert self.pipeline.evaluation
         logger.info(
-            f"Evaluation Starts for model {model_id_to_eval} on split {interval_start} "
-            f"to {interval_end} of dataset {dataset_id}."
+            f"Evaluation Starts for model {model_id_to_eval} and dataset {dataset_id} on intervals:  {intervals}."
         )
         dataset_config = next((d for d in self.pipeline.evaluation.datasets if d.dataset_id == dataset_id))
 
@@ -281,7 +315,7 @@ class EvaluationExecutor:
             dataset_config.model_dump(by_alias=True),
             model_id_to_eval,
             self.pipeline.evaluation.device,
-            intervals=[(interval_start, interval_end)],
+            intervals=cast(list[tuple[int | None, int | None]], intervals),
         )
         for attempt in Retrying(
             stop=stop_after_attempt(5), wait=wait_random_exponential(multiplier=1, min=2, max=60), reraise=True
@@ -295,30 +329,52 @@ class EvaluationExecutor:
                     self.grpc.init_evaluator()
                     raise e
 
+        assert len(response.interval_responses) == len(
+            intervals
+        ), f"We expected {len(intervals)} intervals, but got {len(response.interval_responses)}."
+
         def get_failure_reason(eval_aborted_reason: EvaluationAbortedReason) -> str:
             return EvaluationAbortedReason.DESCRIPTOR.values_by_number[eval_aborted_reason].name
 
         if not response.evaluation_started:
-            failure_reason = get_failure_reason(response.interval_responses[0].eval_aborted_reason)
-            logger.error(
-                f"Evaluation for model {model_id_to_eval} on split {interval_start} to "
-                f"{interval_end} not started with reason: {failure_reason}."
-            )
-            return failure_reason, {}
+            failure_reasons: list[tuple[str | None, dict]] = []
+            # note: interval indexes correspond to the intervals in the request
+            for interval_idx, interval_response in enumerate(response.interval_responses):
+                if interval_response.eval_aborted_reason != EvaluationAbortedReason.NOT_ABORTED:
+                    reason = get_failure_reason(interval_response.eval_aborted_reason)
+                    failure_reasons.append((reason, {}))
+                    logger.error(
+                        f"Evaluation for model {model_id_to_eval} on split {intervals[interval_idx]} "
+                        f"not started with reason: {reason}."
+                    )
+            return failure_reasons
 
-        logger.info(f"Evaluation started for model {model_id_to_eval} on split {interval_start} " f"to {interval_end}.")
+        logger.info(f"Evaluation started for model {model_id_to_eval} on intervals {intervals}.")
         self.grpc.wait_for_evaluation_completion(response.evaluation_id)
         eval_data = self.grpc.get_evaluation_results(response.evaluation_id)
         self.grpc.cleanup_evaluations([response.evaluation_id])
-        # here we assume only one interval is evaluated
-        eval_results: dict = {"dataset_size": response.interval_responses[0].dataset_size, "metrics": []}
 
-        assert len(eval_data) == 1, "The evaluation request only contains one interval so we expect only one result."
-        assert eval_data[0].interval_index == 0
-        for metric in eval_data[0].evaluation_data:
-            eval_results["metrics"].append({"name": metric.metric, "result": metric.result})
+        eval_results: list[tuple[str | None, dict[str, Any]]] = []
+        assert len(eval_data) == len(intervals), f"We expected {len(intervals)} intervals, but got {len(eval_data)}."
+        assert eval_data
 
-        return None, eval_results
+        # as the dataset_size comes from the `EvaluateModelResponse` and response is a dense list (no intervals are
+        # skipped), we build a list of results with the same order as the intervals.
+        # the metrics will be filled in the next loop that unwraps `EvaluationResultResponse`.
+        for interval_response in response.interval_responses:
+            if interval_response.eval_aborted_reason != EvaluationAbortedReason.NOT_ABORTED:
+                reason = get_failure_reason(interval_response.eval_aborted_reason)
+                eval_results.append((reason, {}))
+            else:
+                eval_results.append((None, {"dataset_size": interval_response.dataset_size, "metrics": []}))
+
+        for interval_result in eval_data:
+            interval_idx = interval_result.interval_index
+            assert eval_results[interval_idx][0] is None, "Evaluation failed, no metrics should be present."
+            eval_results[interval_idx][1]["metrics"] = [
+                {"name": metric.metric, "result": metric.result} for metric in interval_result.evaluation_data
+            ]
+        return eval_results
 
 
 # ------------------------------------------------------------------------------------ #

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -12,9 +12,6 @@ from typing import Any, cast
 
 import grpc
 import pandas as pd
-from pydantic import BaseModel
-from tenacity import Retrying, stop_after_attempt, wait_random_exponential
-
 from modyn.config.schema.pipeline import ModynPipelineConfig
 from modyn.config.schema.system import ModynConfig
 
@@ -32,6 +29,8 @@ from modyn.supervisor.internal.pipeline_executor.models import (
     SupervisorLogs,
 )
 from modyn.utils.utils import current_time_micros, dynamic_module_import
+from pydantic import BaseModel
+from tenacity import Retrying, stop_after_attempt, wait_random_exponential
 
 eval_strategy_module = dynamic_module_import("modyn.supervisor.internal.eval.strategies")
 

--- a/modyn/supervisor/internal/pipeline_executor/models.py
+++ b/modyn/supervisor/internal/pipeline_executor/models.py
@@ -401,6 +401,7 @@ StageInfoUnion = Union[
     TriggerExecutionInfo,
     TrainingInfo,
     StoreModelInfo,
+    MultiEvaluationInfo,
     SingleEvaluationInfo,
     SelectorInformInfo,
 ]

--- a/modyn/supervisor/internal/pipeline_executor/models.py
+++ b/modyn/supervisor/internal/pipeline_executor/models.py
@@ -362,6 +362,12 @@ class SingleEvaluationInfo(StageInfo):
         )
 
 
+class MultiEvaluationInfo(StageInfo):
+    dataset_id: str
+    id_model: int
+    interval_results: list[SingleEvaluationInfo] = []
+
+
 class SelectorInformInfo(StageInfo):
     selector_log: dict[str, Any] | None
     remaining_data: bool

--- a/modyn/supervisor/internal/pipeline_executor/models.py
+++ b/modyn/supervisor/internal/pipeline_executor/models.py
@@ -321,28 +321,44 @@ class SingleEvaluationInfo(StageInfo):
             self.results.get("dataset_size", 0),
         )
 
+
+class MultiEvaluationInfo(StageInfo):
+    dataset_id: str
+    id_model: int
+    interval_results: list[SingleEvaluationInfo] = []
+
+    def df_columns(self) -> list[str]:
+        """Provide the column names of the DataFrame representation of the data."""
+        return ["id_model", "dataset_id", "num_intervals"]
+
+    @override
+    @property
+    def df_row(self) -> tuple:
+        return (self.id_model, self.dataset_id, len(self.interval_results))
+
     @classmethod
-    def results_df(cls, infos: list[SingleEvaluationInfo]) -> pd.DataFrame:
+    def results_df(cls, infos: list[MultiEvaluationInfo]) -> pd.DataFrame:
         """As one evaluation can have multiple metrics, we return a DataFrame with one row per metric."""
         return pd.DataFrame(
             [
                 (
                     # per request
-                    info.eval_request.trigger_id,
-                    info.eval_request.training_id,
-                    info.eval_request.id_model,
-                    info.eval_request.currently_active_model,
-                    info.eval_request.currently_trained_model,
-                    info.eval_request.eval_handler,
-                    info.eval_request.dataset_id,
-                    info.eval_request.interval_start,
-                    info.eval_request.interval_end,
-                    info.results.get("dataset_size", 0),
+                    single_info.eval_request.trigger_id,
+                    single_info.eval_request.training_id,
+                    single_info.eval_request.id_model,
+                    single_info.eval_request.currently_active_model,
+                    single_info.eval_request.currently_trained_model,
+                    single_info.eval_request.eval_handler,
+                    single_info.eval_request.dataset_id,
+                    single_info.eval_request.interval_start,
+                    single_info.eval_request.interval_end,
+                    single_info.results.get("dataset_size", 0),
                     # per metric
                     metric["name"],
                     metric["result"],
                 )
-                for info in infos
+                for single_info in infos
+                for info in single_info
                 for metric in info.results["metrics"]  # pylint: disable=unsubscriptable-object
             ],
             columns=[
@@ -360,12 +376,6 @@ class SingleEvaluationInfo(StageInfo):
                 "value",
             ],
         )
-
-
-class MultiEvaluationInfo(StageInfo):
-    dataset_id: str
-    id_model: int
-    interval_results: list[SingleEvaluationInfo] = []
 
 
 class SelectorInformInfo(StageInfo):


### PR DESCRIPTION
# Motivation

We want to utilize the batching logic introduced in https://github.com/eth-easl/modyn/pull/554 by grouping requests in the supervisor.

This will break the analytics tool because of the adjusted logging. Once we have a completed run I'll open a followup PR.