### PR TITLE
fix: Add last interval to `BetweenTwoTriggersEvalStrategy`

### DIFF
--- a/modyn/supervisor/internal/eval/handler.py
+++ b/modyn/supervisor/internal/eval/handler.py
@@ -76,7 +76,7 @@ class EvalHandler:
 
         return eval_requests
 
-    def get_eval_requests_after_pipeline(self, df_trainings: pd.DataFrame) -> list[EvalRequest]:
+    def get_eval_requests_after_pipeline(self, df_trainings: pd.DataFrame, dataset_end_time: int) -> list[EvalRequest]:
         """Args:
             df_trainings: The pipeline stage execution tracking information including training and model infos.
                 Can be acquired by joining TriggerExecutionInfo and StoreModelInfo dataframes.
@@ -92,7 +92,7 @@ class EvalHandler:
         training_intervals: list[tuple[int, int]] = [
             (row["first_timestamp"], row["last_timestamp"]) for _, row in df_trainings.iterrows()
         ]
-        eval_intervals = self.eval_strategy.get_eval_intervals(training_intervals)
+        eval_intervals = self.eval_strategy.get_eval_intervals(training_intervals, dataset_end_time=dataset_end_time)
         df_eval_intervals = pd.DataFrame(
             [
                 (eval_interval.start, eval_interval.end, eval_interval.active_model_trained_before)

--- a/modyn/supervisor/internal/eval/strategies/abstract.py
+++ b/modyn/supervisor/internal/eval/strategies/abstract.py
@@ -36,7 +36,11 @@ class AbstractEvalStrategy(ABC):
         self.config = config
 
     @abstractmethod
-    def get_eval_intervals(self, training_intervals: Iterable[tuple[int, int]]) -> Iterable[EvalInterval]:
+    def get_eval_intervals(
+        self,
+        training_intervals: list[tuple[int, int]],
+        dataset_end_time: int | None = None,
+    ) -> Iterable[EvalInterval]:
         """This method should return an iterable of tuples, where each tuple
         represents a left inclusive, right exclusive evaluation interval.
 

--- a/modyn/supervisor/internal/eval/strategies/between_two_triggers.py
+++ b/modyn/supervisor/internal/eval/strategies/between_two_triggers.py
@@ -9,12 +9,23 @@ class BetweenTwoTriggersEvalStrategy(AbstractEvalStrategy):
     def __init__(self, config: BetweenTwoTriggersEvalStrategyConfig):
         super().__init__(config)
 
-    def get_eval_intervals(self, training_intervals: Iterable[tuple[int, int]]) -> Iterable[EvalInterval]:
+    def get_eval_intervals(
+        self,
+        training_intervals: list[tuple[int, int]],
+        dataset_end_time: int | None = None,
+    ) -> Iterable[EvalInterval]:
+        if not training_intervals:
+            return []
+
+        max_training_end = max(interval[1] for interval in training_intervals)
+        usage_intervals = training_intervals + (
+            [(max_training_end + 1, dataset_end_time)] if dataset_end_time is not None else []
+        )
         return [
             EvalInterval(
                 start=interval_start,
                 end=interval_end,
                 active_model_trained_before=interval_start,
             )
-            for interval_start, interval_end in training_intervals
+            for interval_start, interval_end in usage_intervals
         ]

--- a/modyn/supervisor/internal/eval/strategies/offset.py
+++ b/modyn/supervisor/internal/eval/strategies/offset.py
@@ -26,7 +26,11 @@ class OffsetEvalStrategy(AbstractEvalStrategy):
         super().__init__(config)
         self.offsets = config.offsets
 
-    def get_eval_intervals(self, training_intervals: Iterable[tuple[int, int]]) -> Iterable[EvalInterval]:
+    def get_eval_intervals(
+        self,
+        training_intervals: list[tuple[int, int]],
+        dataset_end_time: int | None = None,
+    ) -> Iterable[EvalInterval]:
         for train_interval_start, train_interval_end in training_intervals:
             for offset in self.offsets:
                 if offset == "-inf":

--- a/modyn/supervisor/internal/eval/strategies/periodic.py
+++ b/modyn/supervisor/internal/eval/strategies/periodic.py
@@ -11,9 +11,17 @@ class PeriodicEvalStrategy(AbstractEvalStrategy, _IntervalEvalStrategyMixin):
         super(AbstractEvalStrategy, self).__init__(config)
         _IntervalEvalStrategyMixin.__init__(self, config)
 
-    def get_eval_intervals(self, training_intervals: Iterable[tuple[int, int]]) -> Iterable[EvalInterval]:
+    def get_eval_intervals(
+        self,
+        training_intervals: list[tuple[int, int]],
+        dataset_end_time: int | None = None,
+    ) -> Iterable[EvalInterval]:
         evaluation_timestamps = list(
-            range(self.config.start_timestamp, self.config.end_timestamp + 1, self.config.every_sec)
+            range(
+                self.config.start_timestamp,
+                self.config.end_timestamp + 1,
+                self.config.every_sec,
+            )
         )
 
         eval_intervals = []

