### PR TITLE
Added llm filtering to pre-sampling strategies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
       - evidently==0.4.27
       - alibi-detect==0.12.*
       - tenacity
+      - openai
   - jsonschema
   - psycopg2
   - sqlalchemy>=2.0

--- a/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
+++ b/modyn/selector/internal/selector_strategies/abstract_selection_strategy.py
@@ -29,7 +29,7 @@ class AbstractSelectionStrategy(ABC):
     """
 
     # pylint: disable-next=too-many-branches
-    def __init__(self, config: SelectionStrategy, modyn_config: dict, pipeline_id: int):
+    def __init__(self, config: SelectionStrategy, modyn_config: dict, pipeline_id: int) -> None:
         self._config = config
 
         self.training_set_size_limit: int = config.limit

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/__init__.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/__init__.py
@@ -5,7 +5,6 @@ from .abstract_presampling_strategy import AbstractPresamplingStrategy  # noqa: 
 from .label_balanced_presampling_strategy import LabelBalancedPresamplingStrategy  # noqa: F401
 from .llm_based_presampling_strategy import LLMEvaluationPresamplingStrategy  # noqa: F401
 from .no_presampling_strategy import NoPresamplingStrategy  # noqa: F401
-from .original_set_strategy import OriginalSetPresamplingStrategy  # noqa: F401
 from .random_no_replacement_presampling_strategy import RandomNoReplacementPresamplingStrategy  # noqa: F401
 from .random_presampling_strategy import RandomPresamplingStrategy  # noqa: F401
 from .trigger_balanced_presampling_strategy import TriggerBalancedPresamplingStrategy  # noqa: F401

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/__init__.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/__init__.py
@@ -3,7 +3,9 @@ import os
 from .abstract_balanced_strategy import AbstractBalancedPresamplingStrategy  # noqa: F401
 from .abstract_presampling_strategy import AbstractPresamplingStrategy  # noqa: F401
 from .label_balanced_presampling_strategy import LabelBalancedPresamplingStrategy  # noqa: F401
+from .llm_based_presampling_strategy import LLMEvaluationPresamplingStrategy  # noqa: F401
 from .no_presampling_strategy import NoPresamplingStrategy  # noqa: F401
+from .original_set_strategy import OriginalSetPresamplingStrategy  # noqa: F401
 from .random_no_replacement_presampling_strategy import RandomNoReplacementPresamplingStrategy  # noqa: F401
 from .random_presampling_strategy import RandomPresamplingStrategy  # noqa: F401
 from .trigger_balanced_presampling_strategy import TriggerBalancedPresamplingStrategy  # noqa: F401

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/llm_based_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/llm_based_presampling_strategy.py
@@ -1,0 +1,125 @@
+import time
+import uuid
+
+import openai
+from sqlalchemy import Column, Integer, MetaData, Table, select
+from sqlalchemy.orm.session import Session
+
+from modyn.config.schema.pipeline import PresamplingConfig
+from modyn.metadata_database.models import SelectorStateMetadata
+from modyn.selector.internal.selector_strategies.presampling_strategies.abstract_presampling_strategy import (
+    AbstractPresamplingStrategy,
+)
+from modyn.selector.internal.storage_backend import AbstractStorageBackend
+
+
+class LLMEvaluationPresamplingStrategy(AbstractPresamplingStrategy):
+    def __init__(
+        self,
+        presampling_config: PresamplingConfig,
+        modyn_config: dict,
+        pipeline_id: int,
+        storage_backend: AbstractStorageBackend,
+    ):
+        super().__init__(presampling_config, modyn_config, pipeline_id, storage_backend)
+        self.batch_size = presampling_config.batch_size
+        self.model_name = presampling_config.model_name
+        self.ratio = presampling_config.ratio
+        self.custom_prompt = presampling_config.custom_prompt
+        self.dataset_id = presampling_config.dataset_id
+        self.client = openai.Client(api_key=presampling_config.api_key, base_url=presampling_config.base_url)
+
+    def evaluate_batch_quality(self, keys: list[int], model_name: str, dataset_id: str) -> list[bool]:
+        """
+        Retrieve sample texts from storage for the given keys and evaluate their quality using the LLM.
+        Uses a custom prompt if provided, otherwise builds a default prompt.
+        If ratio is not 100, instructs the LLM to only keep the top ratio percent.
+        """
+        if model_name is None:
+            model_name = self.model_name
+
+        # Retrieve samples directly via the storage backend.
+        sample_map: dict[int, str] = {}
+        iterator = self._storage_backend._get_data_from_storage(selector_keys=keys, dataset_id=dataset_id)  # type: ignore
+        for ret_keys, samples, _, _, _ in iterator:
+            for k, sample in zip(ret_keys, samples):
+                text = sample.decode("utf-8") if isinstance(sample, bytes) else str(sample)
+                sample_map[k] = text
+
+        # Build the list of texts in the order of keys.
+        batch_texts = [sample_map.get(key, "") for key in keys]
+
+        # Use custom prompt if provided; otherwise, build the default prompt.
+        if self.custom_prompt:
+            eval_prompt = self.custom_prompt
+        else:
+            eval_prompt = (
+                "Determine if the following texts are useful for training an LLM on Wikipedia fact updates.\n\n"
+            )
+            for i, text in enumerate(batch_texts):
+                eval_prompt += f"{i+1}. {text}\n"
+            eval_prompt += (
+                "\nIf the text is informative and fact-based, return 'true'. "
+                "If the text is meaningless, misleading, or repetitive, try to return false at least once per batch. "
+                "If you are unsure, return 'false'. Return only 'true' or 'false' without numbering the responses.\n"
+            )
+        if self.ratio != 100:
+            eval_prompt += f"\nAdditionally, only keep the top {self.ratio}% of the samples.\n"
+
+        while True:
+            try:
+                response = self.client.chat.completions.create(
+                    model=model_name, messages=[{"role": "user", "content": eval_prompt}], max_tokens=512, stream=False
+                )
+                break
+            except Exception:  # pylint:disable=broad-exception-caught
+                time.sleep(5)
+
+        content = response.choices[0].message.content.strip().lower()
+        results = content.split("\n")
+        return [res.strip() == "true" for res in results]
+
+    def get_presampling_query(
+        self,
+        next_trigger_id: int,
+        tail_triggers: int | None,
+        limit: int | None,
+        trigger_dataset_size: int | None,
+    ) -> select:
+        base_query = select(SelectorStateMetadata.sample_key).filter(
+            SelectorStateMetadata.pipeline_id == self.pipeline_id,
+            SelectorStateMetadata.seen_in_trigger_id == next_trigger_id,
+        )
+
+        def fetch_raw_keys(session: Session) -> list[int]:
+            keys = session.execute(base_query).scalars().all()
+            return keys
+
+        raw_keys = self._storage_backend._execute_on_session(fetch_raw_keys)  # type: ignore
+        filtered_keys = []
+
+        for i in range(0, len(raw_keys), self.batch_size):
+            batch_keys = raw_keys[i : i + self.batch_size]
+            # Directly evaluate the quality by calling get_data_from_storage within evaluate_batch_quality.
+            results = self.evaluate_batch_quality(batch_keys, model_name=self.model_name, dataset_id=self.dataset_id)  # type: ignore
+            for idx, keep in enumerate(results):
+                if keep:
+                    filtered_keys.append(batch_keys[idx])
+
+        temp_table_name = f"temp_llm_filter_{uuid.uuid4().hex}"
+        metadata = MetaData()
+        temp_table = Table(
+            temp_table_name,
+            metadata,  # type: ignore
+            Column("sample_key", Integer, primary_key=True),
+        )
+
+        def create_temp_table_and_insert(session: Session) -> None:
+            metadata.create_all(session.get_bind())
+            if filtered_keys:
+                session.execute(temp_table.insert(), [{"sample_key": key} for key in filtered_keys])
+                session.commit()
+
+        self._storage_backend._execute_on_session(create_temp_table_and_insert)  # type: ignore
+
+        return select(temp_table.c.sample_key)

--- a/modyn/selector/internal/selector_strategies/presampling_strategies/llm_based_presampling_strategy.py
+++ b/modyn/selector/internal/selector_strategies/presampling_strategies/llm_based_presampling_strategy.py
@@ -30,13 +30,13 @@ class LLMEvaluationPresamplingStrategy(AbstractPresamplingStrategy):
         self.client = openai.Client(api_key=presampling_config.api_key, base_url=presampling_config.base_url)
 
     def evaluate_batch_quality(self, keys: list[int], model_name: str, dataset_id: str) -> list[bool]:
+        """Retrieve sample texts from storage for the given keys and evaluate
+        their quality using the LLM.
+
+        Uses a custom prompt if provided, otherwise builds a default
+        prompt. If ratio is not 100, instructs the LLM to only keep the
+        top ratio percent.
         """
-        Retrieve sample texts from storage for the given keys and evaluate their quality using the LLM.
-        Uses a custom prompt if provided, otherwise builds a default prompt.
-        If ratio is not 100, instructs the LLM to only keep the top ratio percent.
-        """
-        if model_name is None:
-            model_name = self.model_name
 
         # Retrieve samples directly via the storage backend.
         sample_map: dict[int, str] = {}

