### PR TITLE
Speed up `get_tensors_subset` from O(n^2) to O(n)

### DIFF
--- a/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_get_tensor_subset.py
+++ b/modyn/tests/trainer_server/internal/trainer/remote_downsamplers/test_get_tensor_subset.py
@@ -61,7 +61,7 @@ def test_get_tensors_subset_invalid_index():
     # Test when selected_indexes contains an invalid index
     selected_indexes.append(999)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         get_tensors_subset(selected_indexes, data, target, sample_ids)
 
 

--- a/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_remote_downsampling_strategy.py
+++ b/modyn/trainer_server/internal/trainer/remote_downsamplers/abstract_remote_downsampling_strategy.py
@@ -20,9 +20,9 @@ def get_tensors_subset(
     and then we get the entries of data and target only for the selected
     samples
     """
-
+    sample_id2index = {sample_id: index for index, sample_id in enumerate(sample_ids)}
     # first of all we compute the position of each selected index within the batch
-    in_batch_index = [sample_ids.index(selected_index) for selected_index in selected_indexes]
+    in_batch_index = [sample_id2index[selected_index] for selected_index in selected_indexes]
 
     # then we extract the data
     if isinstance(data, torch.Tensor):


### PR DESCRIPTION
This is a change to replace the changes in my thesis branch to return 0-based indices in the `select_points()` method in downsamplers.

I realize that returning 0-based indices is not generalizable to all downsamplers because there are downsamplers which work class by class even in the batch-then-sample mode, e.g. craig. Therefore there is no built-in concept of 0-based indices for such downsamplers (because they pick points of the same class and select from them).

Therefore I decided to tweak the implementation of `get_tensors_subset()` which is simpler.

A time complexity of O(n) is acceptable because in any selection strategy we have to look at every sample, so an extra O(n) part can be well mixed in the time complexity of a selection strategy.