### PR TITLE
Enable finetuning on `RHO-LOSS` selection strategy when `Twin` strategy is used to produce the irreducible loss model

### DIFF
--- a/modyn/models/rho_loss_twin_model/rho_loss_twin_model.py
+++ b/modyn/models/rho_loss_twin_model/rho_loss_twin_model.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Mapping
 
 import torch
 from modyn.utils import dynamic_module_import
@@ -57,6 +57,10 @@ class RHOLOSSTwinModelModyn(nn.Module):
         # 4. The model is loaded again in the irreducible loss producer.
         # The value of self._current_model does not matter as we do not re-store it.
         self._current_model = 1 - previous_model
+
+        if previous_model == 1 and self.training:
+            logger.info("Finetune on a model that has been trained before. Resetting seen ids.")
+            self._models_seen_ids = [set(), set()]
 
     def forward(self, data: torch.Tensor, sample_ids: Optional[list[int]] = None) -> torch.Tensor:
         assert sample_ids is not None

--- a/modyn/models/rho_loss_twin_model/rho_loss_twin_model.py
+++ b/modyn/models/rho_loss_twin_model/rho_loss_twin_model.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Mapping
+from typing import Any, Optional
 
 import torch
 from modyn.utils import dynamic_module_import

--- a/modyn/selector/internal/selector_strategies/downsampling_strategies/rho_loss_downsampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/downsampling_strategies/rho_loss_downsampling_strategy.py
@@ -64,8 +64,6 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
             last_model_id = None
         self._persist_holdout_set(query, next_rho_trigger_id, selector_storage_backend)
         if self.il_training_config.use_previous_model:
-            if self.holdout_set_strategy == "Twin":
-                raise NotImplementedError("Use previous model currently is not supported for Twin strategy")
             previous_model_id = last_model_id
         else:
             previous_model_id = None
@@ -82,6 +80,8 @@ class RHOLossDownsamplingStrategy(AbstractDownsamplingStrategy):
             second_next_trigger_id = next_rho_trigger_id + 1
             second_query = self._get_rest_data_query(self._pipeline_id, next_trigger_id)
             self._persist_holdout_set(second_query, second_next_trigger_id, selector_storage_backend)
+            # the second training continues from the first training, that's why we finetune from
+            # the first training's model id
             second_model_id, second_trainer_log = self._train_il_model(second_next_trigger_id, model_id)
             rho_log["second_rho_trigger_id"] = second_next_trigger_id
             rho_log["second_il_model_id"] = second_model_id

--- a/modyn/tests/models/test_rho_loss_twin_model.py
+++ b/modyn/tests/models/test_rho_loss_twin_model.py
@@ -162,3 +162,4 @@ def test_backup_and_restore_state(current_model: int, training_mode: bool, twin_
         assert torch.allclose(new_twin_model.model._models[0].output.bias, torch.zeros(2))
         assert torch.allclose(new_twin_model.model._models[1].output.weight, torch.ones(2, 2))
         assert torch.allclose(new_twin_model.model._models[1].output.bias, torch.ones(2))
+        assert new_twin_model.model.training == training_mode

--- a/modyn/tests/models/test_rho_loss_twin_model.py
+++ b/modyn/tests/models/test_rho_loss_twin_model.py
@@ -123,9 +123,11 @@ def test_eval_forward_mixed(twin_model: RHOLOSSTwinModel):
     assert torch.allclose(output, torch.tensor([[1.0] * 10, [0.0] * 10, [0.0] * 10, [1.0] * 10, [0.0] * 10]))
 
 
-def test_backup_and_restore_state(twin_model: RHOLOSSTwinModel):
-    twin_model.model._models_seen_ids = [{1, 2, 3}, {}]
-    assert twin_model.model._current_model == 0
+@pytest.mark.parametrize("current_model", [0, 1])
+def test_backup_and_restore_state(current_model: int, twin_model: RHOLOSSTwinModel):
+    model_seen_ids = [{1, 2, 3}, {4, 5}]
+    twin_model.model._models_seen_ids = model_seen_ids
+    twin_model.model._current_model = current_model
     twin_model.model._models[0].output.weight = torch.nn.Parameter(torch.zeros(2, 2))
     twin_model.model._models[0].output.bias = torch.nn.Parameter(torch.zeros(2))
     twin_model.model._models[1].output.weight = torch.nn.Parameter(torch.ones(2, 2))
@@ -149,8 +151,8 @@ def test_backup_and_restore_state(twin_model: RHOLOSSTwinModel):
             checkpoint = torch.load(io.BytesIO(f.read()), map_location="cpu")
             new_twin_model.model.load_state_dict(checkpoint["model"])
 
-        assert new_twin_model.model._models_seen_ids == [{1, 2, 3}, {}]
-        assert new_twin_model.model._current_model == 1
+        assert new_twin_model.model._models_seen_ids == model_seen_ids
+        assert new_twin_model.model._current_model == 1 - current_model
         assert torch.allclose(new_twin_model.model._models[0].output.weight, torch.zeros(2, 2))
         assert torch.allclose(new_twin_model.model._models[0].output.bias, torch.zeros(2))
         assert torch.allclose(new_twin_model.model._models[1].output.weight, torch.ones(2, 2))

--- a/modyn/tests/supervisor/internal/eval/test_eval_handler.py
+++ b/modyn/tests/supervisor/internal/eval/test_eval_handler.py
@@ -1,7 +1,6 @@
 from typing import Iterable
 
 import pandas as pd
-
 from modyn.config.schema.pipeline.evaluation.handler import EvalHandlerConfig
 from modyn.config.schema.pipeline.evaluation.strategy.between_two_triggers import BetweenTwoTriggersEvalStrategyConfig
 from modyn.config.schema.pipeline.evaluation.strategy.static import StaticEvalStrategyConfig

--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_rho_loss_downsampling.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_remote_rho_loss_downsampling.py
@@ -45,13 +45,13 @@ def dummy_init_params(dummy_system_config: ModynConfig):
     }
 
 
