### PR TITLE
feature: More resilient evaluations

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -186,8 +186,9 @@ disable=raw-checker-failed,
         too-many-arguments,             # we can't determine a good limit here. reviews should spot bad cases of this.
         duplicate-code,                 # Mostly imports and test setup.
         cyclic-import,                  # We use these inside methods that require models from multiple apps. Tests will catch actual errors.
-        too-many-instance-attributes,    # We always ignore this anyways
-        too-many-positional-arguments    # We do not want to limit the number of positional arguments
+        too-many-instance-attributes,   # We always ignore this anyways
+        too-many-positional-arguments,  # We do not want to limit the number of positional arguments
+        too-many-locals                 # We always ignore this anyways
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where

--- a/analytics/tools/find_invalid_runs.ipynb
+++ b/analytics/tools/find_invalid_runs.ipynb
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Motivation\n",
+    "\n",
+    "This notebook can be used to find pipeline runs where we have empty evaluation responses despite expecting some. Older versions of Modyn have lest robustness in the evaluation handling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from modyn.supervisor.internal.grpc.enums import PipelineStage\n",
+    "from modyn.supervisor.internal.pipeline_executor.models import MultiEvaluationInfo, PipelineLogs, SingleEvaluationInfo\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "log_dir = Path(\"/Users/mboether/phd/dynamic-data/sigmod-data/yearbook/debug/logs\")\n",
+    "logfiles = [logfile for logfile in log_dir.glob(\"**/pipeline.log\")]\n",
+    "logfiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def metrics_valid(logfile: Path):\n",
+    "    logs = PipelineLogs.model_validate_json(logfile.read_text())\n",
+    "    for eval_log in logs.supervisor_logs.stage_runs:\n",
+    "        if eval_log.id == PipelineStage.EVALUATE_MULTI.name:\n",
+    "            multiinfo = eval_log.info\n",
+    "            assert isinstance(multiinfo, MultiEvaluationInfo)\n",
+    "\n",
+    "            for info in multiinfo.interval_results:\n",
+    "                assert isinstance(info, SingleEvaluationInfo)\n",
+    "                res = info.results\n",
+    "\n",
+    "                if len(res[\"metrics\"]) == 0:\n",
+    "                    if res[\"dataset_size\"] == 0:\n",
+    "                        print(\n",
+    "                            f\"Warning: Empty metrics but empty dataset in {logfile}: {info}\"\n",
+    "                        )  # Might want to remove this - not sure if needed.\n",
+    "                    else:\n",
+    "                        return False\n",
+    "\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "invalid_pipelines = []\n",
+    "for logfile in tqdm(logfiles):\n",
+    "    if not metrics_valid(logfile):\n",
+    "        invalid_pipelines.append(logfile)\n",
+    "\n",
+    "invalid_pipelines\n",
+    "\n",
+    "# Typically, you'd want to delete those directories because they are invalid (see next cell)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Commented out for safety\n",
+    "\n",
+    "\"\"\"\n",
+    "import shutil\n",
+    "parent_dirs = {file_path.parent for file_path in invalid_pipelines}\n",
+    "\n",
+    "for directory in parent_dirs:\n",
+    "    try:\n",
+    "        shutil.rmtree(directory)\n",
+    "    except Exception as e:\n",
+    "        print(f\"Failed to delete {directory}: {e}\")\n",
+    "\"\"\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/modyn/evaluator/internal/grpc/evaluator_grpc_servicer.py
+++ b/modyn/evaluator/internal/grpc/evaluator_grpc_servicer.py
@@ -317,12 +317,16 @@ class EvaluatorGRPCServicer(EvaluatorServicer):
             single_eval_data = EvaluationIntervalData(interval_index=interval_idx, evaluation_data=metric_result)
             evaluation_data.append(single_eval_data)
 
-        if len(evaluation_data) < len(self._evaluation_dict[evaluation_id].not_failed_interval_ids):
+        num_metrics = len(self._evaluation_dict[evaluation_id].raw_metrics)
+        expected_results = len(self._evaluation_dict[evaluation_id].not_failed_interval_ids) * num_metrics
+        if len(evaluation_data) < expected_results:
             logger.error(
                 f"Could not retrieve results for all intervals of evaluation {evaluation_id}. "
-                f"Expected {len(self._evaluation_dict[evaluation_id].not_failed_interval_ids)}, "
-                f"but got {len(evaluation_data)}. Maybe an exception happened during evaluation."
+                f"Expected {len(self._evaluation_dict[evaluation_id].not_failed_interval_ids)} * {num_metrics} = {expected_results} results, "
+                f"but got {len(evaluation_data)} results. Most likely, an exception happened during evaluation."
             )
+            return EvaluationResultResponse(valid=False)
+
         return EvaluationResultResponse(valid=True, evaluation_results=evaluation_data)
 
     def cleanup_evaluations(

--- a/modyn/evaluator/internal/grpc/evaluator_grpc_servicer.py
+++ b/modyn/evaluator/internal/grpc/evaluator_grpc_servicer.py
@@ -353,9 +353,12 @@ class EvaluatorGRPCServicer(EvaluatorServicer):
             self._evaluation_process_dict.pop(evaluation_id)
 
         for e_id in evaluation_ids:
-            self._evaluation_dict.pop(e_id)
-            self._evaluation_data_dict.pop(e_id)
-            self._evaluation_data_dict_locks.pop(e_id)
+            if e_id in self._evaluation_dict:
+                self._evaluation_dict.pop(e_id)
+            if e_id in self._evaluation_data_dict:
+                self._evaluation_data_dict.pop(e_id)
+            if e_id in self._evaluation_data_dict_locks:
+                self._evaluation_data_dict_locks.pop(e_id)
 
         gc.collect()
         return EvaluationCleanupResponse(succeeded=list(sorted(already_cleaned + not_yet_cleaned)))

--- a/modyn/evaluator/internal/pytorch_evaluator.py
+++ b/modyn/evaluator/internal/pytorch_evaluator.py
@@ -39,7 +39,6 @@ class PytorchEvaluator:
         )
 
         self._device = evaluation_info.device
-        self._device_type = "cuda" if "cuda" in self._device else "cpu"
         self._amp = evaluation_info.amp
 
         self._info("Initialized PyTorch evaluator.")

--- a/modyn/selector/internal/grpc/selector_grpc_servicer.py
+++ b/modyn/selector/internal/grpc/selector_grpc_servicer.py
@@ -58,8 +58,13 @@ class SelectorGRPCServicer(SelectorServicer):
         pid = os.getpid()
 
         logger.info(
-            f"[{pid}][{tid}][Pipeline {pipeline_id}]: Fetching samples for trigger id {trigger_id}"
-            + f" and worker id {worker_id} and partition id {partition_id}"
+            "[%s][%s][Pipeline %s]: Fetching samples for trigger id %s and worker id %s and partition id %s",
+            pid,
+            tid,
+            pipeline_id,
+            trigger_id,
+            worker_id,
+            partition_id,
         )
 
         samples = self.selector_manager.get_sample_keys_and_weights(pipeline_id, trigger_id, worker_id, partition_id)
@@ -90,8 +95,12 @@ class SelectorGRPCServicer(SelectorServicer):
         tid = threading.get_native_id()
         pid = os.getpid()
         logger.info(
-            f"[{pid}][{tid}][Pipeline {pipeline_id}]: Selector is informed of {len(keys)} new data points"
-            + f"+ trigger at timestamp {timestamps[-1] if len(keys) > 0 else 'n/a'}"
+            "[%s][%s][Pipeline %s]: Selector is informed of %s new data points + trigger at timestamp %s",
+            pid,
+            tid,
+            pipeline_id,
+            len(keys),
+            timestamps[-1] if keys else "n/a",
         )
 
         trigger_id, log = self.selector_manager.inform_data_and_trigger(pipeline_id, keys, timestamps, labels)

--- a/modyn/selector/internal/grpc/selector_grpc_servicer.py
+++ b/modyn/selector/internal/grpc/selector_grpc_servicer.py
@@ -45,7 +45,7 @@ class SelectorGRPCServicer(SelectorServicer):
         self.selector_manager = selector_manager
         self._sample_batch_size = sample_batch_size
 
-    def get_sample_keys_and_weights(  # pylint: disable-next=unused-argument
+    def get_sample_keys_and_weights(  # pylint: disable-next=unused-argument, too-many-locals
         self, request: GetSamplesRequest, context: grpc.ServicerContext
     ) -> Iterable[SamplesResponse]:
         pipeline_id, trigger_id, worker_id, partition_id = (

--- a/modyn/selector/internal/grpc/selector_grpc_servicer.py
+++ b/modyn/selector/internal/grpc/selector_grpc_servicer.py
@@ -57,15 +57,11 @@ class SelectorGRPCServicer(SelectorServicer):
         tid = threading.get_native_id()
         pid = os.getpid()
 
-        logger.info(
-            "[%s][%s][Pipeline %s]: Fetching samples for trigger id %s and worker id %s and partition id %s",
-            pid,
-            tid,
-            pipeline_id,
-            trigger_id,
-            worker_id,
-            partition_id,
+        _logmsg = (
+            f"[{pid}][{tid}][Pipeline {pipeline_id}]: Fetching samples for trigger id {trigger_id}"
+            + f" and worker id {worker_id} and partition id {partition_id}"
         )
+        logger.info(_logmsg)
 
         samples = self.selector_manager.get_sample_keys_and_weights(pipeline_id, trigger_id, worker_id, partition_id)
 
@@ -94,14 +90,11 @@ class SelectorGRPCServicer(SelectorServicer):
         pipeline_id, keys, timestamps, labels = request.pipeline_id, request.keys, request.timestamps, request.labels
         tid = threading.get_native_id()
         pid = os.getpid()
-        logger.info(
-            "[%s][%s][Pipeline %s]: Selector is informed of %s new data points + trigger at timestamp %s",
-            pid,
-            tid,
-            pipeline_id,
-            len(keys),
-            timestamps[-1] if keys else "n/a",
+        _lgmsg = (
+            f"[{pid}][{tid}][Pipeline {pipeline_id}]: Selector is informed of {len(keys)} new data points"
+            + f"+ trigger at timestamp {timestamps[-1] if len(keys) > 0 else 'n/a'}"
         )
+        logger.info(_lgmsg)
 
         trigger_id, log = self.selector_manager.inform_data_and_trigger(pipeline_id, keys, timestamps, labels)
         return TriggerResponse(trigger_id=trigger_id, log=JsonString(value=json.dumps(log)))

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -344,8 +344,10 @@ class GRPCHandler(TrainerServerGRPCHandlerMixin):
                     raise e
 
         if not res.valid:
-            logger.error(f"Cannot get the evaluation result for evaluation {evaluation_id}")
-            raise RuntimeError(f"Cannot get the evaluation result for evaluation {evaluation_id}")
+            _msg = f"Cannot get the evaluation result for evaluation {evaluation_id}"
+            logger.error(_msg)
+            raise RuntimeError(_msg)
+
         return res.evaluation_results
 
     def cleanup_evaluations(self, evaluation_ids: list[int]) -> None:

--- a/modyn/supervisor/internal/grpc_handler.py
+++ b/modyn/supervisor/internal/grpc_handler.py
@@ -317,6 +317,7 @@ class GRPCHandler(TrainerServerGRPCHandlerMixin):
                 break  # Exit busy wait
 
             if not res.is_running:
+                logger.info(f"Evaluation {evaluation_id} has finished successfully.")
                 break  # Exit busy wait
 
             sleep(1)
@@ -347,6 +348,8 @@ class GRPCHandler(TrainerServerGRPCHandlerMixin):
             _msg = f"Cannot get the evaluation result for evaluation {evaluation_id}"
             logger.error(_msg)
             raise RuntimeError(_msg)
+
+        logger.debug(f"Obtained evaluation results for evaluation {evaluation_id}")
 
         return res.evaluation_results
 

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -436,7 +436,7 @@ class EvaluationExecutor:
                 # Will trigger a retry in case this is not successful
                 # Can happen, e.g., if the evaluator is overloaded
                 expected_num_metrics = len(request.metrics)
-                for abort_reason, data_dict in eval_results:
+                for result_id, (abort_reason, data_dict) in enumerate(eval_results):
                     if abort_reason is not None:
                         # If there was any reason to abort, we don't care
                         continue
@@ -446,10 +446,12 @@ class EvaluationExecutor:
                     ), f"dataset size of 0, but no EMPTY_INTERVAL response: {eval_results}"
                     actual_num_metrics = len(data_dict["metrics"])
                     assert actual_num_metrics == expected_num_metrics, (
-                        f"actual_num_metrics = {actual_num_metrics}"
+                        f"result {result_id}: actual_num_metrics = {actual_num_metrics}"
                         + f" != expected_num_metrics = {expected_num_metrics}"
                         + "\n"
                         + str(eval_results)
+                        + "\n\n"
+                        + str(eval_data)
                     )
 
                 # All checks succeeded

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -378,7 +378,9 @@ class EvaluationExecutor:
                     # This is likely due to an invalid request in the first place.
                     return failure_reasons
 
-                logger.info(f"Evaluation started for model {model_id_to_eval} on intervals {intervals}.")
+                logger.info(
+                    f"Evaluation {response.evaluation_id} started for model {model_id_to_eval} on intervals {intervals}."
+                )
                 started_evaluations.append(response.evaluation_id)
                 if not self.grpc.wait_for_evaluation_completion(response.evaluation_id):
                     raise RuntimeError("There was an exception during evaluation")  # Trigger retry

--- a/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
+++ b/modyn/supervisor/internal/pipeline_executor/evaluation_executor.py
@@ -339,80 +339,108 @@ class EvaluationExecutor:
             self.pipeline.evaluation.device,
             intervals=cast(list[tuple[int | None, int | None]], intervals),
         )
+
+        def get_failure_reason(eval_aborted_reason: EvaluationAbortedReason) -> str:
+            return EvaluationAbortedReason.DESCRIPTOR.values_by_number[eval_aborted_reason].name
+
         for attempt in Retrying(
-            stop=stop_after_attempt(5),
-            wait=wait_random_exponential(multiplier=1, min=2, max=60),
+            stop=stop_after_attempt(10),
+            wait=wait_random_exponential(multiplier=1, min=2, max=120),
             reraise=True,
         ):
             with attempt:
                 try:
                     response: EvaluateModelResponse = self.grpc.evaluator.evaluate_model(request)
-                except grpc.RpcError as e:  # We catch and reraise to reconnect
+                except grpc.RpcError as e:  # We catch and reraise them to tenacity after reconnecting
                     logger.error(e)
                     logger.error("gRPC connection error, trying to reconnect...")
                     self.grpc.init_evaluator()
                     raise e
 
-        assert len(response.interval_responses) == len(
-            intervals
-        ), f"We expected {len(intervals)} intervals, but got {len(response.interval_responses)}."
+                assert len(response.interval_responses) == len(
+                    intervals
+                ), f"We expected {len(intervals)} intervals, but got {len(response.interval_responses)}."
 
-        def get_failure_reason(eval_aborted_reason: EvaluationAbortedReason) -> str:
-            return EvaluationAbortedReason.DESCRIPTOR.values_by_number[eval_aborted_reason].name
+                if not response.evaluation_started:
+                    failure_reasons: list[tuple[str | None, dict]] = []
+                    # note: interval indexes correspond to the intervals in the request
+                    for interval_idx, interval_response in enumerate(response.interval_responses):
+                        if interval_response.eval_aborted_reason != EvaluationAbortedReason.NOT_ABORTED:
+                            reason = get_failure_reason(interval_response.eval_aborted_reason)
+                            failure_reasons.append((reason, {}))
+                            logger.error(
+                                f"Evaluation for model {model_id_to_eval} on split {intervals[interval_idx]} "
+                                f"not started with reason: {reason}."
+                            )
+                    # No retrying here, if we were to retry it should be done at the evaluator
+                    # This is likely due to an invalid request in the first place.
+                    return failure_reasons
 
-        if not response.evaluation_started:
-            failure_reasons: list[tuple[str | None, dict]] = []
-            # note: interval indexes correspond to the intervals in the request
-            for interval_idx, interval_response in enumerate(response.interval_responses):
-                if interval_response.eval_aborted_reason != EvaluationAbortedReason.NOT_ABORTED:
-                    reason = get_failure_reason(interval_response.eval_aborted_reason)
-                    failure_reasons.append((reason, {}))
-                    logger.error(
-                        f"Evaluation for model {model_id_to_eval} on split {intervals[interval_idx]} "
-                        f"not started with reason: {reason}."
+                logger.info(f"Evaluation started for model {model_id_to_eval} on intervals {intervals}.")
+                self.grpc.wait_for_evaluation_completion(response.evaluation_id)
+                eval_data = self.grpc.get_evaluation_results(response.evaluation_id)
+                self.grpc.cleanup_evaluations([response.evaluation_id])
+
+                eval_results: list[tuple[str | None, dict[str, Any]]] = []
+
+                # ---------------------------------------------- Result Builder ---------------------------------------------- #
+                # The `eval_results` list is a list of tuples. Each tuple contains a failure reason (if any) and a dictionary
+                # with the evaluation results. The order of the tuples corresponds to the order of the intervals.
+                #
+                # response.interval_responses contains the evaluation results for each interval in the same order as the
+                # intervals in the request. Failed evaluations are marked with a failure reason.
+
+                # Metric results come from the `EvaluateModelResponse` and are stored in the `evaluation_data` field. This
+                # only contains the metrics for the intervals that were successfully evaluated.
+                #
+                # Therefore we first build a list of results with the same order as the intervals. The metrics will be filled in
+                # the next loop that unwraps `EvaluationResultResponse`.
+                # ----------------------------------------------------- . ---------------------------------------------------- #
+
+                for interval_response in response.interval_responses:
+                    if interval_response.eval_aborted_reason != EvaluationAbortedReason.NOT_ABORTED:
+                        reason = get_failure_reason(interval_response.eval_aborted_reason)
+                        eval_results.append((reason, {}))
+                    else:
+                        eval_results.append(
+                            (
+                                None,
+                                {"dataset_size": interval_response.dataset_size, "metrics": []},
+                            )
+                        )
+
+                for interval_result in eval_data:
+                    interval_idx = interval_result.interval_index
+                    assert (
+                        eval_results[interval_idx][0] is None
+                    ), "Evaluation failed, this interval idx should not be returned by evaluator."
+                    eval_results[interval_idx][1]["metrics"] = [
+                        {"name": metric.metric, "result": metric.result} for metric in interval_result.evaluation_data
+                    ]
+
+                # Assert that all evaluated intervals have all metrics
+                # Will trigger a retry in case this is not successful
+                # Can happen, e.g., if the evaluator is overloaded
+                expected_num_metrics = len(request.metrics)
+                for abort_reason, data_dict in eval_results:
+                    if abort_reason is not None:
+                        # If there was any reason to abort, we don't care
+                        continue
+
+                    assert (
+                        data_dict["dataset_size"] > 0
+                    ), f"dataset size of 0, but no EMPTY_INTERVAL response: {eval_results}"
+                    actual_num_metrics = len(data_dict["metrics"])
+                    assert actual_num_metrics == expected_num_metrics, (
+                        f"actual_num_metrics = {actual_num_metrics}"
+                        + f" != expected_num_metrics = {expected_num_metrics}"
+                        + "\n"
+                        + str(eval_results)
                     )
-            return failure_reasons
 
-        logger.info(f"Evaluation started for model {model_id_to_eval} on intervals {intervals}.")
-        self.grpc.wait_for_evaluation_completion(response.evaluation_id)
-        eval_data = self.grpc.get_evaluation_results(response.evaluation_id)
-        self.grpc.cleanup_evaluations([response.evaluation_id])
+                return eval_results
 
-        eval_results: list[tuple[str | None, dict[str, Any]]] = []
-
-        # ---------------------------------------------- Result Builder ---------------------------------------------- #
-        # The `eval_results` list is a list of tuples. Each tuple contains a failure reason (if any) and a dictionary
-        # with the evaluation results. The order of the tuples corresponds to the order of the intervals.
-        #
-        # response.interval_responses contains the evaluation results for each interval in the same order as the
-        # intervals in the request. Failed evaluations are marked with a failure reason.
-
-        # Metric results come from the `EvaluateModelResponse` and are stored in the `evaluation_data` field. This
-        # only contains the metrics for the intervals that were successfully evaluated.
-        #
-        # Therefore we first build a list of results with the same order as the intervals. The metrics will be filled in
-        # the next loop that unwraps `EvaluationResultResponse`.
-        # ----------------------------------------------------- . ---------------------------------------------------- #
-
-        for interval_response in response.interval_responses:
-            if interval_response.eval_aborted_reason != EvaluationAbortedReason.NOT_ABORTED:
-                reason = get_failure_reason(interval_response.eval_aborted_reason)
-                eval_results.append((reason, {}))
-            else:
-                eval_results.append(
-                    (
-                        None,
-                        {"dataset_size": interval_response.dataset_size, "metrics": []},
-                    )
-                )
-
-        for interval_result in eval_data:
-            interval_idx = interval_result.interval_index
-            assert eval_results[interval_idx][0] is None, "Evaluation failed, no metrics should be present."
-            eval_results[interval_idx][1]["metrics"] = [
-                {"name": metric.metric, "result": metric.result} for metric in interval_result.evaluation_data
-            ]
-        return eval_results
+        raise RuntimeError("Unreachable code - satisfy mypy.")
 
 
 # ------------------------------------------------------------------------------------ #

--- a/modyn/supervisor/internal/triggers/datadrifttrigger.py
+++ b/modyn/supervisor/internal/triggers/datadrifttrigger.py
@@ -298,8 +298,8 @@ class DataDriftTrigger(BatchedTrigger):
             drift_results[metric_name].is_drift = self.decision_policies[metric_name].evaluate_decision(
                 metric_result.distance
             )
-
-        logger.info("[DataDriftDetector][Dataset %s][Result] %s", self.dataloader_info.dataset_id, drift_results)
+        _logmsg = f"[DataDriftDetector][Dataset {self.dataloader_info.dataset_id}]" + f"[Result] {drift_results}"
+        logger.info(_logmsg)
         if is_warmup:
             return False, {}
 

--- a/modyn/supervisor/internal/triggers/datadrifttrigger.py
+++ b/modyn/supervisor/internal/triggers/datadrifttrigger.py
@@ -299,7 +299,7 @@ class DataDriftTrigger(BatchedTrigger):
                 metric_result.distance
             )
 
-        logger.info(f"[DataDriftDetector][Dataset {self.dataloader_info.dataset_id}]" + f"[Result] {drift_results}")
+        logger.info("[DataDriftDetector][Dataset %s][Result] %s", self.dataloader_info.dataset_id, drift_results)
         if is_warmup:
             return False, {}
 

--- a/modyn/tests/evaluator/internal/grpc/test_evaluator_grpc_servicer.py
+++ b/modyn/tests/evaluator/internal/grpc/test_evaluator_grpc_servicer.py
@@ -486,14 +486,6 @@ def test__run_evaluation_retain_metrics_before_real_exception(test_connect_to_st
     get_result_req = EvaluationResultRequest(evaluation_id=evaluation_id)
     get_result_resp = evaluator.get_evaluation_result(get_result_req, None)
     assert not get_result_resp.valid
-    # evaluation on the last interval was not finished
-    assert len(get_result_resp.evaluation_results) == len(intervals) - 1
-    assert get_result_resp.evaluation_results[0].interval_index == 0
-    assert len(get_result_resp.evaluation_results[0].evaluation_data) == 2
-    assert get_result_resp.evaluation_results[0].evaluation_data[0].metric == "Accuracy"
-    assert get_result_resp.evaluation_results[0].evaluation_data[0].result == pytest.approx(0.5)
-    assert get_result_resp.evaluation_results[0].evaluation_data[1].metric == "F1Score"
-    assert get_result_resp.evaluation_results[0].evaluation_data[1].result == pytest.approx(0.6)
 
 
 @patch.object(EvaluatorGRPCServicer, "connect_to_storage", return_value=DummyStorageStub())
@@ -536,11 +528,6 @@ def test_get_evaluation_result_incomplete_metric(test_is_alive, test_connect_to_
         metric_result_queue.put((1, [("Accuracy", 0.5)]))
         response = evaluator.get_evaluation_result(EvaluationResultRequest(evaluation_id=3), None)
         assert not response.valid
-        assert len(response.evaluation_results) == 1
-        assert response.evaluation_results[0].interval_index == 1
-        assert len(response.evaluation_results[0].evaluation_data) == 1
-        assert response.evaluation_results[0].evaluation_data[0].result == pytest.approx(0.5)
-        assert response.evaluation_results[0].evaluation_data[0].metric == "Accuracy"
 
 
 @patch.object(EvaluatorGRPCServicer, "connect_to_storage", return_value=DummyStorageStub())

--- a/modyn/tests/evaluator/internal/grpc/test_evaluator_grpc_servicer.py
+++ b/modyn/tests/evaluator/internal/grpc/test_evaluator_grpc_servicer.py
@@ -485,7 +485,7 @@ def test__run_evaluation_retain_metrics_before_real_exception(test_connect_to_st
 
     get_result_req = EvaluationResultRequest(evaluation_id=evaluation_id)
     get_result_resp = evaluator.get_evaluation_result(get_result_req, None)
-    assert get_result_resp.valid
+    assert not get_result_resp.valid
     # evaluation on the last interval was not finished
     assert len(get_result_resp.evaluation_results) == len(intervals) - 1
     assert get_result_resp.evaluation_results[0].interval_index == 0
@@ -535,7 +535,7 @@ def test_get_evaluation_result_incomplete_metric(test_is_alive, test_connect_to_
         metric_result_queue = evaluation_process_info.metric_result_queue
         metric_result_queue.put((1, [("Accuracy", 0.5)]))
         response = evaluator.get_evaluation_result(EvaluationResultRequest(evaluation_id=3), None)
-        assert response.valid
+        assert not response.valid
         assert len(response.evaluation_results) == 1
         assert response.evaluation_results[0].interval_index == 1
         assert len(response.evaluation_results[0].evaluation_data) == 1

--- a/modyn/tests/evaluator/internal/test_pytorch_evaluator.py
+++ b/modyn/tests/evaluator/internal/test_pytorch_evaluator.py
@@ -170,7 +170,6 @@ def test_evaluator_init(load_state_mock: MagicMock) -> None:
         )
     )
     assert evaluator._device == "cpu"
-    assert evaluator._device_type == "cpu"
     assert not evaluator._amp
     load_state_mock.assert_called_once_with(pathlib.Path("trained_model.modyn"))
 
@@ -183,7 +182,6 @@ def test_no_transform_evaluator_init(load_state_mock: MagicMock):
     assert isinstance(evaluator._model.model, MockModel)
     assert not evaluator._label_transformer_function
     assert evaluator._device == "cpu"
-    assert evaluator._device_type == "cpu"
     assert not evaluator._amp
     load_state_mock.assert_called_once_with(pathlib.Path("trained_model.modyn"))
 

--- a/modyn/tests/supervisor/internal/pipeline_executor/test_evaluation_executor.py
+++ b/modyn/tests/supervisor/internal/pipeline_executor/test_evaluation_executor.py
@@ -299,6 +299,11 @@ def test_single_batched_evaluation_mixed(
     eval_req2 = dummy_eval_request()
     eval_req.interval_start = 64
     eval_req.interval_end = 14
+
+    request = MagicMock()
+    request.metrics = ["Accuracy"]
+    test_prepare_evaluation_request.return_value = request
+
     results = evaluation_executor._single_batched_evaluation(
         [
             (eval_req.interval_start, eval_req.interval_end),
@@ -317,4 +322,4 @@ def test_single_batched_evaluation_mixed(
     )
     test_wait_for_evaluation_completion.assert_called_once()
     test_get_evaluation_results.assert_called_once()
-    test_cleanup_evaluations.assert_called_once()
+    assert test_cleanup_evaluations.call_count == 2


### PR DESCRIPTION
This PR addresses several issues:

1) When the evaluator crashes with an exception, we actually also send this to the supervisor

2) We validate whether we receive the correct number of results at the supervisor

3) We fix the validation of the correct number of evaluations at the evaluator

4) Some minor additions of retrying to connect in case the connection gets lost

Our observation of missing evaluations should now be caught at the first point (we actually retry on exception at the evaluator) but the others serve as a guarding mechanism.