--- a/modyn/selector/internal/storage_backend/abstract_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/abstract_storage_backend.py
@@ -67,7 +67,5 @@ class AbstractStorageBackend(ABC):
         selector_keys: list[int],
         dataset_id: str,
     ) -> Iterator[tuple[list[int], list[bytes], list[int], list[bytes], int]]:
-        """
-        Retrieve full sample data from storage given a list of keys.
-        """
+        """Retrieve full sample data from storage given a list of keys."""
         raise NotImplementedError()

--- a/modyn/selector/internal/storage_backend/abstract_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/abstract_storage_backend.py
@@ -2,17 +2,27 @@ import logging
 import os
 import platform
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 class AbstractStorageBackend(ABC):
-    def __init__(self, pipeline_id: int, modyn_config: dict, maximum_keys_in_memory: int):
+    def __init__(self, pipeline_id: int, modyn_config: dict, maximum_keys_in_memory: int) -> None:
         self._modyn_config = modyn_config
         self._maximum_keys_in_memory = maximum_keys_in_memory
         self._pipeline_id = pipeline_id
+        self._storagestub = None
+        self._storage_channel = None
+        storage = modyn_config.get(
+            "storage", {}
+        )  # Storage is always part of config but this prevents having to rwritte all the tests.
+        self._storage_address = (
+            f"{storage.get('hostname')}:{storage.get('port')}"
+            if storage.get("hostname") and storage.get("port")
+            else None
+        )
 
         raw_insertion_threads = modyn_config["selector"]["insertion_threads"]
 