-@patch.object(IrreducibleLossProducer, "_load_il_model", return_value=dummy_model())
+@patch.object(IrreducibleLossProducer, "_load_il_eval_model", return_value=dummy_model())
 @patch.object(AbstractRemoteDownsamplingStrategy, "__init__")
 @patch(
     "modyn.trainer_server.internal.trainer.remote_downsamplers.remote_rho_loss_downsampling.IrreducibleLossProducer",
     wraps=IrreducibleLossProducer,
 )
-def test__init__(MockIRLossProducer, mock_abstract_sampler_init__, mock__load_il_model, dummy_init_params):
+def test__init__(MockIRLossProducer, mock_abstract_sampler_init__, mock__load_il_eval_model, dummy_init_params):
     sampler = RemoteRHOLossDownsampling(**dummy_init_params)
     assert sampler.per_sample_loss_fct == dummy_init_params["per_sample_loss"]
     assert not sampler.requires_grad
@@ -72,8 +72,8 @@ def test__init__(MockIRLossProducer, mock_abstract_sampler_init__, mock__load_il
     )
 
 
-@patch.object(IrreducibleLossProducer, "_load_il_model", return_value=dummy_model())
-def test_inform_samples(mock__load_il_model, dummy_init_params):
+@patch.object(IrreducibleLossProducer, "_load_il_eval_model", return_value=dummy_model())
+def test_inform_samples(mock__load_il_eval_model, dummy_init_params):
     batch_size = 3
 
     def fake_per_sample_loss(forward_output, target):
@@ -111,8 +111,8 @@ def test_inform_samples(mock__load_il_model, dummy_init_params):
         assert torch.allclose(mock_per_sample_loss.call_args[0][1], target)
 
 
-@patch.object(IrreducibleLossProducer, "_load_il_model", return_value=dummy_model())
-def test_select_points(mock__load_il_model, dummy_init_params):
+@patch.object(IrreducibleLossProducer, "_load_il_eval_model", return_value=dummy_model())
+def test_select_points(mock__load_il_eval_model, dummy_init_params):
     dummy_init_params["batch_size"] = 5
     dummy_init_params["params_from_selector"]["downsampling_ratio"] = 60
     sampler = RemoteRHOLossDownsampling(**dummy_init_params)
@@ -124,8 +124,8 @@ def test_select_points(mock__load_il_model, dummy_init_params):
     assert torch.allclose(weights, torch.tensor([1.0, 1.0, 1.0]))
 
 
-@patch.object(IrreducibleLossProducer, "_load_il_model", return_value=dummy_model())
-def test_sample_then_batch(mock__load_il_model, dummy_init_params):
+@patch.object(IrreducibleLossProducer, "_load_il_eval_model", return_value=dummy_model())
+def test_sample_then_batch(mock__load_il_eval_model, dummy_init_params):
     batch_size = 3
     num_batches = 5
     data_size = num_batches * batch_size

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/rho_loss_utils/irreducible_loss_producer.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/rho_loss_utils/irreducible_loss_producer.py
@@ -28,7 +28,7 @@ class IrreducibleLossProducer:
         device: str,
     ) -> None:
         logger.info(f"rho pipeline {rho_pipeline_id} loading irreducible loss model {il_model_id}")
-        self.model = IrreducibleLossProducer._load_il_model(modyn_config, rho_pipeline_id, il_model_id)
+        self.model = IrreducibleLossProducer._load_il_eval_model(modyn_config, rho_pipeline_id, il_model_id)
         self.model.model.eval()
         # We probably will train the main model for multiple epochs.
         # The first time we consume a sample, we compute the irreducible loss from the il model.
@@ -73,9 +73,12 @@ class IrreducibleLossProducer:
         return model
 
     @staticmethod
-    def _load_il_model(modyn_config: dict, rho_pipeline_id: int, il_model_id: int) -> Any:
+    def _load_il_eval_model(modyn_config: dict, rho_pipeline_id: int, il_model_id: int) -> Any:
         # load the model architecture
         model = IrreducibleLossProducer._load_il_model_architecture(modyn_config, rho_pipeline_id)
+        # we need to set the model to eval mode before loading the weights
+        # as RHOLossTwinModel has different load_state_dict logic for training and eval mode
+        model.model.eval()
         # load the weights
         model_storage_stub = IrreducibleLossProducer.connect_to_model_storage(
             f"{modyn_config['model_storage']['hostname']}:{modyn_config['model_storage']['port']}"


### PR DESCRIPTION
Per the title