### PR TITLE
fix: EnsembleTrigger test error

### DIFF
--- a/modyn/tests/supervisor/internal/triggers/performance/test_ensembletrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/performance/test_ensembletrigger.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from modyn.config.schema.pipeline.trigger import TriggerConfig  # noqa: F401
 from modyn.config.schema.pipeline.trigger.ensemble import (
     AtLeastNEnsembleStrategy,
     EnsembleTriggerConfig,
@@ -15,6 +16,7 @@ from modyn.supervisor.internal.triggers.ensembletrigger import EnsembleTrigger
 from modyn.supervisor.internal.triggers.timetrigger import TimeTrigger
 from modyn.supervisor.internal.triggers.trigger import TriggerContext
 from modyn.supervisor.internal.triggers.utils.models import TriggerPolicyEvaluationLog
+EnsembleTriggerConfig.model_rebuild()
 
 
 @pytest.fixture

--- a/modyn/tests/supervisor/internal/triggers/performance/test_ensembletrigger.py
+++ b/modyn/tests/supervisor/internal/triggers/performance/test_ensembletrigger.py
@@ -16,6 +16,7 @@ from modyn.supervisor.internal.triggers.ensembletrigger import EnsembleTrigger
 from modyn.supervisor.internal.triggers.timetrigger import TimeTrigger
 from modyn.supervisor.internal.triggers.trigger import TriggerContext
 from modyn.supervisor.internal.triggers.utils.models import TriggerPolicyEvaluationLog
+
 EnsembleTriggerConfig.model_rebuild()
 
 


### PR DESCRIPTION
Fixed the test for EnsembleTrigger, there was a problem with the forward declaration off TriggerConfig, it does not seem to affect any other test with EnsembleTriggers so it should not be a problem anywhere else.