@@ -49,4 +59,15 @@ class AbstractStorageBackend(ABC):
 
     @abstractmethod
     def get_all_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _get_data_from_storage(
+        self,
+        selector_keys: list[int],
+        dataset_id: str,
+    ) -> Iterator[tuple[list[int], list[bytes], list[int], list[bytes], int]]:
+        """
+        Retrieve full sample data from storage given a list of keys.
+        """
         raise NotImplementedError()

--- a/modyn/selector/internal/storage_backend/database/database_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/database/database_storage_backend.py
@@ -230,9 +230,8 @@ class DatabaseStorageBackend(AbstractStorageBackend):
     def _get_data_from_storage(
         self, selector_keys: list[int], dataset_id: str
     ) -> Iterator[tuple[list[int], list[bytes], list[int], list[bytes], int]]:
-        """
-        Retrieve full sample data (samples plus labels/targets) via a gRPC call.
-        """
+        """Retrieve full sample data (samples plus labels/targets) via a gRPC
+        call."""
         if self._storagestub is None:
             self._init_grpc()
         processed_keys: set[int] | list[int] = []

--- a/modyn/selector/internal/storage_backend/local/local_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/local/local_storage_backend.py
@@ -1,7 +1,7 @@
 import ctypes
 import logging
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from sys import platform
 from typing import Any
@@ -239,3 +239,11 @@ class LocalStorageBackend(AbstractStorageBackend):
 
     def get_all_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
         return self.get_data_since_trigger(-1)
+
+    def _get_data_from_storage(
+        self, selector_keys: list[int], dataset_id: str
+    ) -> Iterator[tuple[list[int], list[bytes], list[int], list[bytes], int]]:
+        """
+        Retrieve full sample data from storage given a list of keys.
+        """
+        raise NotImplementedError()

