### PR TITLE
fix: Add `nltk` dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -39,6 +39,7 @@ dependencies:
   - types-psycopg2
   - types-PyYAML
   - transformers
+  - nltk
   - pytorch::pytorch=2.2.1
   - pytorch::torchvision
   - pytorch::cpuonly # comment out if commenting in lines below for CUDA


### PR DESCRIPTION
CI started failing because of missing `nltk`. I suspect that some of our packages remove transitive dependency to `nltk` or introduced this new dependency without recording it in the package dependencies.