### PR TITLE
fix: `PerformanceTrigger` batch pointer

### DIFF
--- a/modyn/supervisor/internal/triggers/performancetrigger.py
+++ b/modyn/supervisor/internal/triggers/performancetrigger.py
@@ -171,7 +171,15 @@ class PerformanceTrigger(Trigger):
                 for policy in self.decision_policies.values():
                     policy.inform_trigger()  # resets the internal state (e.g. misclassification counters)
 
-            trigger_idx = processing_head_in_batch - 1
+            # we need to return an index in the `new_data`. Therefore, we need to subtract number of samples in the
+            # leftover data from the processing head in batch; -1 is required as the head points to the first
+            # unprocessed data point
+            trigger_idx = min(
+                max(processing_head_in_batch - len(self._leftover_data) - 1, 0),
+                len(new_data) - 1,
+            )
+
+            # -------------------------------------------------- Log ------------------------------------------------- #
 
             drift_eval_log = PerformanceTriggerEvalLog(
                 triggered=triggered,
@@ -187,6 +195,8 @@ class PerformanceTrigger(Trigger):
             )
             if log:
                 log.evaluations.append(drift_eval_log)
+
+            # ----------------------------------------------- Response ----------------------------------------------- #
 
             self._last_detection_interval = next_detection_interval
             if triggered:

--- a/modyn/tests/supervisor/internal/triggers/test_performancetrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/test_performancetrigger.py
@@ -177,13 +177,6 @@ def test_inform_new_model(
     )
 
 
-# TODO: tests:
-# - initial trigger + _last_data_interval
-# - one criterion no trigger & one criterion trigger
-# - multiple criteria no trigger & multiple criteria trigger
-# - evaluation dispatch: _run_evaluation
-
-
 @patch.object(PerformanceTrigger, "_run_evaluation", return_value=(5, 2, {"Accuracy": 0.9}))
 @patch.object(DataDensityTracker, "inform_data", return_value=None)
 @patch.object(
@@ -206,6 +199,7 @@ def test_inform(
     # detection interval 1: at sample (3, 103) --> forced trigger
     trigger_results = list(trigger.inform([(i, 100 + i, 0) for i in range(6)]))
     assert len(trigger_results) == 1
+    assert trigger_results == [3]
     assert trigger._triggered_once
     trigger.inform_new_model(1)
     assert len(trigger._leftover_data) == 2
@@ -229,6 +223,7 @@ def test_inform(
     # detection interval 2: at sample (7, 107) --> optional trigger, 3 samples leftover
     trigger_results = list(trigger.inform([(i, 100 + i, 0) for i in range(6, 11)]))
     assert len(trigger_results) == 1
+    assert trigger_results == [1]
     assert trigger._triggered_once
     trigger.inform_new_model(2)
     assert len(trigger._leftover_data) == 3


### PR DESCRIPTION
# Motivation

We previously didn't assert the exact indexes in the tests and used returned wrong batch pointers because of the internal unprocessed samples.