--- a/modyn/selector/internal/storage_backend/local/local_storage_backend.py
+++ b/modyn/selector/internal/storage_backend/local/local_storage_backend.py
@@ -243,7 +243,5 @@ class LocalStorageBackend(AbstractStorageBackend):
     def _get_data_from_storage(
         self, selector_keys: list[int], dataset_id: str
     ) -> Iterator[tuple[list[int], list[bytes], list[int], list[bytes], int]]:
-        """
-        Retrieve full sample data from storage given a list of keys.
-        """
+        """Retrieve full sample data from storage given a list of keys."""
         raise NotImplementedError()

--- a/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_LLM_based_presampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_LLM_based_presampling_strategy.py
@@ -21,12 +21,6 @@ class FakeChannel:
 
 
 class FakeStorageBackend:
-    """
-    Mimics a storage backend that returns a 5-tuple:
-    (keys, samples, targets, labels, response_time)
-    and captures inserted keys when the presampling temporary table is populated.
-    """
-
     def __init__(self, raw_keys):
         self.raw_keys = raw_keys
         self.inserted_keys = []  # Filled when _execute_on_session runs an INSERT
@@ -40,93 +34,6 @@ class FakeStorageBackend:
             [k * 10 for k in selector_keys],
             response_time,
         )
-
-    def _execute_on_session(self, fn):
-        import re
-
-        class FakeBind:
-            """Minimal engine/connection mock so create_all() doesn't crash."""
-
-            def _run_ddl_visitor(self, visitor, element, **kwargs):
-                pass
-
-        class FakeScalars:
-            def __init__(self, keys):
-                self.keys = keys
-
-            def all(self):
-                return self.keys
-
-        class FakeResult:
-            def __init__(self, keys):
-                self.keys = keys
-
-            def scalars(self):
-                return FakeScalars(self.keys)
-
-        class FakeSession:
-            """
-            Manages a dict of table_name -> list of inserted sample_keys,
-            so we can simulate CREATE TABLE, INSERT, and SELECT realistically.
-            """
-
-            def __init__(self, raw_keys, inserted_keys_ref):
-                # For the real 'SelectorStateMetadata' selects, we return raw_keys.
-                self.raw_keys = raw_keys
-
-                # For the new “temp” tables, we track inserted rows in self.tables.
-                self.tables = {}
-                self.inserted_keys_ref = inserted_keys_ref
-
-            def execute(self, statement, *multiparams, **params):
-                # Convert statement to string for easy checking.
-                statement_str = str(statement)
-                statement_up = statement_str.upper()
-
-                # Extract table names from the statement using quick regex searches.
-                create_match = re.search(r"CREATE\s+TABLE\s+(\S+)", statement_str, re.IGNORECASE)
-                insert_match = re.search(r"INSERT\s+INTO\s+(\S+)", statement_str, re.IGNORECASE)
-                select_match = re.search(r"FROM\s+(\S+)", statement_str, re.IGNORECASE)
-
-                if create_match:
-                    table_name = create_match.group(1)
-                    print(f"[FAKE] Creating table: {table_name}")
-                    # Initialize an empty list of rows for that table.
-                    self.tables[table_name] = []
-                    return None
-
-                if insert_match and "INSERT" in statement_up:
-                    table_name = insert_match.group(1)
-                    if multiparams and isinstance(multiparams[0], list):
-                        # multiparams[0] = e.g. [{"sample_key": 2}, {"sample_key": 4}]
-                        inserted = [d["sample_key"] for d in multiparams[0]]
-                        # Append these keys to the table’s row list.
-                        self.tables.setdefault(table_name, []).extend(inserted)
-                        # Also store them in self.inserted_keys_ref for your test to check later.
-                        self.inserted_keys_ref[:] = inserted
-                        print(f"[FAKE] Inserting keys {inserted} into {table_name}")
-                    return None
-
-                if select_match and "SELECT" in statement_up:
-                    table_name = select_match.group(1)
-                    if table_name in self.tables:
-                        result = self.tables[table_name]
-                        print(f"[FAKE] Selecting from {table_name}, returning {result}")
-                        return FakeResult(result)
-
-                    print(f"[FAKE] Selecting from {table_name}, returning raw_keys = {self.raw_keys}")
-                    return FakeResult(self.raw_keys)
-
-                return None
-
-            def get_bind(self):
-                return FakeBind()
-
-            def commit(self):
-                pass
-
-        session_instance = FakeSession(self.raw_keys, self.inserted_keys)
-        return fn(session_instance)
 
 
 def get_config() -> PresamplingConfig:

