### PR TITLE
fix: Do not use `model_id` in Pydantic

### DIFF
--- a/modyn/supervisor/internal/triggers/avoidablemissclassification_costtrigger.py
+++ b/modyn/supervisor/internal/triggers/avoidablemissclassification_costtrigger.py
@@ -85,7 +85,7 @@ class AvoidableMisclassificationCostTrigger(CostTrigger, PerformanceTriggerMixin
         )
 
         regret_log = {
-            "model_id": model_id,
+            "id_model": model_id,
             "num_samples": num_samples,
             "num_misclassifications": num_misclassifications,
             "evaluation_scores": evaluation_scores,

--- a/modyn/supervisor/internal/triggers/performancetrigger.py
+++ b/modyn/supervisor/internal/triggers/performancetrigger.py
@@ -126,7 +126,7 @@ class PerformanceTrigger(BatchedTrigger, PerformanceTriggerMixin):
             triggered=triggered,
             trigger_index=trigger_candidate_idx,
             evaluation_interval=(batch[0][1], batch[-1][1]),
-            model_id=model_id or -1,
+            id_model=model_id or -1,
             num_samples=num_samples or -1,
             num_misclassifications=num_misclassifications or -1,
             evaluation_scores=evaluation_scores or {},

--- a/modyn/supervisor/internal/triggers/utils/models.py
+++ b/modyn/supervisor/internal/triggers/utils/models.py
@@ -32,7 +32,7 @@ class EnsembleTriggerEvalLog(_BaseTriggerEvalLog):
 
 class PerformanceTriggerEvalLog(_BaseTriggerEvalLog):
     type: Literal["performance"] = Field("performance")
-    model_id: int | None = Field(None, description="The model ID of the model that was evaluated.")
+    id_model: int | None = Field(None, description="The model ID of the model that was evaluated.")
     num_misclassifications: int = Field(0, description="The number of misclassifications in the evaluation interval.")
     evaluation_scores: dict[str, float] = Field(
         default_factory=dict,


### PR DESCRIPTION
For the dict, we probably do not need to change this, but let's just avoid any potential conflict.