### PR TITLE
feat: Add `nbstripout`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,10 @@ repos:
     rev: v1.20.9
     hooks:
       - id: typos
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.7.1
+    hooks:
+      - id: nbstripout
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:


### PR DESCRIPTION
# Motivation

As we have a couple of Jupyter notebooks in the repo now, let's ensure nobody commits the notebooks without clearing the outputs.