--- a/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_LLM_based_presampling_strategy.py
+++ b/modyn/tests/selector/internal/selector_strategies/presampling_strategies/test_LLM_based_presampling_strategy.py
@@ -1,0 +1,193 @@
+from unittest.mock import MagicMock, patch
+
+import grpc
+
+from modyn.config.schema.pipeline import PresamplingConfig
+
+# Adjust this import according to your repository structure.
+from modyn.selector.internal.selector_strategies.presampling_strategies import LLMEvaluationPresamplingStrategy
+
+
+# --- Define a minimal FakeChannel ---
+class FakeChannel:
+    def subscribe(self, callback, try_to_connect=False):
+        pass
+
+    def unsubscribe(self, callback):
+        pass
+
+    def unary_stream(self, method, request_serializer, response_deserializer):
+        return lambda req: []
+
+
+class FakeStorageBackend:
+    """
+    Mimics a storage backend that returns a 5-tuple:
+    (keys, samples, targets, labels, response_time)
+    and captures inserted keys when the presampling temporary table is populated.
+    """
+
+    def __init__(self, raw_keys):
+        self.raw_keys = raw_keys
+        self.inserted_keys = []  # Filled when _execute_on_session runs an INSERT
+
+    def _get_data_from_storage(self, selector_keys: list[int], dataset_id: str):
+        response_time = 1
+        yield (
+            selector_keys,
+            [f"sample text {k}".encode() for k in selector_keys],
+            [f"target text {k}".encode() for k in selector_keys],
+            [k * 10 for k in selector_keys],
+            response_time,
+        )
+
+    def _execute_on_session(self, fn):
+        import re
+
+        class FakeBind:
+            """Minimal engine/connection mock so create_all() doesn't crash."""
+
+            def _run_ddl_visitor(self, visitor, element, **kwargs):
+                pass
+
+        class FakeScalars:
+            def __init__(self, keys):
+                self.keys = keys
+
+            def all(self):
+                return self.keys
+
+        class FakeResult:
+            def __init__(self, keys):
+                self.keys = keys
+
+            def scalars(self):
+                return FakeScalars(self.keys)
+
+        class FakeSession:
+            """
+            Manages a dict of table_name -> list of inserted sample_keys,
+            so we can simulate CREATE TABLE, INSERT, and SELECT realistically.
+            """
+
+            def __init__(self, raw_keys, inserted_keys_ref):
+                # For the real 'SelectorStateMetadata' selects, we return raw_keys.
+                self.raw_keys = raw_keys
+
+                # For the new “temp” tables, we track inserted rows in self.tables.
+                self.tables = {}
+                self.inserted_keys_ref = inserted_keys_ref
+
+            def execute(self, statement, *multiparams, **params):
+                # Convert statement to string for easy checking.
+                statement_str = str(statement)
+                statement_up = statement_str.upper()
+
+                # Extract table names from the statement using quick regex searches.
+                create_match = re.search(r"CREATE\s+TABLE\s+(\S+)", statement_str, re.IGNORECASE)
+                insert_match = re.search(r"INSERT\s+INTO\s+(\S+)", statement_str, re.IGNORECASE)
+                select_match = re.search(r"FROM\s+(\S+)", statement_str, re.IGNORECASE)
+
+                if create_match:
+                    table_name = create_match.group(1)
+                    print(f"[FAKE] Creating table: {table_name}")
+                    # Initialize an empty list of rows for that table.
+                    self.tables[table_name] = []
+                    return None
+
+                if insert_match and "INSERT" in statement_up:
+                    table_name = insert_match.group(1)
+                    if multiparams and isinstance(multiparams[0], list):
+                        # multiparams[0] = e.g. [{"sample_key": 2}, {"sample_key": 4}]
+                        inserted = [d["sample_key"] for d in multiparams[0]]
+                        # Append these keys to the table’s row list.
+                        self.tables.setdefault(table_name, []).extend(inserted)
+                        # Also store them in self.inserted_keys_ref for your test to check later.
+                        self.inserted_keys_ref[:] = inserted
+                        print(f"[FAKE] Inserting keys {inserted} into {table_name}")
+                    return None
+
+                if select_match and "SELECT" in statement_up:
+                    table_name = select_match.group(1)
+                    if table_name in self.tables:
+                        result = self.tables[table_name]
+                        print(f"[FAKE] Selecting from {table_name}, returning {result}")
+                        return FakeResult(result)
+
+                    print(f"[FAKE] Selecting from {table_name}, returning raw_keys = {self.raw_keys}")
+                    return FakeResult(self.raw_keys)
+
+                return None
+
+            def get_bind(self):
+                return FakeBind()
+
+            def commit(self):
+                pass
+
+        session_instance = FakeSession(self.raw_keys, self.inserted_keys)
+        return fn(session_instance)
+
+
+def get_config() -> PresamplingConfig:
+    return PresamplingConfig(ratio=100, strategy="LLMEvaluation", dataset_id="dummy-dataset", api_key="dummy")
+
+
+def get_modyn_config() -> dict:
+    return {"dummy": "config"}
+
+
+def create_strategy(storage_backend, batch_size=2, custom_prompt=""):
+    config = get_config()
+    strategy = LLMEvaluationPresamplingStrategy(
+        presampling_config=config,
+        modyn_config=get_modyn_config(),
+        pipeline_id=10,
+        storage_backend=storage_backend,
+    )
+    return strategy
+
+
+# --- Tests for LLMEvaluationPresamplingStrategy ---
+
+
+def test_constructor():
+    storage_backend = FakeStorageBackend(raw_keys=[])
+    strategy = create_strategy(storage_backend)
+    # Verify that attributes are correctly set.
+    assert strategy.batch_size == 10
+    assert strategy.model_name == "meta-llama/Llama-3.3-70B-Instruct"
+    assert strategy.dataset_id == "dummy-dataset"
+
+
+def test_evaluate_batch_quality():
+    storage_backend = FakeStorageBackend(raw_keys=[])
+    strategy = create_strategy(storage_backend, batch_size=3)
+    # Prepare a fake response from the chat completions endpoint.
+    fake_response = MagicMock()
+    fake_choice = MagicMock()
+    fake_choice.message.content = "true\nfalse\ntrue"
+    fake_response.choices = [fake_choice]
+    with patch.object(strategy.client.chat.completions, "create", return_value=fake_response) as mock_create:
+        result = strategy.evaluate_batch_quality([101, 102, 103], model_name="dummy-model", dataset_id="dummy-dataset")
+        # Expect [True, False, True]
+        assert result == [True, False, True]
+        mock_create.assert_called_once()
+
+
+# --- Test get_presampling_query using a FakeChannel ---
+@patch("modyn.utils.grpc_connection_established", return_value=True)
+@patch.object(grpc, "insecure_channel", return_value=FakeChannel())
+@patch.object(
+    LLMEvaluationPresamplingStrategy,
+    "evaluate_batch_quality",
+    side_effect=[[False, True, True, False, True, False, False, False, True, False], [False, True]],
+)
+def test_get_presampling_query(mock_eval, mock_insecure_channel, mock_utils_grpc):
+    storage_backend = FakeStorageBackend(raw_keys=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+    strategy = create_strategy(storage_backend)
+    query = strategy.get_presampling_query(next_trigger_id=5, tail_triggers=None, limit=None, trigger_dataset_size=100)
+    compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+    assert "temp_llm_filter_" in compiled
+    assert "sample_key" in compiled
+    assert storage_backend.inserted_keys == [2, 3, 5, 9, 12]

--- a/modyn/tests/selector/internal/storage_backend/utils.py
+++ b/modyn/tests/selector/internal/storage_backend/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from modyn.selector.internal.storage_backend import AbstractStorageBackend
@@ -27,4 +27,9 @@ class MockStorageBackend(AbstractStorageBackend):
         pass
 
     def get_all_data(self) -> Iterable[tuple[list[int], dict[str, object]]]:
+        pass
+
+    def _get_data_from_storage(
+        self, selector_keys: list[int], worker_id: int | None = None
+    ) -> Iterator[tuple[list[int], list[bytes], list[int] | list[bytes], int]]:
         pass


### PR DESCRIPTION
This adds a selection strategy that uses the LLM from the Clariden API in the selector. It required a few changes to the backend dataset so we could retrieve samples, and I added the necessary configuration options so you can customize the prompt, model, and API in case you want to use a different service.