--- a/modyn/supervisor/internal/eval/strategies/slicing.py
+++ b/modyn/supervisor/internal/eval/strategies/slicing.py
@@ -18,7 +18,11 @@ class SlicingEvalStrategy(AbstractEvalStrategy):
     def __init__(self, config: SlicingEvalStrategyConfig):
         super().__init__(config)
 
-    def get_eval_intervals(self, training_intervals: Iterable[tuple[int, int]]) -> Iterable[EvalInterval]:
+    def get_eval_intervals(
+        self,
+        training_intervals: list[tuple[int, int]],
+        dataset_end_time: int | None = None,
+    ) -> Iterable[EvalInterval]:
         previous_split = self.config.eval_start_from
         while True:
             current_split = min(previous_split + self.config.eval_every_sec, self.config.eval_end_at)

--- a/modyn/supervisor/internal/eval/strategies/static.py
+++ b/modyn/supervisor/internal/eval/strategies/static.py
@@ -9,7 +9,11 @@ class StaticEvalStrategy(AbstractEvalStrategy):
     def __init__(self, config: StaticEvalStrategyConfig):
         super().__init__(config)
 
-    def get_eval_intervals(self, training_intervals: Iterable[tuple[int, int]]) -> Iterable[EvalInterval]:
+    def get_eval_intervals(
+        self,
+        training_intervals: list[tuple[int, int]],
+        dataset_end_time: int | None = None,
+    ) -> Iterable[EvalInterval]:
         return [
             EvalInterval(
                 start=interval_start,

--- a/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/pipeline_executor.py
@@ -869,7 +869,7 @@ class PipelineExecutor:
             return
 
         self.logs.materialize(s.log_directory, mode="increment")
-        self.eval_executor.register_tracking_info(tracking_dfs=s.tracking)
+        self.eval_executor.register_tracking_info(tracking_dfs=s.tracking, dataset_end_time=self.state.max_timestamp)
         self.eval_executor.create_snapshot()
 
     @pipeline_stage(PipelineStage.POST_EVALUATION, parent=PipelineStage.MAIN, log=False, track=False)

--- a/modyn/tests/supervisor/internal/eval/strategies/test_between_two_triggers.py
+++ b/modyn/tests/supervisor/internal/eval/strategies/test_between_two_triggers.py
@@ -8,11 +8,14 @@ def test_between_two_triggers() -> None:
     config = BetweenTwoTriggersEvalStrategyConfig()
     strategy = BetweenTwoTriggersEvalStrategy(config)
 
-    intervals = strategy.get_eval_intervals(training_intervals=[(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)])
+    intervals = strategy.get_eval_intervals(
+        training_intervals=[(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)], dataset_end_time=12
+    )
     assert intervals == [
         EvalInterval(start=0, end=1, active_model_trained_before=0),
         EvalInterval(start=2, end=3, active_model_trained_before=2),
         EvalInterval(start=4, end=5, active_model_trained_before=4),
         EvalInterval(start=6, end=7, active_model_trained_before=6),
         EvalInterval(start=8, end=9, active_model_trained_before=8),
+        EvalInterval(start=10, end=12, active_model_trained_before=10),
     ]

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_evaluation_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_evaluation_executor.py
@@ -97,7 +97,8 @@ def test_evaluation_executor_state_management(
         {
             PipelineStage.HANDLE_SINGLE_TRIGGER.name: tracking_df,
             PipelineStage.STORE_TRAINED_MODEL.name: tracking_df,
-        }
+        },
+        dataset_end_time=99,
     )
     evaluation_executor.create_snapshot()
 
@@ -201,12 +202,14 @@ def test_evaluation_handler_post_training(
         {
             PipelineStage.HANDLE_SINGLE_TRIGGER.name: tracking_df,
             PipelineStage.STORE_TRAINED_MODEL.name: tracking_df,
-        }
+        },
+        dataset_end_time=99,
     )
     evaluation_executor.run_post_pipeline_evaluations()
     test_get_eval_requests_after_training.assert_not_called()
     test_get_eval_requests_after_pipeline.assert_called_once()
     test_launch_evaluations_async.assert_called_once()
+    assert evaluation_executor.context.dataset_end_time == 99
 
 
 @patch.object(EvaluationExecutor, "_single_batched_evaluation", return_value=[("failure", {}), ("failure", {})])


### PR DESCRIPTION
# Motivation

As for the time after the last training there's no more training hence the time is not covered in an eval interval, we need to handle this case manually