### PR TITLE
fix: Restore old caching in CI

### DIFF
--- a/.github/actions/mamba/action.yml
+++ b/.github/actions/mamba/action.yml
@@ -10,11 +10,21 @@ runs:
       run: sudo apt-get install --no-install-recommends -qy libdw-dev libelf-dev
       shell: bash
 
+    - name: Set cache date
+      run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+      shell: bash
+
+    # increase to reset cache manually
+    - name: Set cache number
+      run: echo "CACHE_NUMBER=2" >> $GITHUB_ENV
+      shell: bash
+
     - name: Setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: environment.yml
-        cache-environment: true
+        cache-environment-key: environment-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        cache-downloads-key: downloads-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         init-shell: bash
 
     - name: Install dev requirements

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -32,11 +32,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Conda env
-        uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822
-        with:
-          environment-file: environment.yml
-          cache-environment: true
+      - name: Setup mamba
+        uses: ./.github/actions/mamba
       - name: Install repository
         run: |
           python -m pip install --no-build-isolation --no-deps --disable-pip-version-check -e .

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
+
       - name: Run pre-commit-conda
         uses: quantco/pre-commit-conda@v1
 
@@ -32,12 +33,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Setup mamba
         uses: ./.github/actions/mamba
+
       - name: Install repository
         run: |
           python -m pip install --no-build-isolation --no-deps --disable-pip-version-check -e .
           micromamba run -n modyn pip install -r dev-requirements.txt
+
       - name: Run mypy
         run: mypy .
 


### PR DESCRIPTION
**Benefit**: central configuration of environment setup.

**Note**: mypy ci job will run ~1 min slower due to additional (unnecessary) dependencies in `dev-requirements.txt` and the apt install from the local action.