### PR TITLE
fix: Add missing log arg

### DIFF
--- a/modyn/supervisor/internal/triggers/batchedtrigger.py
+++ b/modyn/supervisor/internal/triggers/batchedtrigger.py
@@ -76,7 +76,7 @@ class BatchedTrigger(Trigger):
 
             # ----------------------------------------------- Detection ---------------------------------------------- #
 
-            triggered = self._evaluate_batch(next_detection_interval, trigger_candidate_idx)
+            triggered = self._evaluate_batch(next_detection_interval, trigger_candidate_idx, log=log)
             self._last_detection_interval = next_detection_interval
 
             # ----------------------------------------------- Response ----------------------------------------------- #


### PR DESCRIPTION
# Motivation

We currently didn't log any trigger evaluation records as the batchtrigger refactoring resulted in a missing argument